### PR TITLE
[ENG-397] feat: allow pending state when switching tabs

### DIFF
--- a/src/components/Configure/CreateInstallation.tsx
+++ b/src/components/Configure/CreateInstallation.tsx
@@ -34,7 +34,11 @@ export function CreateInstallation() {
   const apiKey = useContext(ApiKeyContext);
   const { projectId } = useProject();
   const { resetBoundary, setErrors } = useErrorState();
-  const { setConfigureState, objectConfigurationsState } = useConfigureState();
+  const {
+    setConfigureState,
+    objectConfigurationsState,
+    resetPendingConfigurationState,
+  } = useConfigureState();
   const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
   const [isLoading, setLoadingState] = useState<boolean>(false);
 
@@ -96,6 +100,7 @@ export function CreateInstallation() {
 
       res.finally(() => {
         setLoadingState(false);
+        resetPendingConfigurationState(selectedObjectName);
       });
     } else {
       console.error('OnSaveCreate: missing required props');

--- a/src/components/Configure/UpdateInstallation.tsx
+++ b/src/components/Configure/UpdateInstallation.tsx
@@ -40,7 +40,11 @@ export function UpdateInstallation(
   // 2. get the hydrated revision (contains full form)
   // 3. generate the configuration state from the hydrated revision and config
   const { resetBoundary, setErrors } = useErrorState();
-  const { setConfigureState, objectConfigurationsState } = useConfigureState();
+  const {
+    setConfigureState,
+    objectConfigurationsState,
+    resetPendingConfigurationState,
+  } = useConfigureState();
   const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
   const resetState = useCallback(
     () => {
@@ -61,8 +65,8 @@ export function UpdateInstallation(
   );
 
   useEffect(() => {
-    resetState();
-  }, [resetState]);
+    if (!configureState) { resetState(); }
+  }, [configureState, resetState]);
 
   const hydratedObject = useMemo(() => {
     const hydrated = hydratedRevision?.content?.read?.standardObjects?.find(
@@ -112,6 +116,7 @@ export function UpdateInstallation(
 
       res.finally(() => {
         setLoadingState(false);
+        resetPendingConfigurationState(selectedObjectName);
       });
     } else {
       console.error('update installation props missing');


### PR DESCRIPTION
### feat: adds more pending state logic
- saves pending state between objects
- keeps pending when calling saved

during update and create calls we manually update the pending states. we also avoid calling reset states when an existing configuration state or configuration objects state exists.


![pending-state-demo-2](https://github.com/amp-labs/react/assets/5396828/6140369e-c967-424a-acb4-afa5f5f4f47f)

