### PR TITLE
[ENG-512] feat: connect write form to state

### DIFF
--- a/src/components/Configure/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/ObjectManagementNav/index.tsx
@@ -17,7 +17,7 @@ import { NavObjectItem } from './NavObjectItem';
 import { OTHER_CONST, OtherTab } from './OtherTab';
 import { UNINSTALL_INSTALLATION_CONST, UninstallInstallation } from './UninstallInstallation';
 
-const WRITE_FEATURE_FLAG = false; // hide write tab
+const WRITE_FEATURE_FLAG = true; // hide write tab
 
 // Create a context for the selected navObject's name
 const SelectedObjectNameContext = createContext<string | null | undefined>(null);

--- a/src/components/Configure/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/ObjectManagementNav/index.tsx
@@ -17,7 +17,7 @@ import { NavObjectItem } from './NavObjectItem';
 import { OTHER_CONST, OtherTab } from './OtherTab';
 import { UNINSTALL_INSTALLATION_CONST, UninstallInstallation } from './UninstallInstallation';
 
-const WRITE_FEATURE_FLAG = true; // hide write tab
+const WRITE_FEATURE_FLAG = false; // hide write tab
 
 // Create a context for the selected navObject's name
 const SelectedObjectNameContext = createContext<string | null | undefined>(null);

--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -4,9 +4,7 @@ import {
 } from '@chakra-ui/react';
 
 import { HydratedIntegrationFieldExistent, IntegrationFieldMapping } from '../../../../../services/api';
-import { useSelectedObjectName } from '../../../ObjectManagementNav';
-import { useConfigureState } from '../../../state/ConfigurationStateProvider';
-import { getConfigureState } from '../../../state/utils';
+import { useFields } from '../useFields';
 
 import { setFieldMapping } from './setFieldMapping';
 
@@ -21,10 +19,9 @@ interface FieldMappingProps {
 export function FieldMapping(
   { field, onSelectChange, allFields }: FieldMappingProps,
 ) {
-  const { selectedObjectName } = useSelectedObjectName();
-  const { objectConfigurationsState, setConfigureState } = useConfigureState();
+  const { configureState, selectedObjectName, setConfigureState } = useFields();
   const [disabled, setDisabled] = useState(true);
-  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+
   const selectedRequiredMapFields = configureState?.read?.selectedFieldMappings;
   const fieldValue = selectedRequiredMapFields?.[field.mapToName];
 

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -1,27 +1,20 @@
 import { useMemo } from 'react';
 import {
-  Box, FormControl,
-  FormErrorMessage, Stack,
+  Box, FormControl, FormErrorMessage, Stack,
 } from '@chakra-ui/react';
 
 import {
   ErrorBoundary, useErrorState,
 } from '../../../../../context/ErrorContextProvider';
-import { useSelectedObjectName } from '../../../ObjectManagementNav';
-import { useConfigureState } from '../../../state/ConfigurationStateProvider';
-import {
-  getConfigureState,
-} from '../../../state/utils';
 import { isIntegrationFieldMapping } from '../../../utils';
 import { FieldHeader } from '../FieldHeader';
+import { useFields } from '../useFields';
 
 import { FieldMapping } from './FieldMapping';
 import { setFieldMapping } from './setFieldMapping';
 
 export function RequiredFieldMappings() {
-  const { selectedObjectName } = useSelectedObjectName();
-  const { objectConfigurationsState, setConfigureState } = useConfigureState();
-  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+  const { selectedObjectName, configureState, setConfigureState } = useFields();
   const { isError, removeError } = useErrorState();
 
   const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/components/Configure/content/fields/OptionalFields/OptionalFields.tsx
+++ b/src/components/Configure/content/fields/OptionalFields/OptionalFields.tsx
@@ -1,19 +1,15 @@
 import { Box, Checkbox, Stack } from '@chakra-ui/react';
 
-import { useProject } from '../../../../../context/ProjectContext';
-import { useSelectedObjectName } from '../../../ObjectManagementNav';
-import { useConfigureState } from '../../../state/ConfigurationStateProvider';
-import { getConfigureState } from '../../../state/utils';
 import { isIntegrationFieldMapping } from '../../../utils';
 import { FieldHeader } from '../FieldHeader';
+import { useFields } from '../useFields';
 
 import { setOptionalField } from './setOptionalField';
 
 export function OptionalFields() {
-  const { appName } = useProject();
-  const { objectConfigurationsState, setConfigureState } = useConfigureState();
-  const { selectedObjectName } = useSelectedObjectName();
-  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+  const {
+    appName, configureState, setConfigureState, selectedObjectName,
+  } = useFields();
   const selectedOptionalFields = configureState?.read?.selectedOptionalFields;
 
   const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
@@ -3,29 +3,22 @@ import { Box, Checkbox, Stack } from '@chakra-ui/react';
 import { FieldHeader } from '../FieldHeader';
 import { useFields } from '../useFields';
 
-// TODO - remove and fetch data from configuration state populated from hydrated revison
-const WRITE_DUMMY_DATA = {
-  objects: [
-    {
-      objectName: 'account',
-      displayName: 'Account',
-    },
-    {
-      objectName: 'contact',
-      displayName: 'Contact',
-    },
-  ],
-};
+import { setNonConfigurableWriteField } from './setNonConfigurableWriteField';
 
 export function WriteFields() {
-  const { appName, configureState, setConfigureState } = useFields();
+  const {
+    appName, selectedObjectName, configureState, setConfigureState,
+  } = useFields();
+  const selectedWriteFields = configureState?.write?.selectedNonConfigurableWriteFields;
 
   const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;
-    console.warn('Checking Write Fields', { name, checked });
+    if (selectedObjectName && configureState) {
+      setNonConfigurableWriteField(selectedObjectName, setConfigureState, name, checked);
+    }
   };
 
-  const shouldRender = !!(WRITE_DUMMY_DATA);
+  const shouldRender = !!(configureState?.write?.writeObjects);
   return (
     shouldRender && (
       <>
@@ -38,12 +31,13 @@ export function WriteFields() {
           borderRadius={8}
           padding={4}
         >
-          {WRITE_DUMMY_DATA?.objects?.map((field) => (
+          {configureState?.write?.writeObjects?.map((field) => (
             <Box key={field.objectName} display="flex" gap="5px" borderBottom="1px" borderColor="gray.100">
               <Checkbox
                 name={field.objectName}
                 id={field.objectName}
                 onChange={onCheckboxChange}
+                isChecked={!!selectedWriteFields?.[field.objectName]}
               >
                 {field.displayName}
               </Checkbox>

--- a/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
@@ -1,7 +1,7 @@
 import { Box, Checkbox, Stack } from '@chakra-ui/react';
 
-import { useProject } from '../../../../../context/ProjectContext';
 import { FieldHeader } from '../FieldHeader';
+import { useFields } from '../useFields';
 
 // TODO - remove and fetch data from configuration state populated from hydrated revison
 const WRITE_DUMMY_DATA = {
@@ -18,7 +18,7 @@ const WRITE_DUMMY_DATA = {
 };
 
 export function WriteFields() {
-  const { appName } = useProject();
+  const { appName, configureState, setConfigureState } = useFields();
 
   const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;

--- a/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
+++ b/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
@@ -1,0 +1,39 @@
+import { Draft } from 'immer';
+
+import { ConfigureState } from '../../../types';
+
+function setNonConfigurableWriteFieldProducer(
+  draft: Draft<ConfigureState>,
+  fieldKey: string,
+  checked: boolean,
+) {
+  if (draft?.write?.selectedNonConfigurableWriteFields === null) {
+    // immer syntax to set a value
+    // eslint-disable-next-line no-param-reassign
+    draft.write.selectedNonConfigurableWriteFields = {};
+  }
+
+  if (draft?.write) {
+    const draftSelectedWriteFields = draft.write.selectedNonConfigurableWriteFields;
+    draftSelectedWriteFields[fieldKey] = checked;
+
+    if (!checked) {
+      delete draftSelectedWriteFields[fieldKey];
+    }
+
+    // TODO: add isModified check
+  }
+}
+
+export function setNonConfigurableWriteField(
+  selectedObjectName: string,
+  setConfigureState: (objectName: string,
+    producer: (draft: Draft<ConfigureState>) => void) => void,
+  fieldKey: string,
+  checked: boolean,
+) {
+  setConfigureState(
+    selectedObjectName,
+    (draft) => { setNonConfigurableWriteFieldProducer(draft, fieldKey, checked); },
+  );
+}

--- a/src/components/Configure/content/fields/useFields.tsx
+++ b/src/components/Configure/content/fields/useFields.tsx
@@ -1,0 +1,18 @@
+import { useProject } from '../../../../context/ProjectContext';
+import { useSelectedObjectName } from '../../ObjectManagementNav';
+import { useConfigureState } from '../../state/ConfigurationStateProvider';
+import { getConfigureState } from '../../state/utils';
+
+export const useFields = () => {
+  const { appName } = useProject();
+  const { objectConfigurationsState, setConfigureState } = useConfigureState();
+  const { selectedObjectName } = useSelectedObjectName();
+  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+
+  return {
+    appName,
+    configureState,
+    setConfigureState,
+    selectedObjectName,
+  };
+};

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -11,7 +11,7 @@ type SelectedNonConfigurableWriteFields = {
 
 // write state slice
 export type ConfigureStateWrite = {
-  writeObjects: Array<HydratedIntegrationWriteObject> | null,
+  writeObjects: HydratedIntegrationWriteObject[] | null,
   selectedNonConfigurableWriteFields: SelectedNonConfigurableWriteFields | null,
 };
 


### PR DESCRIPTION
### Summary
- removes dummy data
- connects write form state to context
- refactors field state to use a `useField` hook. 

#### demo with hydratedRevision data
![write-field-state](https://github.com/amp-labs/react/assets/5396828/2ccc8685-e1a5-4bd7-970f-1ce1c824ac40)

#### steps
1. ~UI write tab + form~
2. ~refactor read state~
3. ~add write state to context~
4. **connect data to write state slice** (in progress)
4a. **connect hydratedRevision data**
4b. connect config data
5. submit write state slice
6. add isModified / in progress state

