### PR TITLE
[ENG-267] refactor: install integration fields

### DIFF
--- a/src/components/Configure/content.tsx
+++ b/src/components/Configure/content.tsx
@@ -1,0 +1,22 @@
+import { capitalize } from '../../utils';
+
+// reconfigure content
+export const content = {
+  reconfigureIntro: (
+    appName: string,
+    apiProvider: string,
+    workspace: string,
+  ) => (
+    // eslint-disable-next-line max-len
+    <>{capitalize(apiProvider)} integration: <b>{workspace}</b>.</>
+  ),
+  reconfigureRequiredFields: (
+    appName: string,
+    objectName: string,
+  ) => <>{appName} reads the following <b>{objectName}</b> fields</>,
+  customMappingText: (
+    objectName: string,
+    customField: string,
+    // eslint-disable-next-line max-len
+  ) => <>Which of your custom fields from <b>{objectName}</b> should be mapped to <b>{customField}</b>?</>,
+};

--- a/src/components/Configure/fields/OptionalFields.tsx
+++ b/src/components/Configure/fields/OptionalFields.tsx
@@ -1,0 +1,52 @@
+import {
+  Box, Checkbox, Stack, Text,
+} from '@chakra-ui/react';
+
+import { ConfigureState } from '../types';
+import { isIntegrationFieldMapping } from '../utils';
+
+type OptionalFieldsProps = {
+  configureState: ConfigureState;
+  setConfigureState: (configureState: ConfigureState) => void;
+};
+
+export function OptionalFields({ configureState, setConfigureState }: OptionalFieldsProps) {
+  const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = e.target;
+    const { optionalFields } = configureState;
+    const optionalFieldToUpdate = optionalFields?.find((field) => field.fieldName === name);
+
+    if (optionalFieldToUpdate) {
+      // Update the value property to new checked value
+      optionalFieldToUpdate.value = checked;
+
+      // update state
+      setConfigureState({ ...configureState, optionalFields: [...optionalFields || []] });
+    }
+  };
+
+  return (
+    <>
+      <Text marginBottom="5px">Optional Fields</Text>
+      <Stack marginBottom="20px">
+        {configureState.optionalFields?.map((field) => {
+          if (!isIntegrationFieldMapping(field)) {
+            return (
+              <Box key={field.fieldName} display="flex" gap="5px" borderBottom="1px" borderColor="gray.100">
+                <Checkbox
+                  name={field.fieldName}
+                  id={field.fieldName}
+                  isChecked={!!field.value}
+                  onChange={onCheckboxChange}
+                >
+                  {field.displayName}
+                </Checkbox>
+              </Box>
+            );
+          }
+          return null; // fallback for customed mapped fields
+        })}
+      </Stack>
+    </>
+  );
+}

--- a/src/components/Configure/fields/RequiredCustomFields.tsx
+++ b/src/components/Configure/fields/RequiredCustomFields.tsx
@@ -1,0 +1,65 @@
+import {
+  Select, Stack, Text,
+} from '@chakra-ui/react';
+
+import { content } from '../content';
+import { useSelectedObjectName } from '../ObjectManagementNav';
+import { ConfigureState } from '../types';
+import { isIntegrationFieldMapping } from '../utils';
+
+type RequiredCustomFieldsProps = {
+  configureState: ConfigureState;
+  setConfigureState: (configureState: ConfigureState) => void;
+};
+
+export function RequiredCustomFields(
+  { configureState, setConfigureState }: RequiredCustomFieldsProps,
+) {
+  const { selectedObjectName } = useSelectedObjectName();
+  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { value, name } = e.target;
+    const { requiredCustomMapFields } = configureState;
+    const requiredCustomMapFieldtoUpdate = requiredCustomMapFields?.find(
+      (field) => field.mapToName === name,
+    );
+
+    if (requiredCustomMapFieldtoUpdate) {
+      // Update the custome field value property to new value
+      requiredCustomMapFieldtoUpdate.value = value;
+      const newState = {
+        ...configureState,
+        requiredCustomMapFields: [...requiredCustomMapFields || []],
+      };
+
+      // update state
+      setConfigureState(newState);
+    }
+  };
+  return (
+    <Stack>
+      {configureState.requiredCustomMapFields?.map((field) => {
+        if (isIntegrationFieldMapping(field)) {
+          return (
+            <Stack key={field.mapToName}>
+              <Text marginBottom="5px">
+                {content.customMappingText(selectedObjectName || '', field.mapToName)}
+              </Text>
+              <Select
+                name={field.mapToName}
+                variant="flushed"
+                value={field.value}
+                onChange={onSelectChange}
+                placeholder="Please select one"
+              >
+                {configureState?.allFields?.map((f) => (
+                  <option key={f.fieldName} value={f.fieldName}>{f.displayName}</option>
+                ))}
+              </Select>
+            </Stack>
+          );
+        }
+        return null; // fallback for existant fields
+      })}
+    </Stack>
+  );
+}

--- a/src/components/Configure/fields/RequiredFields.tsx
+++ b/src/components/Configure/fields/RequiredFields.tsx
@@ -1,0 +1,32 @@
+import { Box, Tag, Text } from '@chakra-ui/react';
+
+import { useProject } from '../../../context/ProjectContext';
+import { content } from '../content';
+import { useSelectedObjectName } from '../ObjectManagementNav';
+import { ConfigureState } from '../types';
+import { isIntegrationFieldMapping } from '../utils';
+
+type RequiredFieldsProps = {
+  configureState: ConfigureState;
+};
+
+export function RequiredFields({ configureState }: RequiredFieldsProps) {
+  const { selectedObjectName } = useSelectedObjectName();
+  const { project } = useProject();
+  const appName = project?.appName || '';
+  return (
+    <>
+      <Text marginBottom="5px">
+        {content.reconfigureRequiredFields(appName, selectedObjectName || '')}
+      </Text>
+      <Box marginBottom="20px">
+        {configureState.requiredFields?.map((field) => {
+          if (!isIntegrationFieldMapping(field)) {
+            return <Tag key={field.fieldName}>{field.displayName}</Tag>;
+          }
+          return null; // fallback for customed mapped fields
+        })}
+      </Box>
+    </>
+  );
+}

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -1,0 +1,20 @@
+import {
+  HydratedIntegrationField,
+  HydratedIntegrationFieldExistent,
+  IntegrationFieldMapping,
+} from '../../services/api';
+
+export type ConfigureStateIntegrationField = HydratedIntegrationFieldExistent & {
+  value: string | number | boolean | null,
+};
+
+export type CustomConfigureStateIntegrationField = IntegrationFieldMapping & {
+  value: string | number | undefined,
+};
+
+export type ConfigureState = {
+  allFields: HydratedIntegrationFieldExistent[] | null, // needed for custom mapping
+  requiredFields: HydratedIntegrationField[] | null,
+  optionalFields: ConfigureStateIntegrationField[] | null,
+  requiredCustomMapFields: CustomConfigureStateIntegrationField[] | null,
+};

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -75,7 +75,7 @@ export function getOptionalFieldsFromObject(object: HydratedIntegrationObject)
 export const getReadObject = (
   config: Config,
   objectName:string,
-) => config?.content?.read?.standardObjects[objectName];
+) => config?.content?.read?.standardObjects?.[objectName];
 
 // 5. get value for field
 export function getValueFromConfigExist(config: Config, objectName: string, key: string): boolean {


### PR DESCRIPTION
### refactors required, optional and custom fields
allows us to clean up reconfigure integration and reuse for create flow.
- creates field folder in `<InstallIntegrations/>`
- moves input select handlers + field inputs to separate files.
 
app works as expected
![Screenshot 2023-10-09 at 11 47 36 AM](https://github.com/amp-labs/react/assets/5396828/5febb391-7b1d-4214-a7e9-29e9c5fa78b2)
