### PR TITLE
refactor: adds InstallIntegrationContext

### DIFF
--- a/src/components/Configure/CreateInstallation.tsx
+++ b/src/components/Configure/CreateInstallation.tsx
@@ -4,7 +4,11 @@
 import { useCallback, useContext, useEffect } from 'react';
 
 import { ApiKeyContext } from '../../context/ApiKeyContext';
+import { useConnections } from '../../context/ConnectionsContext';
 import { useHydratedRevision } from '../../context/HydratedRevisionContext';
+import { useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
+import { useProject } from '../../context/ProjectContext';
+import { api, CreateInstallationOperationRequest } from '../../services/api';
 
 import { useConfigureState } from './state/ConfigurationStateProvider';
 import { resetConfigurationState } from './state/utils';
@@ -16,9 +20,12 @@ const UNDEFINED_CONFIG = undefined;
 
 //  Create Installation Flow
 export function CreateInstallation() {
+  const { integrationId, groupRef, consumerRef } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
+  const { selectedConnection } = useConnections();
   const apiKey = useContext(ApiKeyContext);
+  const { projectId } = useProject();
 
   // 1. get the hydrated revision
   // 3. generate the configuration state from the hydrated revision
@@ -41,8 +48,47 @@ export function CreateInstallation() {
   }, [resetState]);
 
   const onSave = () => {
-    // TODO: create new installation
+    // TODO: create new installation : wip
     console.log('on save create new installation', apiKey);
+    const objectName = selectedObjectName || '';
+
+    const createInstallationRequest: CreateInstallationOperationRequest = {
+      projectId,
+      integrationId,
+      installation: {
+        groupRef,
+        connectionId: selectedConnection?.id ?? '',
+        config: {
+          revisionId: hydratedRevision?.id ?? '',
+          createdBy: consumerRef,
+          content: {
+            api: hydratedRevision?.content?.api || '',
+            read: {
+              standardObjects: {
+                [objectName]: {
+                  objectName,
+                  // todo form config for read from hydratedRevision and configuration state
+                  schedule: '',
+                  destination: '',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    api().createInstallation(createInstallationRequest, {
+      headers: {
+        'X-Api-Key': apiKey ?? '',
+      },
+    })
+      .then((installation) => {
+        console.log('installation', installation);
+      })
+      .catch((err) => {
+        console.error('ERROR: ', err);
+      });
   };
 
   const title = <>Create a new installation</>;

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -1,14 +1,7 @@
-import {
-  useContext, useEffect, useMemo, useState,
-} from 'react';
-
-import { ApiKeyContext } from '../../context/ApiKeyContext';
 import { ConnectionsProvider } from '../../context/ConnectionsContext';
 import { HydratedRevisionProvider } from '../../context/HydratedRevisionContext';
-import { useIntegrationList } from '../../context/IntegrationListContext';
+import { InstallIntegrationProvider, useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
 import { useProject } from '../../context/ProjectContext';
-import { api, Installation } from '../../services/api';
-import { findIntegrationFromList } from '../../utils';
 
 import { ConfigurationProvider } from './state/ConfigurationStateProvider';
 import { CreateInstallation } from './CreateInstallation';
@@ -16,6 +9,26 @@ import { ErrorTextBoxPlaceholder } from './ErrorTextBoxPlaceholder';
 import { ObjectManagementNav } from './ObjectManagementNav';
 import { ProtectedConnectionLayout } from './ProtectedConnectionLayout';
 import { UpdateInstallation } from './UpdateInstallation';
+
+// todo : add the install integration provider to supply these properties
+function InstallationContent() {
+  const { integrationObj, installation } = useInstallIntegrationProps();
+
+  if (!integrationObj) {
+    return <ErrorTextBoxPlaceholder />;
+  }
+
+  return installation && integrationObj ? (
+    // If installation exists, render update installation flow
+    <UpdateInstallation
+      installation={installation}
+      integrationObj={integrationObj}
+    />
+  ) : (
+    // No installation, render create installation flow
+    <CreateInstallation />
+  );
+}
 
 interface InstallIntegrationProps {
   integration: string, // integration name
@@ -32,71 +45,27 @@ export function InstallIntegration(
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();
-  const { integrations } = useIntegrationList();
-  const [installations, setInstallations] = useState<Installation[]>([]);
-  const installation = installations?.[0] || null;
-  const apiKey = useContext(ApiKeyContext);
-
-  const integrationObj = useMemo(
-    () => findIntegrationFromList(integration, integrations || []),
-    [integration, integrations],
-  );
-
-  // check if integration has been installed in AmpersandProvider
-  useEffect(() => {
-    if (integrationObj?.id) {
-      // check if installation exists on selected integration
-      api().listInstallations({ projectId, integrationId: integrationObj.id, groupRef }, {
-        headers: {
-          'X-Api-Key': apiKey ?? '',
-        },
-      })
-        .then((_installations) => { setInstallations(_installations || []); })
-        .catch((err) => { console.error('ERROR: ', err); });
-    }
-  }, [projectId, integrationObj?.id, apiKey, groupRef]);
-
-  // if no integration, render error page
-  if (!integrations || !integrations.length || !integration || !integrationObj) {
-    return <ErrorTextBoxPlaceholder />;
-  }
-
-  const content = installation && integrationObj ? (
-  // if installation exists, render update installation flow
-    <UpdateInstallation
-      installation={installation}
-      integrationObj={integrationObj}
-    />
-  ) : (
-    // no installation, render create installation flow
-    <CreateInstallation />
-  );
-
   return (
-    <ConnectionsProvider
-      projectId={projectId}
+    // install integration provider provides all props, integrationObj and installation
+    <InstallIntegrationProvider
+      integration={integration}
+      consumerRef={consumerRef}
+      consumerName={consumerName}
       groupRef={groupRef}
-      provider={integrationObj?.provider}
+      groupName={groupName}
     >
-      <ProtectedConnectionLayout
-        consumerRef={consumerRef}
-        consumerName={consumerName}
-        groupRef={groupRef}
-        groupName={groupName}
-      >
-        <HydratedRevisionProvider
-          projectId={projectId}
-          integrationId={integrationObj?.id}
-          revisionId={integrationObj?.latestRevision?.id}
-        >
-          <ObjectManagementNav config={installation?.config}>
-            <ConfigurationProvider config={installation?.config}>
-              {content}
-            </ConfigurationProvider>
-          </ObjectManagementNav>
-        </HydratedRevisionProvider>
-      </ProtectedConnectionLayout>
-    </ConnectionsProvider>
+      <ConnectionsProvider projectId={projectId}>
+        <ProtectedConnectionLayout>
+          <HydratedRevisionProvider projectId={projectId}>
+            <ObjectManagementNav>
+              <ConfigurationProvider>
+                <InstallationContent />
+              </ConfigurationProvider>
+            </ObjectManagementNav>
+          </HydratedRevisionProvider>
+        </ProtectedConnectionLayout>
+      </ConnectionsProvider>
+    </InstallIntegrationProvider>
 
   );
 }

--- a/src/components/Configure/ObjectManagementNav.tsx
+++ b/src/components/Configure/ObjectManagementNav.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState } from 'react';
 import { Box, Tab, Tabs } from '@chakra-ui/react';
 
 import { useHydratedRevision } from '../../context/HydratedRevisionContext';
+import { useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
 import { Config, HydratedRevision } from '../../services/api';
 
 import { getActionTypeFromActions, getReadObject, PLACEHOLDER_VARS } from './utils';
@@ -56,7 +57,6 @@ export function useSelectedObjectName() {
 }
 
 type ObjectManagementNavProps = {
-  config?: Config;
   children?: React.ReactNode;
 };
 
@@ -66,10 +66,11 @@ function getSelectedObject(navObjects: NavObject[], tabIndex: number): NavObject
 
 // note: when the object key exists in the config; the user has already completed the object before
 export function ObjectManagementNav({
-  config,
   children,
 }: ObjectManagementNavProps) {
+  const { installation } = useInstallIntegrationProps();
   const { hydratedRevision, loading, error } = useHydratedRevision();
+  const config = installation?.config;
   const navObjects = hydratedRevision && generateNavObjects(config, hydratedRevision);
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabsChange = (index: number) => { setTabIndex(index); };

--- a/src/components/Configure/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/ProtectedConnectionLayout.tsx
@@ -1,20 +1,18 @@
 import { useEffect } from 'react';
 
 import { useConnections } from '../../context/ConnectionsContext';
+import { useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
 import SalesforceOauthFlow from '../Salesforce/SalesforceOauthFlow';
 
 interface ConfigureIntegrationBaseProps {
-  consumerRef: string,
-  consumerName?: string,
-  groupRef: string,
-  groupName?: string,
   children: React.ReactNode,
 }
 
 // if connection does not exist, render SalesforceOauthFlow
-export function ProtectedConnectionLayout({
-  consumerRef, consumerName, groupRef, groupName, children,
-}: ConfigureIntegrationBaseProps) {
+export function ProtectedConnectionLayout({ children }: ConfigureIntegrationBaseProps) {
+  const {
+    consumerRef, consumerName, groupRef, groupName,
+  } = useInstallIntegrationProps();
   const { selectedConnection, setSelectedConnection, connections } = useConnections();
 
   useEffect(() => {

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -1,10 +1,9 @@
 import React, {
-  createContext, useContext, useEffect, useMemo,
-  useState,
+  createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
 import { useHydratedRevision } from '../../../context/HydratedRevisionContext';
-import { Config } from '../../../services/api';
+import { useInstallIntegrationProps } from '../../../context/InstallIntegrationContext';
 import { useSelectedObjectName } from '../ObjectManagementNav';
 import { ConfigureState } from '../types';
 
@@ -35,20 +34,21 @@ export function useConfigureState() {
 }
 
 type ConfigurationProviderProps = {
-  config?: Config;
   children: React.ReactNode;
 };
 
 // Create a provider component for the configuration context
 export function ConfigurationProvider(
-  { config, children }: ConfigurationProviderProps,
+  { children }: ConfigurationProviderProps,
 ) {
+  const { installation } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
   // 1. get config from installations (contains form selection state)
   // 2. get the hydrated revision from installation revisionId (contains full form)
   // 3. generate the configuration state from the hydrated revision and config
   const [configureState, setConfigureState] = useState<ConfigureState>(initialConfigureState);
+  const config = installation?.config;
 
   useEffect(() => {
     // set configurationState when hydratedRevision is loaded

--- a/src/context/ConnectionsContext.tsx
+++ b/src/context/ConnectionsContext.tsx
@@ -5,6 +5,7 @@ import React, {
 import { api, Connection } from '../services/api';
 
 import { ApiKeyContext } from './ApiKeyContext';
+import { useInstallIntegrationProps } from './InstallIntegrationContext';
 
 interface ConnectionsContextValue {
   connections: Connection[] | null;
@@ -32,17 +33,14 @@ export const useConnections = (): ConnectionsContextValue => {
 
 type ConnectionsProviderProps = {
   projectId: string;
-  groupRef: string;
-  provider?: string;
   children?: React.ReactNode;
 };
 
 export function ConnectionsProvider({
   projectId,
-  groupRef,
-  provider,
   children,
 }: ConnectionsProviderProps) {
+  const { groupRef, provider } = useInstallIntegrationProps();
   const [connections, setConnections] = useState<Connection[] | null>(null);
   const [selectedConnection, setSelectedConnection] = useState<Connection | null>(null);
   const apiKey = useContext(ApiKeyContext);

--- a/src/context/HydratedRevisionContext.tsx
+++ b/src/context/HydratedRevisionContext.tsx
@@ -6,6 +6,7 @@ import { api, HydratedRevision } from '../services/api';
 
 import { ApiKeyContext } from './ApiKeyContext';
 import { useConnections } from './ConnectionsContext';
+import { useInstallIntegrationProps } from './InstallIntegrationContext';
 
 interface HydratedRevisionContextValue {
   hydratedRevision: HydratedRevision | null;
@@ -31,23 +32,21 @@ export const useHydratedRevision = () => {
 
 type HydratedRevisionProviderProps = {
   projectId?: string | null;
-  integrationId?: string | null;
-  revisionId?: string | null;
   children?: React.ReactNode;
 };
 
 export function HydratedRevisionProvider({
   projectId,
-  integrationId,
-  revisionId,
   children,
 } : HydratedRevisionProviderProps) {
+  const { integrationId, integrationObj } = useInstallIntegrationProps();
   const [hydratedRevision, setHydratedRevision] = useState<HydratedRevision | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const apiKey = useContext(ApiKeyContext);
   const { selectedConnection } = useConnections();
   const connectionId = selectedConnection?.id;
+  const revisionId = integrationObj?.latestRevision?.id;
 
   useEffect(() => {
     // Fetch the hydrated revision data using your API call

--- a/src/context/InstallIntegrationContext.tsx
+++ b/src/context/InstallIntegrationContext.tsx
@@ -1,0 +1,97 @@
+import {
+  createContext, useContext, useEffect, useMemo, useState,
+} from 'react';
+
+import { api, Installation, Integration } from '../services/api';
+import { findIntegrationFromList } from '../utils';
+
+import { ApiKeyContext } from './ApiKeyContext';
+import { useIntegrationList } from './IntegrationListContext';
+import { useProject } from './ProjectContext';
+
+// Define the context value type
+interface InstallIntegrationContextValue {
+  integrationId: string;
+  provider: string;
+  integrationObj: Integration | null;
+  consumerRef: string;
+  consumerName?: string;
+  groupRef: string;
+  groupName?: string;
+  installation: Installation | undefined;
+}
+// Create a context to pass down the props
+const InstallIntegrationContext = createContext<InstallIntegrationContextValue>({
+  integrationId: '',
+  provider: '',
+  integrationObj: null,
+  consumerRef: '',
+  consumerName: '',
+  groupRef: '',
+  groupName: '',
+  installation: undefined,
+});
+
+// Create a custom hook to access the props
+export function useInstallIntegrationProps() {
+  const context = useContext(InstallIntegrationContext);
+  if (!context) {
+    throw new Error('useInstallIntegrationProps must be used within an InstallIntegrationProvider');
+  }
+  return context;
+}
+
+interface InstallIntegrationProviderProps {
+  integration: string, // integration name
+  consumerRef: string,
+  consumerName?: string,
+  groupRef: string,
+  groupName?: string,
+  children: React.ReactNode,
+}
+
+// Wrap your parent component with the context provider
+export function InstallIntegrationProvider({
+  children, integration, consumerRef, consumerName, groupRef, groupName,
+}: InstallIntegrationProviderProps) {
+  const { projectId } = useProject();
+  const [installations, setInstallations] = useState<Installation[]>([]);
+  const installation = installations?.[0] || null; // there should only be one installation for mvp
+  const apiKey = useContext(ApiKeyContext);
+  const { integrations } = useIntegrationList();
+  const integrationObj = useMemo(
+    () => findIntegrationFromList(integration, integrations || []),
+    [integration, integrations],
+  );
+
+  // check if integration has been installed in AmpersandProvider
+  useEffect(() => {
+    if (integrationObj?.id) {
+      // check if installation exists on selected integration
+      api().listInstallations({ projectId, integrationId: integrationObj.id, groupRef }, {
+        headers: {
+          'X-Api-Key': apiKey ?? '',
+        },
+      })
+        .then((_installations) => { setInstallations(_installations || []); })
+        .catch((err) => { console.error('ERROR: ', err); });
+    }
+  }, [projectId, integrationObj?.id, apiKey, groupRef]);
+
+  const props = useMemo(() => ({
+    integrationId: integrationObj?.id || '',
+    provider: integrationObj?.provider || '',
+    integrationObj: integrationObj || null,
+    consumerRef,
+    consumerName,
+    groupRef,
+    groupName,
+    installation,
+  }), [integrationObj, consumerRef, consumerName, groupRef, groupName, installation]);
+
+  return (
+    <InstallIntegrationContext.Provider value={props}>
+      {children}
+    </InstallIntegrationContext.Provider>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,7 @@
 import {
   Config,
   Configuration, Connection,
+  CreateInstallationOperationRequest,
   DefaultApi, HydratedIntegrationAction,
   HydratedIntegrationField,
   HydratedIntegrationFieldExistent,
@@ -87,6 +88,7 @@ export const api = () => apiValue;
 export type {
   Config,
   Connection,
+  CreateInstallationOperationRequest,
   HydratedIntegrationAction,
   HydratedIntegrationObject,
   HydratedIntegrationField,


### PR DESCRIPTION
### adds InstallIntegrationContext
- moves all InstallIntegration props, installation, and integrationObj to context
- removes several properties that can now be accessed via the `useInstallIntegrationProps` hook
- starts passing in some props to create installation which will be done in a follow up

#### update works as expected
create installation still in progress