### PR TITLE
fix: fix feature flag write / uninstall case

### DIFF
--- a/src/components/Configure/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/ObjectManagementNav/index.tsx
@@ -41,14 +41,14 @@ function getSelectedObject(navObjects: NavObject[], tabIndex: number): NavObject
   if (navObjects?.[tabIndex]) {
     // read tabs
     return navObjects[tabIndex];
-  } if (tabIndex === navObjects.length) {
+  } if (WRITE_FEATURE_FLAG && tabIndex === navObjects.length) {
     // other - non configurable write tab
     return { name: OTHER_CONST, completed: false };
   }
-  if (tabIndex > navObjects.length - 1) {
-    // uninstall tab
-    return { name: UNINSTALL_INSTALLATION_CONST, completed: false };
-  }
+
+  // uninstall tab
+  return { name: UNINSTALL_INSTALLATION_CONST, completed: false };
+
   return undefined;
 }
 


### PR DESCRIPTION
### Summary
The uninstall button shows the wrong content because the feature flag doesn't add the correct length of buttons. This fixes the logic to allow feature flag logic.

#### expected
<img width="896" alt="Screenshot 2024-01-17 at 3 08 03 PM" src="https://github.com/amp-labs/react/assets/5396828/e56e7c8f-458a-4e46-93eb-dac447b13971">
