### PR TITLE
[ENG-114] build: incrementally standardize codebase eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,30 +5,25 @@
     },
     "extends": [
         "airbnb",
-        "plugin:@typescript-eslint/recommended"
+        "airbnb-typescript",
+        "plugin:react/jsx-runtime"
     ],
     "overrides": [
     ],
+    "parser": "@typescript-eslint/parser",
     "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
+        "project": "./tsconfig.json"
+      },
     "plugins": [
-        "react"
+        "react",
+        "@typescript-eslint"
     ],
     "rules": {
-        "no-restricted-exports": 0,
-        "no-use-before-define": 0,
-        "import/extensions": 0,
         "import/no-unresolved": 0,
-        "import/prefer-default-export": 0,
-        "react/destructuring-assignment": 0,
-        "react/jsx-filename-extension": 0,
         "react/jsx-one-expression-per-line": 0,
-        "react/jsx-props-no-spreading": 0,
         "react/no-unescaped-entities": 0,
-        "react/react-in-jsx-scope": 0,
-        "react/require-default-props": 0,
-        "jsx/quotes": 0
+        "import/prefer-default-export": 0,
+        "react/jsx-props-no-spreading": 0,        
+         "react/require-default-props": 0
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@chakra-ui/icons": "^2.0.9",
         "axios": "^1.3.2",
+        "eslint-config-airbnb-typescript": "^17.1.0",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -4137,7 +4138,6 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -4239,7 +4239,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
@@ -4267,7 +4266,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4532,7 +4530,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -4689,7 +4686,6 @@
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -4792,7 +4788,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
@@ -4894,7 +4889,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.22.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
@@ -4946,7 +4940,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3",
@@ -4967,7 +4960,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -5075,7 +5067,6 @@
     },
     "node_modules/eslint-config-airbnb-base": {
       "version": "15.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
@@ -5089,6 +5080,20 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
+      }
+    },
+    "node_modules/eslint-config-airbnb-typescript": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-17.1.0.tgz",
+      "integrity": "sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==",
+      "dependencies": {
+        "eslint-config-airbnb-base": "^15.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.13.0 || ^6.0.0",
+        "@typescript-eslint/parser": "^5.0.0 || ^6.0.0",
+        "eslint": "^7.32.0 || ^8.2.0",
+        "eslint-plugin-import": "^2.25.3"
       }
     },
     "node_modules/eslint-config-standard": {
@@ -5787,7 +5792,6 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
@@ -5837,12 +5841,10 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -5859,7 +5861,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5883,7 +5884,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -5924,7 +5924,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -5977,7 +5976,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -6010,7 +6008,6 @@
     },
     "node_modules/gopd": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
@@ -6031,7 +6028,6 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -6042,7 +6038,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6058,7 +6053,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
@@ -6069,7 +6063,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6080,7 +6073,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6091,7 +6083,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -6189,7 +6180,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.0",
@@ -6210,7 +6200,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6228,7 +6217,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -6239,7 +6227,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6254,7 +6241,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6276,7 +6262,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6325,7 +6310,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6344,7 +6328,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6366,7 +6349,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6381,7 +6363,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -6403,7 +6384,6 @@
     },
     "node_modules/is-string": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6417,7 +6397,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -6431,7 +6410,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.12",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.11"
@@ -6445,7 +6423,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -6456,7 +6433,6 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -7427,7 +7403,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7435,7 +7410,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7443,7 +7417,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7460,7 +7433,6 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -7982,7 +7954,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8139,7 +8110,6 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8156,7 +8126,6 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8177,7 +8146,6 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8204,7 +8172,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -8324,7 +8291,6 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8340,7 +8306,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8353,7 +8318,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8543,7 +8507,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8556,7 +8519,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8573,7 +8535,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
@@ -8591,7 +8552,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8616,7 +8576,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8779,7 +8738,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",
@@ -8794,7 +8752,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^2.0.9",
     "axios": "^1.3.2",
+    "eslint-config-airbnb-typescript": "^17.1.0",
     "lodash": "^4.17.21"
   }
 }

--- a/src/components/Configure/Configure.tsx
+++ b/src/components/Configure/Configure.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   FormEvent, useContext, useEffect, useState,
 } from 'react';
 import {
@@ -28,117 +28,40 @@ import { SourceListContext, SubdomainContext } from '../AmpersandProvider/Ampers
 import { ProviderConnectionContext } from '../AmpersandProvider';
 import SalesforceOauthFlow from '../Salesforce/SalesforceOauthFlow';
 
-interface InstallIntegrationProps {
-  integration: string,
-  userId: string,
-  groupId: string,
-  redirectUrl?: string,
+function SetUpWrite(/* props: InstallProps */) {
+  return (<>TODO</>);
 }
 
-export function InstallIntegration(
-  {
-    integration, userId, groupId, redirectUrl,
-  }: InstallIntegrationProps,
-) {
-  return (
-    <ConfigureIntegrationBase
-      integration={integration}
-      userId={userId}
-      groupId={groupId}
-      redirectUrl={redirectUrl}
-    />
-  );
-}
-
-interface ReconfigureIntegrationProps {
-  integration: string,
-  userId: string,
-  groupId: string,
-  redirectUrl?: string,
-}
-export function ReconfigureIntegration(
-  {
-    integration, userId, groupId, redirectUrl,
-  }: ReconfigureIntegrationProps,
-) {
-  const [userConfig, setUserConfig] = useState<IntegrationConfig | undefined>(undefined);
-
-  // GET USER'S EXISTING CONFIG IF EXISTING
-  useEffect(() => {
-    getUserConfig(userId, groupId, integration)
-      .then((config) => setUserConfig(config));
-  }, [userId, groupId, integration]);
-
-  return (
-    <ConfigureIntegrationBase
-      integration={integration}
-      userId={userId}
-      groupId={groupId}
-      userConfig={userConfig}
-      redirectUrl={redirectUrl}
-    />
-  );
-}
-
-interface ConfigureIntegrationBaseProps {
-  integration: string,
-  userId: string,
-  groupId: string,
-  userConfig?: IntegrationConfig,
-  redirectUrl?: string,
-}
-
-// Base component for configuring and reconfiguring an integration.
-function ConfigureIntegrationBase({
-  integration, userId, groupId, userConfig, redirectUrl,
-}: ConfigureIntegrationBaseProps) {
-  const { subdomain } = useContext(SubdomainContext);
-  const { isConnectedToProvider } = useContext(ProviderConnectionContext);
-
-  const sourceList: SourceList | null = useContext(SourceListContext);
-  let source;
-  let appName = 'this app';
-
-  if (sourceList) {
-    source = findSourceFromList(integration, sourceList);
-    appName = sourceList.appName;
-  }
-
-  if (!source) {
-    return <CenteredTextBox text="We can't load the integration" />;
-  }
-  const { api } = source;
-
-  //  TODO: isConnectedToProvider should be an API call
-  if (!isConnectedToProvider[api]) {
-    return (
-      <SalesforceOauthFlow
-        userId={userId}
-        groupId={groupId}
-      />
-    );
-  }
-
-  const { type } = source;
-  if (type === 'read') {
-    return (
-      <SetUpRead
-        integration={integration}
-        source={source}
-        subdomain={subdomain}
-        appName={appName}
-        userConfig={userConfig}
-        api={api}
-        userId={userId}
-        groupId={groupId}
-        redirectUrl={redirectUrl}
-      />
-    );
-  } if (type === 'write') {
-    return <SetUpWrite />;
-  }
-  return null;
-}
+const strings = {
+  configureIntro: (
+    appName: string,
+    api: string,
+    subdomain: string,
+  ) => <>Let's integrate {appName} with your {capitalize(api)} instance <b>{subdomain}</b>.</>,
+  reconfigureIntro: (
+    appName: string,
+    api: string,
+    subdomain: string,
+  ) => (
+    <>
+      Let's update {appName}'s integration with your {capitalize(api)} instance <b>{subdomain}</b>.
+    </>
+  ),
+  configureRequiredFields: (
+    appName: string,
+    object: ObjectConfigOptions,
+  ) => {
+    const { name } = object;
+    return <>{appName} will read the following <b>{name.displayName}</b> fields:</>;
+  },
+  reconfigureRequiredFields: (
+    appName: string,
+    object: ObjectConfigOptions,
+  ) => {
+    const { name } = object;
+    return <>{appName} is reading the following <b>{name.displayName}</b> fields:</>;
+  },
+};
 
 interface SetUpReadProps {
   integration: string,
@@ -324,37 +247,113 @@ function SetUpRead({
   );
 }
 
-function SetUpWrite(/* props: InstallProps */) {
-  return (<>TODO</>);
+interface ConfigureIntegrationBaseProps {
+  integration: string,
+  userId: string,
+  groupId: string,
+  userConfig?: IntegrationConfig,
+  redirectUrl?: string,
 }
 
-const strings = {
-  configureIntro: (
-    appName: string,
-    api: string,
-    subdomain: string,
-  ) => <>Let's integrate {appName} with your {capitalize(api)} instance <b>{subdomain}</b>.</>,
-  reconfigureIntro: (
-    appName: string,
-    api: string,
-    subdomain: string,
-  ) => (
-    <>
-      Let's update {appName}'s integration with your {capitalize(api)} instance <b>{subdomain}</b>.
-    </>
-  ),
-  configureRequiredFields: (
-    appName: string,
-    object: ObjectConfigOptions,
-  ) => {
-    const { name } = object;
-    return <>{appName} will read the following <b>{name.displayName}</b> fields:</>;
-  },
-  reconfigureRequiredFields: (
-    appName: string,
-    object: ObjectConfigOptions,
-  ) => {
-    const { name } = object;
-    return <>{appName} is reading the following <b>{name.displayName}</b> fields:</>;
-  },
-};
+// Base component for configuring and reconfiguring an integration.
+function ConfigureIntegrationBase({
+  integration, userId, groupId, userConfig, redirectUrl,
+}: ConfigureIntegrationBaseProps) {
+  const { subdomain } = useContext(SubdomainContext);
+  const { isConnectedToProvider } = useContext(ProviderConnectionContext);
+
+  const sourceList: SourceList | null = useContext(SourceListContext);
+  let source;
+  let appName = 'this app';
+
+  if (sourceList) {
+    source = findSourceFromList(integration, sourceList);
+    appName = sourceList.appName;
+  }
+
+  if (!source) {
+    return <CenteredTextBox text="We can't load the integration" />;
+  }
+  const { api } = source;
+
+  //  TODO: isConnectedToProvider should be an API call
+  if (!isConnectedToProvider[api]) {
+    return (
+      <SalesforceOauthFlow
+        userId={userId}
+        groupId={groupId}
+      />
+    );
+  }
+
+  const { type } = source;
+  if (type === 'read') {
+    return (
+      <SetUpRead
+        integration={integration}
+        source={source}
+        subdomain={subdomain}
+        appName={appName}
+        userConfig={userConfig}
+        api={api}
+        userId={userId}
+        groupId={groupId}
+        redirectUrl={redirectUrl}
+      />
+    );
+  } if (type === 'write') {
+    return <SetUpWrite />;
+  }
+  return null;
+}
+interface InstallIntegrationProps {
+  integration: string,
+  userId: string,
+  groupId: string,
+  redirectUrl?: string,
+}
+
+export function InstallIntegration(
+  {
+    integration, userId, groupId, redirectUrl,
+  }: InstallIntegrationProps,
+) {
+  return (
+    <ConfigureIntegrationBase
+      integration={integration}
+      userId={userId}
+      groupId={groupId}
+      redirectUrl={redirectUrl}
+    />
+  );
+}
+
+interface ReconfigureIntegrationProps {
+  integration: string,
+  userId: string,
+  groupId: string,
+  redirectUrl?: string,
+}
+export function ReconfigureIntegration(
+  {
+    integration, userId, groupId, redirectUrl,
+  }: ReconfigureIntegrationProps,
+) {
+  const [userConfig, setUserConfig] = useState<IntegrationConfig | undefined>(undefined);
+
+  // GET USER'S EXISTING CONFIG IF EXISTING
+  useEffect(() => {
+    getUserConfig(userId, groupId, integration)
+      .then((config) => setUserConfig(config));
+  }, [userId, groupId, integration]);
+
+  return (
+    <ConfigureIntegrationBase
+      integration={integration}
+      userId={userId}
+      groupId={groupId}
+      userConfig={userConfig}
+      redirectUrl={redirectUrl}
+    />
+  );
+}

--- a/src/components/OAuthPopup/OAuthPopup.tsx
+++ b/src/components/OAuthPopup/OAuthPopup.tsx
@@ -63,7 +63,7 @@ function OAuthPopup({
   useEffect(() => {
     window.addEventListener('message', (event) => {
       if (event.origin === AMP_BACKEND_SERVER) {
-        //  this event come from our own server)
+        //  this event come from our own server
         if (event.data?.eventType === SUCCESS_EVENT) {
           clearTimer();
           setIsConnectedToProvider({ salesforce: true });

--- a/src/components/Salesforce/ConnectSalesforce.tsx
+++ b/src/components/Salesforce/ConnectSalesforce.tsx
@@ -4,7 +4,7 @@
  * Component that prompts user to connect Salesforce, connecting subdomain and OAuth.
  */
 
-import React, { useContext, useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { Box, Container, Text } from '@chakra-ui/react';
 import SalesforceOauthFlow from './SalesforceOauthFlow';

--- a/src/components/Salesforce/SalesforceOauthFlow.tsx
+++ b/src/components/Salesforce/SalesforceOauthFlow.tsx
@@ -5,7 +5,7 @@
  * that Salesforce instance.
  */
 
-import React, { useContext, useState } from 'react';
+import { useContext, useState } from 'react';
 import {
   Alert, AlertIcon, AlertDescription, Box, Button, Container, Flex, FormControl,
   FormLabel, Heading, Input, Image, Link, Text,
@@ -92,7 +92,8 @@ function SalesforceOauthFlow({ userId, groupId }: SalesforceOauthFlowProps) {
             color="blackAlpha.600"
             isExternal
           >
-            What is my Salesforce subdomain? <ExternalLinkIcon mx="2px" />
+            What is my Salesforce subdomain?
+            <ExternalLinkIcon mx="2px" />
           </Link>
           <OAuthErrorAlert error={error} />
           <Flex marginTop="1em">

--- a/src/types/configTypes.ts
+++ b/src/types/configTypes.ts
@@ -1,7 +1,10 @@
+/* eslint-disable no-use-before-define */
+// TODO - reorder types to match this rule
+
 export type SourceList = {
   appName: string;
   integrations: Array<IntegrationSource>;
-}
+};
 
 export interface IntegrationSource {
   name: string;
@@ -17,7 +20,7 @@ export interface ObjectConfigOptions {
   customFieldMapping?: FieldMappingOption[];
 }
 
-export type DataFields = Array<DataField>
+export type DataFields = Array<DataField>;
 
 type DataObjectName = string;
 type DataFieldName = string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -40,25 +40,6 @@ export const findObjectInIntegrationConfig = (
 );
 
 /**
- * Given a source, create the config payload to be saved.
- * Gets rid of extra data like display names.
- *
- * @param objects {ObjectConfigOptions[]} Array of object config options.
- * @returns {ObjectConfig} Config payload for source.
- */
-export const getDefaultConfigForSource = (
-  objects: ObjectConfigOptions[],
-): IntegrationConfig => map(
-  objects,
-  (object: ObjectConfigOptions): ObjectConfig => ({
-    objectName: object.name.objectName,
-    requiredFields: reduceDataFieldsToFieldConfig(object.requiredFields) || {},
-    selectedOptionalFields: reduceDataFieldsToFieldConfig(object.optionalFields) || {},
-    selectedFieldMapping: {}, // SET BY USER IN CONFIGURE FLOW
-  }),
-);
-
-/**
  * Create config payload for data fields.
  *
  * @param fields {DataFields} Config parameter.
@@ -76,6 +57,25 @@ const reduceDataFieldsToFieldConfig = (fields?: DataFields): FieldConfig | null 
     {} as FieldConfig,
   );
 };
+
+/**
+ * Given a source, create the config payload to be saved.
+ * Gets rid of extra data like display names.
+ *
+ * @param objects {ObjectConfigOptions[]} Array of object config options.
+ * @returns {ObjectConfig} Config payload for source.
+ */
+export const getDefaultConfigForSource = (
+  objects: ObjectConfigOptions[],
+): IntegrationConfig => map(
+  objects,
+  (object: ObjectConfigOptions): ObjectConfig => ({
+    objectName: object.name.objectName,
+    requiredFields: reduceDataFieldsToFieldConfig(object.requiredFields) || {},
+    selectedOptionalFields: reduceDataFieldsToFieldConfig(object.optionalFields) || {},
+    selectedFieldMapping: {}, // SET BY USER IN CONFIGURE FLOW
+  }),
+);
 
 // Redirect page to another URL, can be relative (e.g. `/login`) or absolute (e.g. `https://www.google.com`).
 export const redirectTo = (url: string) => {


### PR DESCRIPTION
### incrementally standardize codebase eslint
- adds airbnb typescript eslint
- removes eslint overrides
- removes React as a required import 
-- (https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)  
-- `plugin:react/jsx-runtime`

#### refactors to honor `no-use-before-define`
although not required because of hoisting in js, I think this over complicates js code and defining before we use is easier to understand.

#### testing run 
```npm run lint``` 
only console errors should show

