### PR TITLE
refactor: onSaveRead for create and update installation pages

### DIFF
--- a/src/components/Configure/actions/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/onSaveReadCreateInstallation.ts
@@ -39,7 +39,7 @@ const getObjectFromHydratedRevision = (
  * @param consumerRef
  * @returns
  */
-const generateCreateConfigFromConfigureState = (
+const generateCreateReadConfigFromConfigureState = (
   configureState: ConfigureState,
   objectName: string,
   hydratedRevision: HydratedRevision,
@@ -79,7 +79,7 @@ const generateCreateConfigFromConfigureState = (
   return createConfigObj;
 };
 
-export const onSaveCreate = (
+export const onSaveReadCreateInstallation = (
   projectId: string,
   integrationId: string,
   groupRef: string,
@@ -90,8 +90,8 @@ export const onSaveCreate = (
   hydratedRevision: HydratedRevision,
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
-): Promise<any> => {
-  const createConfig = generateCreateConfigFromConfigureState(
+): Promise<void | null> => {
+  const createConfig = generateCreateReadConfigFromConfigureState(
     configureState,
     objectName,
     hydratedRevision,

--- a/src/components/Configure/actions/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/onSaveReadUpdateInstallation.ts
@@ -27,7 +27,7 @@ import { ConfigureState } from '../types';
  * @param schedule
  * @returns
  */
-const generateUpdateConfigFromConfigureState = (
+const generateUpdateReadConfigFromConfigureState = (
   configureState: ConfigureState,
   objectName: string,
   hydratedObject: HydratedIntegrationObject,
@@ -59,7 +59,7 @@ const generateUpdateConfigFromConfigureState = (
   return updateConfigObject;
 };
 
-export const onSaveUpdate = (
+export const onSaveReadUpdateInstallation = (
   projectId: string,
   integrationId: string,
   installationId: string,
@@ -68,15 +68,20 @@ export const onSaveUpdate = (
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
   hydratedObject: HydratedIntegrationObject,
-): Promise<any> => {
+): Promise<void | null> => {
   // get configuration state
   // transform configuration state to update shape
-  const updateConfig = generateUpdateConfigFromConfigureState(
+  const updateConfig = generateUpdateReadConfigFromConfigureState(
     configureState,
     selectedObjectName || '',
     hydratedObject,
     hydratedObject.schedule,
   );
+
+  if (!updateConfig) {
+    console.error('Error when generating updateConfig from configureState');
+    return Promise.resolve(null);
+  }
 
   const updateInstallationRequest: UpdateInstallationOperationRequest = {
     projectId,

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -32,8 +32,9 @@ export function ConfigureInstallationBase(
   const { configureState, selectedObjectName } = useSelectedConfigureState();
 
   // has the form been modified?
-  const isModified = configureState?.read?.isOptionalFieldsModified
-    || configureState?.read?.isRequiredMapFieldsModified;
+  const isReadModified = configureState?.read?.isOptionalFieldsModified
+  || configureState?.read?.isRequiredMapFieldsModified;
+  const isModified = isReadModified || configureState?.write?.isWriteModified;
 
   // is this a new state (modified or creating a new state)
   const isStateNew = isModified || isCreateMode;

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -8,7 +8,9 @@ import {
 import {
   ErrorBoundary,
 } from '../../../context/ErrorContextProvider';
-import { onSaveCreate } from '../actions/onSaveCreate';
+import { onSaveReadCreateInstallation } from '../actions/onSaveReadCreateInstallation';
+// import { onSaveWriteCreateInstallation } from '../actions/onSaveWriteCreateInstallation';
+import { OTHER_CONST } from '../ObjectManagementNav/OtherTab';
 import { setHydrateConfigState } from '../state/utils';
 import { validateFieldMappings } from '../utils';
 
@@ -27,6 +29,9 @@ export function CreateInstallation() {
     resetConfigureState, objectConfigurationsState, resetPendingConfigurationState, configureState,
   } = useMutateInstallation();
   const [isLoading, setLoadingState] = useState<boolean>(false);
+
+  // is other selected?
+  const isOtherSelected = selectedObjectName === OTHER_CONST;
 
   const resetState = useCallback(
     () => {
@@ -50,8 +55,7 @@ export function CreateInstallation() {
     }
   }, [configureState, objectConfigurationsState, hydratedRevision, loading, resetState]);
 
-  const onSave = (e: any) => {
-    e.preventDefault();
+  const onSaveRead = () => {
     // check if fields with requirements are met
     const { requiredMapFields, selectedFieldMappings } = configureState?.read || {};
     const { errorList } = validateFieldMappings(
@@ -62,9 +66,9 @@ export function CreateInstallation() {
     if (errorList.length > 0) { return; } // skip if there are errors
 
     if (selectedObjectName && selectedConnection?.id && apiKey && projectId
-      && integrationId && groupRef && consumerRef && hydratedRevision) {
+       && integrationId && groupRef && consumerRef && hydratedRevision) {
       setLoadingState(true);
-      const res = onSaveCreate(
+      const res = onSaveReadCreateInstallation(
         projectId,
         integrationId,
         groupRef,
@@ -82,7 +86,45 @@ export function CreateInstallation() {
         resetPendingConfigurationState(selectedObjectName);
       });
     } else {
-      console.error('OnSaveCreate: missing required props');
+      console.error('CreateInstallallation - onSaveReadCreate: missing required props');
+    }
+  };
+
+  const onSaveWrite = () => {
+  // TODO: followup
+
+    // check if fields with requirements are met
+    // if (selectedObjectName && selectedConnection?.id && apiKey && projectId
+    //   && integrationId && groupRef && consumerRef && hydratedRevision) {
+    //   setLoadingState(true);
+    //   const res = onSaveWriteCreateInstallation(
+    //     projectId,
+    //     integrationId,
+    //     groupRef,
+    //     consumerRef,
+    //     selectedConnection.id,
+    //     apiKey,
+    //     hydratedRevision,
+    //     configureState,
+    //     setInstallation,
+    //   );
+
+    //   res.finally(() => {
+    //     setLoadingState(false);
+    //     resetPendingConfigurationState(selectedObjectName);
+    // reset write pending/isModified state
+    //   });
+    // } else {
+    //   console.error('CreateInstallallation - onSaveWriteCreate: missing required props');
+    // }
+  };
+
+  const onSave = (e: any) => {
+    e.preventDefault();
+    if (!isOtherSelected) {
+      onSaveRead();
+    } else {
+      onSaveWrite();
     }
   };
 

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -6,7 +6,8 @@ import {
   ErrorBoundary,
 } from '../../../context/ErrorContextProvider';
 import { Installation, Integration } from '../../../services/api';
-import { onSaveUpdate } from '../actions/onSaveUpdate';
+import { onSaveReadUpdateInstallation } from '../actions/onSaveReadUpdateInstallation';
+import { OTHER_CONST } from '../ObjectManagementNav/OtherTab';
 import { setHydrateConfigState } from '../state/utils';
 import { validateFieldMappings } from '../utils';
 
@@ -30,6 +31,8 @@ export function UpdateInstallation(
   } = useMutateInstallation();
 
   const [isLoading, setLoadingState] = useState<boolean>(false);
+  // is other selected?
+  const isOtherSelected = selectedObjectName === OTHER_CONST;
 
   // when no installation or config exists, render create flow
   const { config } = installation;
@@ -61,9 +64,7 @@ export function UpdateInstallation(
     return hydrated;
   }, [hydratedRevision, selectedObjectName]);
 
-  const onSave = (e: any) => {
-    e.preventDefault();
-
+  const onSaveRead = () => {
     // check if fields with requirements are met
     const { requiredMapFields, selectedFieldMappings } = configureState?.read || {};
     const { errorList } = validateFieldMappings(
@@ -81,7 +82,7 @@ export function UpdateInstallation(
       && projectId
       && hydratedObject) {
       setLoadingState(true);
-      const res = onSaveUpdate(
+      const res = onSaveReadUpdateInstallation(
         projectId,
         integrationObj.id,
         installation.id,
@@ -97,7 +98,22 @@ export function UpdateInstallation(
         resetPendingConfigurationState(selectedObjectName);
       });
     } else {
-      console.error('update installation props missing');
+      console.error('UpdateInstallation - onSaveUpdate missing required props');
+    }
+  };
+
+  const onSaveWrite = () => {
+    // TODO - followup
+    console.warn('onSaveWrite Update');
+  };
+
+  const onSave = (e: any) => {
+    e.preventDefault();
+
+    if (!isOtherSelected) {
+      onSaveRead();
+    } else {
+      onSaveWrite();
     }
   };
 


### PR DESCRIPTION
### Summary
prepares for new feature of adding onSaveWrite by separating onSaveRead, this PR is separated to make it easier to review file name changes.

- feat: add write on save placeholders
- refactor: rename onSaveCreate to onSaveReadCreate and onSaveUpdate to onSaveReadUpdate
- fix some action types



