### PR TITLE
refactor: separate required field mappings state

### DIFF
--- a/src/components/Configure/CreateInstallation.tsx
+++ b/src/components/Configure/CreateInstallation.tsx
@@ -19,6 +19,7 @@ import { useHydratedRevision } from './state/HydratedRevisionContext';
 import { getConfigureState, setHydrateConfigState } from './state/utils';
 import { ConfigureInstallationBase } from './ConfigureInstallationBase';
 import { useSelectedObjectName } from './ObjectManagementNav';
+import { validateFieldMappings } from './utils';
 
 // the config should be undefined for create flow
 const UNDEFINED_CONFIG = undefined;
@@ -66,20 +67,14 @@ export function CreateInstallation() {
 
   const onSave = (e: any) => {
     e.preventDefault();
-
-    const { requiredMapFields } = configureState;
-    const fieldsWithRequirementsNotMet = requiredMapFields?.filter(
-      (field) => !field.value,
-    ) || [];
-
-    const errList = fieldsWithRequirementsNotMet.map((field) => field.mapToName);
-    setErrors(ErrorBoundary.MAPPING, errList);
-
-    // if requires fields are not met, set error fields and return
-    if (fieldsWithRequirementsNotMet?.length) {
-      console.error('required fields not met', fieldsWithRequirementsNotMet.map((field) => field.mapToDisplayName));
-      return;
-    }
+    // check if fields with requirements are met
+    const { requiredMapFields, selectedFieldMappings } = configureState || {};
+    const { errorList } = validateFieldMappings(
+      requiredMapFields,
+      selectedFieldMappings,
+      setErrors,
+    );
+    if (errorList.length > 0) { return; } // skip if there are errors
 
     if (selectedObjectName && selectedConnection?.id && apiKey && projectId
       && integrationId && groupRef && consumerRef && hydratedRevision) {

--- a/src/components/Configure/UpdateInstallation.tsx
+++ b/src/components/Configure/UpdateInstallation.tsx
@@ -17,6 +17,7 @@ import { useHydratedRevision } from './state/HydratedRevisionContext';
 import { getConfigureState, setHydrateConfigState } from './state/utils';
 import { ConfigureInstallationBase } from './ConfigureInstallationBase';
 import { useSelectedObjectName } from './ObjectManagementNav';
+import { validateFieldMappings } from './utils';
 
 interface UpdateInstallationProps {
   installation: Installation,
@@ -76,18 +77,13 @@ export function UpdateInstallation(
     e.preventDefault();
 
     // check if fields with requirements are met
-    const { requiredMapFields } = configureState;
-    const fieldsWithRequirementsNotMet = requiredMapFields?.filter(
-      (field) => !field.value,
-    )
-      || [];
-
-    const errList = fieldsWithRequirementsNotMet.map((field) => field.mapToName);
-    setErrors(ErrorBoundary.MAPPING, errList);
-
-    // if requires fields are not met, set error fields and return
-    if (fieldsWithRequirementsNotMet?.length) {
-      console.error('required fields not met', fieldsWithRequirementsNotMet.map((field) => field.mapToDisplayName));
+    const { requiredMapFields, selectedFieldMappings } = configureState || {};
+    const { errorList } = validateFieldMappings(
+      requiredMapFields,
+      selectedFieldMappings,
+      setErrors,
+    );
+    if (errorList.length > 0) {
       return;
     }
 

--- a/src/components/Configure/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/fields/FieldMappings/FieldMapping.tsx
@@ -3,15 +3,15 @@ import {
   Select, Stack, Text,
 } from '@chakra-ui/react';
 
-import { HydratedIntegrationFieldExistent } from '../../../../services/api';
+import { HydratedIntegrationFieldExistent, IntegrationFieldMapping } from '../../../../services/api';
 import { useSelectedObjectName } from '../../ObjectManagementNav';
 import { useConfigureState } from '../../state/ConfigurationStateProvider';
-import { ConfigureStateMappingIntegrationField } from '../../types';
+import { getConfigureState } from '../../state/utils';
 
 import { setFieldMapping } from './setFieldMapping';
 
 interface FieldMappingProps {
-  field: ConfigureStateMappingIntegrationField,
+  field: IntegrationFieldMapping,
   onSelectChange: (
     e: React.ChangeEvent<HTMLSelectElement>
   ) => void,
@@ -22,19 +22,20 @@ export function FieldMapping(
   { field, onSelectChange, allFields }: FieldMappingProps,
 ) {
   const { selectedObjectName } = useSelectedObjectName();
-  const { setConfigureState } = useConfigureState();
+  const { objectConfigurationsState, setConfigureState } = useConfigureState();
   const [disabled, setDisabled] = useState(true);
+  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+  const { selectedFieldMappings: selectedRequiredMapFields } = configureState || {};
+  const fieldValue = selectedRequiredMapFields?.[field.mapToName];
 
   useEffect(() => {
-    // set default value if no value exists
     /* eslint no-underscore-dangle: ["error", { "allow": ["_default"] }] */
-    if (!!field._default && !field.value) {
-      if (selectedObjectName && !!field._default && !field.value) {
-        setFieldMapping(selectedObjectName, setConfigureState, field.mapToName, field._default);
-      }
+    if (!!field._default && !fieldValue && selectedObjectName && !!configureState) {
+      // set field mapping default value if no value exists
+      setFieldMapping(selectedObjectName, setConfigureState, field.mapToName, field._default);
     }
     setDisabled(false);
-  }, [field, setConfigureState, selectedObjectName]);
+  }, [field, setConfigureState, selectedObjectName, fieldValue, configureState]);
 
   const options = useMemo(() => allFields?.map(
     (f) => <option key={f.fieldName} value={f.fieldName}>{f.displayName}</option>,
@@ -47,9 +48,9 @@ export function FieldMapping(
       <Select
         name={field.mapToName}
         variant="flushed"
-        value={field.value}
+        value={fieldValue || undefined}
         onChange={onSelectChange}
-        placeholder={!field.value ? 'Please select one' : undefined} // remove placeholder when value is selected
+        placeholder={!fieldValue ? 'Please select one' : undefined} // remove placeholder when value is selected
         disabled={disabled}
       >
         {options}

--- a/src/components/Configure/fields/FieldMappings/setFieldMapping.ts
+++ b/src/components/Configure/fields/FieldMappings/setFieldMapping.ts
@@ -1,6 +1,6 @@
 import { Draft } from 'immer';
 
-import { checkFieldsEquality, createSavedFields } from '../../state/utils';
+import { checkFieldsEquality } from '../../state/utils';
 import { ConfigureState } from '../../types';
 
 function setFieldMappingProducer(
@@ -8,19 +8,14 @@ function setFieldMappingProducer(
   fieldKey: string,
   newValue: string,
 ) {
-  const draftRequiredMapFields = draft?.requiredMapFields || [];
-  const mapField = draftRequiredMapFields.find((field) => field?.mapToName === fieldKey);
-  if (mapField) {
-    mapField.value = newValue;
-    const savedFields = draft.savedConfig.requiredMapFields;
-    const updatedFields = createSavedFields(draftRequiredMapFields);
-    const isModified = !checkFieldsEquality(savedFields, updatedFields);
-    // immer exception if we try to set a value
-    // eslint-disable-next-line no-param-reassign
-    draft.isRequiredMapFieldsModified = isModified;
-  } else {
-    console.warn(`Could not find field with key ${fieldKey}`);
-  }
+  const draftRequiredMapFields = draft?.selectedFieldMappings || {};
+  draftRequiredMapFields[fieldKey] = newValue;
+  const savedFields = draft.savedConfig.requiredMapFields;
+  const updatedFields = draftRequiredMapFields;
+  const isModified = !checkFieldsEquality(savedFields, updatedFields);
+  // immer exception if we try to set a value
+  // eslint-disable-next-line no-param-reassign
+  draft.isRequiredMapFieldsModified = isModified;
 }
 
 export function setFieldMapping(

--- a/src/components/Configure/fields/OptionalFields/setOptionalField.ts
+++ b/src/components/Configure/fields/OptionalFields/setOptionalField.ts
@@ -10,6 +10,9 @@ function setOptionalFieldProducer(
 ) {
   const draftSelectedOptionalFields = draft?.selectedOptionalFields || {};
   draftSelectedOptionalFields[fieldKey] = checked;
+  if (!checked) {
+    delete draftSelectedOptionalFields[fieldKey];
+  }
   const savedFields = draft.savedConfig.optionalFields;
   const updatedFields = draftSelectedOptionalFields;
   const isModified = !checkFieldsEquality(savedFields, updatedFields);

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -4,31 +4,26 @@ import {
   IntegrationFieldMapping,
 } from '../../services/api';
 
-export type ConfigureStateIntegrationField = HydratedIntegrationFieldExistent & {
-  value: string | number | boolean | null,
-};
-
-export type ConfigureStateMappingIntegrationField = IntegrationFieldMapping & {
-  value: string | number | undefined,
-};
-
 export type SelectOptionalFields = {
   [key: string]: boolean,
 };
 
-export type SavedConfigureFields = Record<string, string | number | boolean | null>;
+export type SelectMappingFields = {
+  [key: string]: string | undefined,
+};
 
 type SavedConfigureState = {
   optionalFields: SelectOptionalFields,
-  requiredMapFields: SavedConfigureFields,
+  requiredMapFields: SelectMappingFields,
 };
 
 export type ConfigureState = {
   allFields: HydratedIntegrationFieldExistent[] | null, // needed for custom mapping
   requiredFields: HydratedIntegrationField[] | null,
   optionalFields: HydratedIntegrationField[] | null,
-  requiredMapFields: ConfigureStateMappingIntegrationField[] | null,
+  requiredMapFields: IntegrationFieldMapping[] | null,
   selectedOptionalFields: SelectOptionalFields | null,
+  selectedFieldMappings: SelectMappingFields | null,
   isOptionalFieldsModified: boolean, // checks if selected optional fields is modified
   isRequiredMapFieldsModified: boolean, // checks if required map fields is modified
   savedConfig: SavedConfigureState, // check when to know if config is saved / modified

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -1,4 +1,7 @@
 import {
+  ErrorBoundary,
+} from '../../context/ErrorContextProvider';
+import {
   Config,
   HydratedIntegrationField,
   HydratedIntegrationObject,
@@ -9,6 +12,7 @@ import {
 
 import {
   NavObject,
+  SelectMappingFields,
 } from './types';
 
 /**
@@ -44,10 +48,11 @@ export function getRequiredFieldsFromObject(object: HydratedIntegrationObject)
 
 // 2b. get required custom mapping fields
 export function getRequiredMapFieldsFromObject(object: HydratedIntegrationObject)
-  : HydratedIntegrationField[] | null {
-  return object?.requiredFields?.filter(
+  : IntegrationFieldMapping[] | null {
+  const requiredMapFields = object?.requiredFields?.filter(
     (rf: HydratedIntegrationField) => isIntegrationFieldMapping(rf) && !!rf.mapToName,
-  ) || null;
+  ) || [];
+  return requiredMapFields as IntegrationFieldMapping[]; // type hack
 }
 
 // 3. get optional fields
@@ -67,13 +72,6 @@ export const getReadObject = (
 export function getValueFromConfigExist(config: Config, objectName: string, key: string): boolean {
   const object = getReadObject(config, objectName);
   return object?.selectedFields?.[key] || false;
-}
-
-// 4b. get value for custom mapping field
-export function getValueFromConfigCustomMapping(config: Config, objectName: string, key: string)
-  : string {
-  const object = getReadObject(config, objectName);
-  return object?.selectedFieldMappings?.[key] || '';
 }
 
 // aux. get field value based on type guard
@@ -99,4 +97,25 @@ export function generateNavObjects(config: Config | undefined, hydratedRevision:
   });
 
   return navObjects;
+}
+
+// validates whether required fields are filled out or throws error
+export function validateFieldMappings(
+  requiredMapFields: IntegrationFieldMapping[] | null,
+  selectedRequiredMapFields: SelectMappingFields | null,
+  setErrors: (boundary: ErrorBoundary, errors: string[]) => void,
+) {
+  // check if fields with requirements are met
+  const fieldsWithRequirementsNotMet = requiredMapFields?.filter(
+    (field) => !selectedRequiredMapFields?.[field?.mapToName],
+  ) || [];
+
+  const errorList = fieldsWithRequirementsNotMet.map((field) => field.mapToName);
+  setErrors(ErrorBoundary.MAPPING, errorList);
+
+  // if requires fields are not met, set error fields and return
+  if (fieldsWithRequirementsNotMet?.length) {
+    console.error('required fields not met', fieldsWithRequirementsNotMet.map((field) => field.mapToDisplayName));
+  }
+  return { errorList };
 }


### PR DESCRIPTION
note: switch to main branch after `dl-refactor-configuration-state-2` is merged.

### refactors requiredMapFields
- separated hydrated revision `requiredMapFields` & config `selectedFieldMappings`
- fixes checked bug when item is not checked.

We adopt the state management that we're using in `optionalFields` where the hydrated revision is used to populate the fields, but the config state is check for the corresponding values. This removes the transformation step needed to combine the hydrated revision and config and transform back in the old model and make equality checks easier.

This PR also separates the fields storing just hydratedRevision values so we can freeze them in a higher level provider.
```
  // refactor this section to be immutable at hydrated revision level
  const object = getStandardObjectFromAction(action, objectName);
  const requiredFields = object && getRequiredFieldsFromObject(object);
  const optionalFields = object && getOptionalFieldsFromObject(object);
  const requiredMapFields = object && getRequiredMapFieldsFromObject(object);
```


