### PR TITLE
fix: Change ConfigureIntegrationBase to return the expected types

### DIFF
--- a/src/components/Configure/ConfigureIntegrationBase.tsx
+++ b/src/components/Configure/ConfigureIntegrationBase.tsx
@@ -48,15 +48,16 @@ export function ConfigureIntegrationBase({
     const [connection] = connections;
     // This will cause the component to re-render with the selected connection.
     setSelectedConnection(connection);
-  } else {
-    // Require user to login to Saleforce if there are no connections yet.
-    return (
-      <SalesforceOauthFlow
-        consumerRef={consumerRef}
-        consumerName={consumerName}
-        groupRef={groupRef}
-        groupName={groupName}
-      />
-    );
+    return null;
   }
+
+  // Require user to login to Saleforce if there are no connections yet.
+  return (
+    <SalesforceOauthFlow
+      consumerRef={consumerRef}
+      consumerName={consumerName}
+      groupRef={groupRef}
+      groupName={groupName}
+    />
+  );
 }


### PR DESCRIPTION
This fixes a small bug where ConfigureIntegrationBase returned the wrong type, which caused `npm run build` to fail. The return type needs to be `null`, rather than `undefined`.