### PR TITLE
refactor: adds hook useApiKey

### DIFF
--- a/src/components/AmpersandProvider/AmpersandProvider.tsx
+++ b/src/components/AmpersandProvider/AmpersandProvider.tsx
@@ -7,7 +7,7 @@
 
 import React, { createContext, useContext } from 'react';
 
-import { ApiKeyProvider } from '../../context/ApiKeyContext';
+import { ApiKeyProvider } from '../../context/ApiKeyProvider';
 import { ErrorStateProvider } from '../../context/ErrorContextProvider';
 import { IntegrationListProvider } from '../../context/IntegrationListContext';
 import { ProjectProvider } from '../../context/ProjectContext';

--- a/src/components/Configure/CreateInstallation.tsx
+++ b/src/components/Configure/CreateInstallation.tsx
@@ -2,10 +2,10 @@
  * this page is wip: untested
  */
 import {
-  useCallback, useContext, useEffect, useState,
+  useCallback, useEffect, useState,
 } from 'react';
 
-import { ApiKeyContext } from '../../context/ApiKeyContext';
+import { useApiKey } from '../../context/ApiKeyProvider';
 import { useConnections } from '../../context/ConnectionsContext';
 import {
   ErrorBoundary, useErrorState,
@@ -31,7 +31,7 @@ export function CreateInstallation() {
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
   const { selectedConnection } = useConnections();
-  const apiKey = useContext(ApiKeyContext);
+  const apiKey = useApiKey();
   const { projectId } = useProject();
   const { resetBoundary, setErrors } = useErrorState();
   const {
@@ -70,8 +70,7 @@ export function CreateInstallation() {
     const { requiredMapFields } = configureState;
     const fieldsWithRequirementsNotMet = requiredMapFields?.filter(
       (field) => !field.value,
-    )
-      || [];
+    ) || [];
 
     const errList = fieldsWithRequirementsNotMet.map((field) => field.mapToName);
     setErrors(ErrorBoundary.MAPPING, errList);

--- a/src/components/Configure/UpdateInstallation.tsx
+++ b/src/components/Configure/UpdateInstallation.tsx
@@ -1,8 +1,8 @@
 import {
-  useCallback, useContext, useEffect, useMemo, useState,
+  useCallback, useEffect, useMemo, useState,
 } from 'react';
 
-import { ApiKeyContext } from '../../context/ApiKeyContext';
+import { useApiKey } from '../../context/ApiKeyProvider';
 import {
   ErrorBoundary,
   useErrorState,
@@ -27,14 +27,15 @@ interface UpdateInstallationProps {
 export function UpdateInstallation(
   { installation, integrationObj }: UpdateInstallationProps,
 ) {
+  const apiKey = useApiKey();
   const { setInstallation } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
-  const apiKey = useContext(ApiKeyContext);
   const { projectId } = useProject();
+  const [isLoading, setLoadingState] = useState<boolean>(false);
+
   // when no installation or config exists, render create flow
   const { config } = installation;
-  const [isLoading, setLoadingState] = useState<boolean>(false);
 
   // 1. get config from installations (contains form selection state)
   // 2. get the hydrated revision (contains full form)

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -2,7 +2,7 @@ import React, {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ApiKeyContext } from '../../../context/ApiKeyContext';
+import { useApiKey } from '../../../context/ApiKeyProvider';
 import { useConnections } from '../../../context/ConnectionsContext';
 import {
   ErrorBoundary, useErrorState,
@@ -41,13 +41,15 @@ export function HydratedRevisionProvider({
   projectId,
   children,
 }: HydratedRevisionProviderProps) {
-  const { integrationId, integrationObj } = useInstallIntegrationProps();
+  const { selectedConnection } = useConnections();
   const { integrations } = useIntegrationList();
+  const { integrationId, integrationObj } = useInstallIntegrationProps();
+
   const [hydratedRevision, setHydratedRevision] = useState<HydratedRevision | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const { isError, removeError, setError } = useErrorState();
-  const apiKey = useContext(ApiKeyContext);
-  const { selectedConnection } = useConnections();
+  const apiKey = useApiKey();
+
   const connectionId = selectedConnection?.id;
   const revisionId = integrationObj?.latestRevision?.id;
   const errorIntegrationIdentifier = integrationObj?.name || integrationId;

--- a/src/components/OAuthPopup/OAuthPopup.tsx
+++ b/src/components/OAuthPopup/OAuthPopup.tsx
@@ -5,11 +5,10 @@
  */
 
 import React, {
-  useCallback,
-  useContext, useEffect, useRef, useState,
+  useCallback, useEffect, useRef, useState,
 } from 'react';
 
-import { ApiKeyContext } from '../../context/ApiKeyContext';
+import { useApiKey } from '../../context/ApiKeyProvider';
 import { useConnections } from '../../context/ConnectionsContext';
 import { useProject } from '../../context/ProjectContext';
 import { AMP_SERVER, api } from '../../services/api';
@@ -52,13 +51,13 @@ function OAuthPopup({
   children,
   onClose,
 }: PopupProps) {
+  const { projectId } = useProject();
+  const apiKey = useApiKey();
   const [externalWindow, setExternalWindow] = useState<Window | null>();
   const intervalRef = useRef<number>();
 
   const clearTimer = () => window.clearInterval(intervalRef.current);
   const { setSelectedConnection } = useConnections();
-  const { projectId } = useProject();
-  const apiKey = useContext(ApiKeyContext);
 
   useEffect(() => {
     if (url) setExternalWindow(createPopup({ url, title }));

--- a/src/components/Salesforce/SalesforceOauthFlow.tsx
+++ b/src/components/Salesforce/SalesforceOauthFlow.tsx
@@ -3,9 +3,7 @@
  * that Salesforce instance.
  */
 
-import {
-  useCallback, useContext, useState,
-} from 'react';
+import { useCallback, useState } from 'react';
 import { ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   Alert, AlertDescription, AlertIcon, Box, Button, Container, Flex, FormControl,
@@ -13,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 
 import { PROVIDER_SALESFORCE } from '../../constants';
-import { ApiKeyContext } from '../../context/ApiKeyContext';
+import { useApiKey } from '../../context/ApiKeyProvider';
 import { useProject } from '../../context/ProjectContext';
 import { api, ProviderApp } from '../../services/api';
 import OAuthPopup from '../OAuthPopup/OAuthPopup';
@@ -51,12 +49,12 @@ interface SalesforceOauthFlowProps {
 function SalesforceOauthFlow({
   consumerRef, consumerName, groupRef, groupName,
 }: SalesforceOauthFlowProps) {
+  const { projectId } = useProject();
+  const apiKey = useApiKey();
+
   const [workspace, setWorkspace] = useState<string>('');
   const [oAuthCallbackURL, setOAuthCallbackURL] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  const { projectId } = useProject();
-  const apiKey = useContext(ApiKeyContext);
 
   const handleSubmit = async () => {
     setError(null);

--- a/src/context/ApiKeyContext.tsx
+++ b/src/context/ApiKeyContext.tsx
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-export const ApiKeyContext = createContext<string | null>(null);
-
-export const ApiKeyProvider = ApiKeyContext.Provider;

--- a/src/context/ApiKeyProvider.tsx
+++ b/src/context/ApiKeyProvider.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react';
+
+export const ApiKeyContext = createContext<string | null>(null);
+
+export const ApiKeyProvider = ApiKeyContext.Provider;
+
+export const useApiKey = () => {
+  const apiKey = useContext(ApiKeyContext);
+
+  if (apiKey === null) {
+    throw new Error('useApiKey must be used within an ApiKeyProvider');
+  }
+
+  return apiKey;
+};

--- a/src/context/ConnectionsContext.tsx
+++ b/src/context/ConnectionsContext.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   createContext,
   useContext, useEffect, useMemo, useState,
 } from 'react';
@@ -7,7 +7,7 @@ import { LoadingIcon } from '../assets/LoadingIcon';
 import { ErrorTextBox } from '../components/Configure/ErrorTextBox';
 import { api, Connection } from '../services/api';
 
-import { ApiKeyContext } from './ApiKeyContext';
+import { useApiKey } from './ApiKeyProvider';
 import {
   ErrorBoundary, useErrorState,
 } from './ErrorContextProvider';
@@ -46,10 +46,11 @@ export function ConnectionsProvider({
   projectId,
   children,
 }: ConnectionsProviderProps) {
+  const apiKey = useApiKey();
   const { groupRef, provider } = useInstallIntegrationProps();
+
   const [connections, setConnections] = useState<Connection[] | null>(null);
   const [selectedConnection, setSelectedConnection] = useState<Connection | null>(null);
-  const apiKey = useContext(ApiKeyContext);
   const [isLoading, setLoadingState] = useState<boolean>(true);
   const { setError, isError } = useErrorState();
 

--- a/src/context/InstallIntegrationContext.tsx
+++ b/src/context/InstallIntegrationContext.tsx
@@ -8,7 +8,7 @@ import { ErrorTextBox } from '../components/Configure/ErrorTextBox';
 import { api, Installation, Integration } from '../services/api';
 import { findIntegrationFromList } from '../utils';
 
-import { ApiKeyContext } from './ApiKeyContext';
+import { useApiKey } from './ApiKeyProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 import { useIntegrationList } from './IntegrationListContext';
 import { useProject } from './ProjectContext';
@@ -60,18 +60,20 @@ interface InstallIntegrationProviderProps {
 export function InstallIntegrationProvider({
   children, integration, consumerRef, consumerName, groupRef, groupName,
 }: InstallIntegrationProviderProps) {
+  const apiKey = useApiKey();
   const { projectId } = useProject();
-  const [installations, setInstallations] = useState<Installation[]>([]);
-  const installation = installations?.[0] || null; // there should only be one installation for mvp
-  const apiKey = useContext(ApiKeyContext);
   const { integrations } = useIntegrationList();
+
+  const [installations, setInstallations] = useState<Installation[]>([]);
+  const [isLoading, setLoadingState] = useState<boolean>(true);
+  const { setError, isError } = useErrorState();
+
+  const installation = installations?.[0] || null; // there should only be one installation for mvp
+
   const integrationObj = useMemo(
     () => findIntegrationFromList(integration, integrations || []),
     [integration, integrations],
   );
-
-  const [isLoading, setLoadingState] = useState<boolean>(true);
-  const { setError, isError } = useErrorState();
 
   useEffect(() => {
     if (integrationObj === null && integrations?.length) {

--- a/src/context/IntegrationListContext.tsx
+++ b/src/context/IntegrationListContext.tsx
@@ -7,7 +7,7 @@ import { LoadingIcon } from '../assets/LoadingIcon';
 import { ErrorTextBox } from '../components/Configure/ErrorTextBox';
 import { api, Integration } from '../services/api';
 
-import { ApiKeyContext } from './ApiKeyContext';
+import { useApiKey } from './ApiKeyProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 
 interface IntegrationListContextValue {
@@ -36,9 +36,9 @@ type IntegrationListContextProviderProps = {
 export function IntegrationListProvider(
   { projectId, children }: IntegrationListContextProviderProps,
 ) {
-  const [integrations, setIntegrations] = useState<Integration[] | null>(null);
-  const apiKey = useContext(ApiKeyContext);
+  const apiKey = useApiKey();
   const { setError, isError } = useErrorState();
+  const [integrations, setIntegrations] = useState<Integration[] | null>(null);
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {

--- a/src/context/ProjectContext.tsx
+++ b/src/context/ProjectContext.tsx
@@ -1,13 +1,12 @@
 import {
-  createContext,
-  useContext, useEffect, useMemo, useState,
+  createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
 import { LoadingIcon } from '../assets/LoadingIcon';
 import { ErrorTextBox } from '../components/Configure/ErrorTextBox';
 import { api, Project } from '../services/api';
 
-import { ApiKeyContext } from './ApiKeyContext';
+import { useApiKey } from './ApiKeyProvider';
 import {
   ErrorBoundary, useErrorState,
 } from './ErrorContextProvider';
@@ -42,10 +41,10 @@ type ProjectProviderProps = {
 export function ProjectProvider(
   { projectId, children }: ProjectProviderProps,
 ) {
-  const [project, setProject] = useState<Project | null>(null);
-  const apiKey = useContext(ApiKeyContext);
-  const [isLoading, setLoadingState] = useState<boolean>(true);
+  const apiKey = useApiKey();
   const { isError, setError } = useErrorState();
+  const [project, setProject] = useState<Project | null>(null);
+  const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {
     api().getProject({ projectId }, {

--- a/src/hooks/useIsIntegrationInstalled.ts
+++ b/src/hooks/useIsIntegrationInstalled.ts
@@ -1,10 +1,6 @@
-import {
-  useContext,
-  useEffect, useMemo,
-  useState,
-} from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { ApiKeyContext } from '../context/ApiKeyContext';
+import { useApiKey } from '../context/ApiKeyProvider';
 import { useIntegrationList } from '../context/IntegrationListContext';
 import { useProject } from '../context/ProjectContext';
 import { api, Installation, Integration } from '../services/api';
@@ -18,9 +14,10 @@ export const useIsIntegrationInstalled = (
   integration: string,
   groupRef: string,
 ): UseIsIntegrationInstalledResult => {
-  const apiKey = useContext(ApiKeyContext);
+  const apiKey = useApiKey();
   const { projectId } = useProject();
   const { integrations } = useIntegrationList();
+
   const [isLoaded, setIsLoaded] = useState(false);
   const [isIntegrationInstalled, setIsIntegrationInstalled] = useState<boolean | null>(null);
 


### PR DESCRIPTION
cleans some spacing and refactors useApiKey so we do not need to import useContext separately.


