### PR TITLE
style: object pending state

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   },
   "peerDependencies": {
     "@chakra-ui/react": "^2.4.4",
-    "@emotion/react": "^11.10.5",
-    "@emotion/styled": "^11.10.5",
+    "@emotion/react": "^x.x.x",
+    "@emotion/styled": "^x.x.x",
     "framer-motion": "^x.x.x",
     "react": "^18.0.0"
   },

--- a/src/assets/NavIcon.tsx
+++ b/src/assets/NavIcon.tsx
@@ -1,4 +1,17 @@
-export function NavIcon(completed: boolean) {
+import React from 'react';
+
+export function NavIcon(completed: boolean, pending?: boolean) {
+  if (pending) {
+    return (React.createElement(
+      'svg',
+      {
+        xmlns: 'http://www.w3.org/2000/svg', width: '18', height: '18', viewBox: '0 0 18 18', fill: 'none',
+      },
+      React.createElement('circle', {
+        cx: '9', cy: '9', r: '5', fill: '#FBD38D',
+      }),
+    ));
+  }
   if (completed) {
     return (
       <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
@@ -7,6 +20,7 @@ export function NavIcon(completed: boolean) {
       </svg>
     );
   }
+  // default to empty icon
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
       <circle cx="9" cy="9" r="5" fill="#BFDBFE" />

--- a/src/components/Configure/ObjectManagementNav/NavObjectItem.tsx
+++ b/src/components/Configure/ObjectManagementNav/NavObjectItem.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import {
-  Box, Button, useMultiStyleConfig, useTab,
+  Box, Button, Text,
+  useMultiStyleConfig, useTab,
 } from '@chakra-ui/react';
 
 import { NavIcon } from '../../../assets/NavIcon';
@@ -8,10 +9,11 @@ import { NavIcon } from '../../../assets/NavIcon';
 interface NavObjectItemProps {
   objectName: string;
   completed: boolean;
+  pending?: boolean;
 }
 
 export const NavObjectItem = forwardRef<HTMLButtonElement, NavObjectItemProps>(
-  ({ objectName, completed }, ref) => {
+  ({ objectName, completed, pending }, ref) => {
     // 1. Reuse the `useTab` hook
     const tabProps = useTab({ ref });
 
@@ -19,7 +21,7 @@ export const NavObjectItem = forwardRef<HTMLButtonElement, NavObjectItemProps>(
     const styles = useMultiStyleConfig('Tabs', tabProps);
 
     return (
-      <Button __css={styles.tab} {...tabProps} variant="outline">
+      <Button __css={styles.tab} {...tabProps} variant="outline" minHeight={15}>
         <Box
           as="span"
           display="flex"
@@ -27,7 +29,11 @@ export const NavObjectItem = forwardRef<HTMLButtonElement, NavObjectItemProps>(
           gap={2}
           mr="3"
         >
-          {NavIcon(completed)} {objectName}
+          {NavIcon(completed, pending)}
+          <Box textAlign="left">
+            <Text>{objectName}</Text>
+            {pending && <Text fontSize={10} fontStyle="italic">pending</Text>}
+          </Box>
         </Box>
         {tabProps.children}
       </Button>


### PR DESCRIPTION
### adds pending state style to object nav
when the user exits a selection they need to know that the pending object has not been saved yet. This adds the pending style without the pending state logic.
#### empty states

<img width="790" alt="Screenshot 2023-10-19 at 4 15 37 PM" src="https://github.com/amp-labs/react/assets/5396828/fefa0ef9-4950-40e1-9311-587bcc2d92b5"> 

#### pending states
<img width="816" alt="Screenshot 2023-10-19 at 4 15 51 PM" src="https://github.com/amp-labs/react/assets/5396828/5f446ab8-12c2-4924-8405-a93ce896a84e">


