### PR TITLE
refactor: preps ConfigurationStateProvider for refactor

### DIFF
--- a/src/components/Configure/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/ConfigureInstallationBase.tsx
@@ -6,11 +6,11 @@ import {
 } from '@chakra-ui/react';
 
 import { LoadingIcon } from '../../assets/LoadingIcon';
-import { useHydratedRevision } from '../../context/HydratedRevisionContext';
 
 import { OptionalFields } from './fields/OptionalFields';
 import { RequiredFieldMappings } from './fields/RequiredFieldMappings';
 import { RequiredFields } from './fields/RequiredFields';
+import { useHydratedRevision } from './state/HydratedRevisionContext';
 
 interface ConfigureInstallationBaseProps {
   onSave: FormEventHandler,

--- a/src/components/Configure/CreateInstallation.tsx
+++ b/src/components/Configure/CreateInstallation.tsx
@@ -10,12 +10,12 @@ import { useConnections } from '../../context/ConnectionsContext';
 import {
   ErrorBoundary, useErrorState,
 } from '../../context/ErrorContextProvider';
-import { useHydratedRevision } from '../../context/HydratedRevisionContext';
 import { useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
 import { useProject } from '../../context/ProjectContext';
 
 import { onSaveCreate } from './actions/onSaveCreate';
 import { useConfigureState } from './state/ConfigurationStateProvider';
+import { useHydratedRevision } from './state/HydratedRevisionContext';
 import { getConfigureState, resetConfigurationState } from './state/utils';
 import { ConfigureInstallationBase } from './ConfigureInstallationBase';
 import { useSelectedObjectName } from './ObjectManagementNav';

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -1,10 +1,10 @@
 import { ConnectionsProvider } from '../../context/ConnectionsContext';
 import { ErrorBoundary, useErrorState } from '../../context/ErrorContextProvider';
-import { HydratedRevisionProvider } from '../../context/HydratedRevisionContext';
 import { InstallIntegrationProvider, useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
 import { useProject } from '../../context/ProjectContext';
 
 import { ConfigurationProvider } from './state/ConfigurationStateProvider';
+import { HydratedRevisionProvider } from './state/HydratedRevisionContext';
 import { CreateInstallation } from './CreateInstallation';
 import { ErrorTextBox } from './ErrorTextBox';
 import { ObjectManagementNav } from './ObjectManagementNav';

--- a/src/components/Configure/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/ObjectManagementNav/index.tsx
@@ -3,10 +3,10 @@ import {
 } from 'react';
 import { Box, Tabs, Text } from '@chakra-ui/react';
 
-import { useHydratedRevision } from '../../../context/HydratedRevisionContext';
 import { useInstallIntegrationProps } from '../../../context/InstallIntegrationContext';
 import { useProject } from '../../../context/ProjectContext';
 import { useConfigureState } from '../state/ConfigurationStateProvider';
+import { useHydratedRevision } from '../state/HydratedRevisionContext';
 import { NavObject } from '../types';
 import { generateNavObjects } from '../utils';
 

--- a/src/components/Configure/UpdateInstallation.tsx
+++ b/src/components/Configure/UpdateInstallation.tsx
@@ -7,13 +7,13 @@ import {
   ErrorBoundary,
   useErrorState,
 } from '../../context/ErrorContextProvider';
-import { useHydratedRevision } from '../../context/HydratedRevisionContext';
 import { useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
 import { useProject } from '../../context/ProjectContext';
 import { Installation, Integration } from '../../services/api';
 
 import { onSaveUpdate } from './actions/onSaveUpdate';
 import { useConfigureState } from './state/ConfigurationStateProvider';
+import { useHydratedRevision } from './state/HydratedRevisionContext';
 import { getConfigureState, resetConfigurationState } from './state/utils';
 import { ConfigureInstallationBase } from './ConfigureInstallationBase';
 import { useSelectedObjectName } from './ObjectManagementNav';

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -2,10 +2,10 @@ import React, {
   createContext, useCallback, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { useHydratedRevision } from '../../../context/HydratedRevisionContext';
 import { useInstallIntegrationProps } from '../../../context/InstallIntegrationContext';
 import { ConfigureState, ObjectConfigurationsState } from '../types';
 
+import { useHydratedRevision } from './HydratedRevisionContext';
 import {
   resetAllObjectsConfigurationState,
 } from './utils';

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -2,16 +2,15 @@ import React, {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from '../components/Configure/ErrorTextBox';
-import { api, HydratedRevision } from '../services/api';
-
-import { ApiKeyContext } from './ApiKeyContext';
-import { useConnections } from './ConnectionsContext';
+import { ApiKeyContext } from '../../../context/ApiKeyContext';
+import { useConnections } from '../../../context/ConnectionsContext';
 import {
   ErrorBoundary, useErrorState,
-} from './ErrorContextProvider';
-import { useInstallIntegrationProps } from './InstallIntegrationContext';
-import { useIntegrationList } from './IntegrationListContext';
+} from '../../../context/ErrorContextProvider';
+import { useInstallIntegrationProps } from '../../../context/InstallIntegrationContext';
+import { useIntegrationList } from '../../../context/IntegrationListContext';
+import { api, HydratedRevision } from '../../../services/api';
+import { ErrorTextBox } from '../ErrorTextBox';
 
 interface HydratedRevisionContextValue {
   hydratedRevision: HydratedRevision | null;

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -26,7 +26,7 @@ type SavedConfigureState = {
 export type ConfigureState = {
   allFields: HydratedIntegrationFieldExistent[] | null, // needed for custom mapping
   requiredFields: HydratedIntegrationField[] | null,
-  optionalFields: ConfigureStateIntegrationField[] | null,
+  optionalFields: HydratedIntegrationField[] | null,
   requiredMapFields: ConfigureStateMappingIntegrationField[] | null,
   selectedOptionalFields: SelectOptionalFields | null,
   isOptionalFieldsModified: boolean, // checks if selected optional fields is modified

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -53,7 +53,9 @@ export function getRequiredMapFieldsFromObject(object: HydratedIntegrationObject
 // 3. get optional fields
 export function getOptionalFieldsFromObject(object: HydratedIntegrationObject)
   : HydratedIntegrationField[] | null {
-  return object?.optionalFields || null;
+  return object?.optionalFields?.filter(
+    (rf: HydratedIntegrationField) => !isIntegrationFieldMapping(rf) && !!rf.fieldName,
+  ) || null;
 }
 
 export const getReadObject = (


### PR DESCRIPTION
### refactor 
ConfigurationStateProvider is managing both fetch state from hydrated revision and local body config state. This PR preps the separation and moves HydratedRevisionContext so that we can separate some state from ConfigurationStateProvider.
