### PR TITLE
feat: Add some endpoints for dev and staging

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -11,7 +11,9 @@ import {
   Installation, Integration,
   IntegrationFieldMapping,
   Project,
-} from '../../generated-sources/api/src/index';
+} from '../../generated-sources/api/src';
+
+import { getApiEndpoint } from './apiService';
 
 /**
    * To update the api you need to
@@ -25,33 +27,13 @@ import {
    * based on the api.yaml swagger (open-api v2) spec
    *
    * */
-const PRISM_MOCK_URL = 'http://127.0.0.1:4010';
-
-const LOCAL_URL = 'http://localhost:8080';
-const DEV_URL = 'https:// dev-api.withampersand.com';
-const STAGING_URL = 'https://staging-api.withampersand.com';
-const PRODUCTION_URL = 'https://api.withampersand.com';
 const VERSION = 'v1';
 
 const getApiRoot = (server: string, version: string): string => `${server}/${version}`;
 
 // REACT_APP_AMP_SERVER=local npm start will use the local server
 function assignRoot(): string {
-  const env = process.env.REACT_APP_AMP_SERVER;
-  switch (env) {
-    case 'prod':
-      return getApiRoot(PRODUCTION_URL, VERSION);
-    case 'staging':
-      return getApiRoot(STAGING_URL, VERSION);
-    case 'dev':
-      return getApiRoot(DEV_URL, VERSION);
-    case 'local':
-      return getApiRoot(LOCAL_URL, VERSION);
-    case 'mock':
-      return PRISM_MOCK_URL;
-    default:
-      return getApiRoot(PRODUCTION_URL, VERSION);
-  }
+  return getApiRoot(getApiEndpoint(), VERSION);
 }
 
 export const AMP_API_ROOT = assignRoot();

--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -13,11 +13,13 @@ export function getApiEndpoint(): string {
     case 'local':
       return 'http://localhost:8080';
     case 'dev':
-      return 'dev-api.withampersand.com';
+      return 'https://dev-api.withampersand.com';
     case 'staging':
-      return 'staging-api.withampersand.com';
+      return 'https://staging-api.withampersand.com';
     case 'prod':
       return 'https://api.withampersand.com';
+    case 'mock':
+      return 'http://127.0.0.1:4010';
     case '':
       return 'https://api.withampersand.com';
     default:


### PR DESCRIPTION
This PR adds the ability to switch to our dev or staging endpoint, in addition to local or prod. It also lets the caller provide their own custom URL if the presets we provide don't apply to their use case (think HTTP proxy).