### PR TITLE
feat: Allow the api to be swapped out with another

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -42,7 +42,7 @@ export function InstallIntegration(
   useEffect(() => {
     if (integrationObj?.id) {
       // check if installation exists on selected integration
-      api.listInstallations({ projectId, integrationId: integrationObj.id, groupRef }, {
+      api().listInstallations({ projectId, integrationId: integrationObj.id, groupRef }, {
         headers: {
           'X-Api-Key': apiKey ?? '',
         },

--- a/src/components/OAuthPopup/OAuthPopup.tsx
+++ b/src/components/OAuthPopup/OAuthPopup.tsx
@@ -65,7 +65,7 @@ function OAuthPopup({
   }, [url, title]);
 
   const refreshConnections = useCallback(async (connectionId: string) => {
-    const connection = await api.getConnection({ projectId, connectionId }, {
+    const connection = await api().getConnection({ projectId, connectionId }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },

--- a/src/components/Salesforce/SalesforceOauthFlow.tsx
+++ b/src/components/Salesforce/SalesforceOauthFlow.tsx
@@ -68,7 +68,7 @@ function SalesforceOauthFlow({
 
     if (customerSubdomain) {
       try {
-        const providerApps = await api.listProviderApps({
+        const providerApps = await api().listProviderApps({
           projectId,
         }, {
           headers: {
@@ -81,7 +81,7 @@ function SalesforceOauthFlow({
           throw new Error('You must first set up a Salesforce Connected App using the Ampersand Console.');
         }
 
-        const url = await api.oauthConnect({
+        const url = await api().oauthConnect({
           connectOAuthParams: {
             providerWorkspaceRef: customerSubdomain,
             projectId,

--- a/src/context/ConnectionsContext.tsx
+++ b/src/context/ConnectionsContext.tsx
@@ -48,7 +48,7 @@ export function ConnectionsProvider({
   const apiKey = useContext(ApiKeyContext);
 
   useEffect(() => {
-    api.listConnections({ projectId, groupRef, provider }, {
+    api().listConnections({ projectId, groupRef, provider }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },

--- a/src/context/HydratedRevisionContext.tsx
+++ b/src/context/HydratedRevisionContext.tsx
@@ -51,7 +51,7 @@ export function HydratedRevisionProvider({
   useEffect(() => {
     // Fetch the hydrated revision data using your API call
     if (projectId && integrationId && revisionId && connectionId) {
-      api.getHydratedRevision({
+      api().getHydratedRevision({
         projectId,
         integrationId,
         revisionId,

--- a/src/context/IntegrationListContext.tsx
+++ b/src/context/IntegrationListContext.tsx
@@ -37,7 +37,7 @@ export function IntegrationListProvider(
   const apiKey = useContext(ApiKeyContext);
 
   useEffect(() => {
-    api.listIntegrations({ projectId }, {
+    api().listIntegrations({ projectId }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },

--- a/src/context/ProjectContext.tsx
+++ b/src/context/ProjectContext.tsx
@@ -38,7 +38,7 @@ export function ProjectProvider(
   const apiKey = useContext(ApiKeyContext);
 
   useEffect(() => {
-    api.getProject({ projectId }, {
+    api().getProject({ projectId }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -71,7 +71,14 @@ const config = new Configuration({
   basePath: AMP_API_ROOT,
 });
 
-export const api = new DefaultApi(config);
+let apiValue = new DefaultApi(config);
+
+// For testing, etc. we may want to use a different API configuration than the default
+export const setApi = (api: DefaultApi) => {
+  apiValue = api;
+};
+
+export const api = () => apiValue;
 
 /**
    * Types exported from generated api


### PR DESCRIPTION
In some cases, we need to change the API endpoint at runtime (rather than build time). This PR will let us do that.

Since react doesn't like mutable exports, this uses a callback to simulate mutability.
