### PR TITLE
[ENG-379]feat: loading connections

### DIFF
--- a/src/context/ConnectionsContext.tsx
+++ b/src/context/ConnectionsContext.tsx
@@ -2,6 +2,7 @@ import React, {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
+import { LoadingIcon } from '../assets/LoadingIcon';
 import { api, Connection } from '../services/api';
 
 import { ApiKeyContext } from './ApiKeyContext';
@@ -44,6 +45,7 @@ export function ConnectionsProvider({
   const [connections, setConnections] = useState<Connection[] | null>(null);
   const [selectedConnection, setSelectedConnection] = useState<Connection | null>(null);
   const apiKey = useContext(ApiKeyContext);
+  const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {
     api().listConnections({ projectId, groupRef, provider }, {
@@ -51,8 +53,10 @@ export function ConnectionsProvider({
         'X-Api-Key': apiKey ?? '',
       },
     }).then((_connections) => {
+      setLoadingState(false);
       setConnections(_connections);
     }).catch((err) => {
+      setLoadingState(false);
       console.error('ERROR: ', err);
     });
   }, [projectId, apiKey, groupRef, provider]);
@@ -66,7 +70,7 @@ export function ConnectionsProvider({
 
   return (
     <ConnectionsContext.Provider value={contextValue}>
-      {children}
+      {isLoading ? <LoadingIcon /> : children}
     </ConnectionsContext.Provider>
   );
 }


### PR DESCRIPTION
Loading screen covers all UI when connection api is called. 
5 second time out added on the server side to capture video.


https://github.com/amp-labs/react/assets/135054647/27f60465-66ce-4e46-bd05-9d782572239f

