### PR TITLE
cleanup: remove immutability from state.

### DIFF
--- a/src/components/Configure/fields/OptionalFields.tsx
+++ b/src/components/Configure/fields/OptionalFields.tsx
@@ -13,25 +13,28 @@ export function OptionalFields() {
   const { objectConfigurationsState, setConfigureState } = useConfigureState();
   const { selectedObjectName } = useSelectedObjectName();
   const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+  const { selectedOptionalFields } = configureState || {};
 
   const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;
 
     if (selectedObjectName) {
       // Update the value property to new checked value
-      let { selectedOptionalFields } = configureState || {};
-      selectedOptionalFields = selectedOptionalFields || {};
-      selectedOptionalFields[name] = checked;
+      const updatedSelectedOptionalFields = {
+        ...selectedOptionalFields,
+        [name]: checked,
+      };
 
       // update state
       setConfigureState(
         selectedObjectName,
-        { ...configureState, selectedOptionalFields },
+        {
+          ...configureState,
+          selectedOptionalFields: updatedSelectedOptionalFields,
+        },
       );
     }
   };
-
-  const { selectedOptionalFields } = configureState || {};
 
   return (
     <>

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -112,19 +112,17 @@ export const generateSelectedFieldsFromConfigureState = (configureState: Configu
   const { requiredFields, selectedOptionalFields } = configureState;
   const fields = new Set<string>();
   requiredFields?.forEach((field) => fields.add(getFieldKeyValue(field)));
-  // adds optional fields that are selected (true)
 
   // convert set to object for config
-  let selectedFields = Array.from(fields).reduce((acc, field) => ({
+  const selectedFields = Array.from(fields).reduce((acc, field) => ({
     ...acc,
     [field]: true,
   }), {});
 
-  selectedFields = {
+  return {
     ...selectedFields,
-    ...(selectedOptionalFields || {}),
+    ...(selectedOptionalFields || {}), // adds optional fields that are selected (true)
   };
-  return selectedFields;
 };
 
 /**


### PR DESCRIPTION
in general we want to avoid using `let` since the pointers of what's mutable and immutable gets more complicated. Even if we use `const` on an array it doesn't make it immutable in the way we might think since the pointer can still change. We want handle state changes like a reduce an compose a new state object when possible.

In this change, `let` is changed to `const` and we avoid mutable state when possible.