### PR TITLE
[ENG-255] feat: adds custom mapping select to reconfigure installation

### DIFF
--- a/generated-sources/api/.openapi-generator/FILES
+++ b/generated-sources/api/.openapi-generator/FILES
@@ -10,7 +10,6 @@ src/models/BatchUpsertIntegrationsRequest.ts
 src/models/Config.ts
 src/models/ConfigContent.ts
 src/models/Connection.ts
-src/models/ConnectionsList.ts
 src/models/Consumer.ts
 src/models/CreateConsumerRequest.ts
 src/models/CreateDestinationRequest.ts

--- a/generated-sources/api/src/apis/DefaultApi.ts
+++ b/generated-sources/api/src/apis/DefaultApi.ts
@@ -17,7 +17,6 @@ import * as runtime from '../runtime';
 import type {
   BatchUpsertIntegrationsRequest,
   Connection,
-  ConnectionsList,
   CreateConsumerRequest,
   CreateDestinationRequest,
   CreateGroupRequest,
@@ -44,8 +43,6 @@ import {
     BatchUpsertIntegrationsRequestToJSON,
     ConnectionFromJSON,
     ConnectionToJSON,
-    ConnectionsListFromJSON,
-    ConnectionsListToJSON,
     CreateConsumerRequestFromJSON,
     CreateConsumerRequestToJSON,
     CreateDestinationRequestFromJSON,
@@ -571,12 +568,12 @@ export interface DefaultApiInterface {
      * @throws {RequiredError}
      * @memberof DefaultApiInterface
      */
-    listConnectionsRaw(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ConnectionsList>>;
+    listConnectionsRaw(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Connection>>>;
 
     /**
      * List a project\'s connections
      */
-    listConnections(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ConnectionsList>;
+    listConnections(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Connection>>;
 
     /**
      * 
@@ -1440,7 +1437,7 @@ export class DefaultApi extends runtime.BaseAPI implements DefaultApiInterface {
     /**
      * List a project\'s connections
      */
-    async listConnectionsRaw(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ConnectionsList>> {
+    async listConnectionsRaw(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Connection>>> {
         if (requestParameters.projectId === null || requestParameters.projectId === undefined) {
             throw new runtime.RequiredError('projectId','Required parameter requestParameters.projectId was null or undefined when calling listConnections.');
         }
@@ -1468,13 +1465,13 @@ export class DefaultApi extends runtime.BaseAPI implements DefaultApiInterface {
             query: queryParameters,
         }, initOverrides);
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => ConnectionsListFromJSON(jsonValue));
+        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(ConnectionFromJSON));
     }
 
     /**
      * List a project\'s connections
      */
-    async listConnections(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ConnectionsList> {
+    async listConnections(requestParameters: ListConnectionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Connection>> {
         const response = await this.listConnectionsRaw(requestParameters, initOverrides);
         return await response.value();
     }

--- a/generated-sources/api/src/models/index.ts
+++ b/generated-sources/api/src/models/index.ts
@@ -5,7 +5,6 @@ export * from './BatchUpsertIntegrationsRequest';
 export * from './Config';
 export * from './ConfigContent';
 export * from './Connection';
-export * from './ConnectionsList';
 export * from './Consumer';
 export * from './CreateConsumerRequest';
 export * from './CreateDestinationRequest';


### PR DESCRIPTION
### adds custom select mapping to reconfigure installation
- maps over custom map fields 
- fills all select options with all fields in hyrdated revision

#### demo
![reconfigure-custome-select](https://github.com/amp-labs/react/assets/5396828/15164d37-ceac-479e-9c44-a6957c6e9951)


#### not included
- refactor to separate files
- prompts
- default value that may not exists

