### PR TITLE
chore: remove unnecessary console warning in hydrated revision context

### DIFF
--- a/src/context/HydratedRevisionContext.tsx
+++ b/src/context/HydratedRevisionContext.tsx
@@ -73,8 +73,6 @@ export function HydratedRevisionProvider({
           setLoading(false);
           setError(err.message || 'An error occurred while fetching data');
         });
-    } else {
-
     }
   }, [projectId, integrationId, revisionId, connectionId, apiKey, integrations]);
 


### PR DESCRIPTION
this warning is not necessary since it just means that the other API calls haven't finished yet, and everything is still loading. seeing it in the dev console looks scary and might confuse builders who are using our UI library. 