### PR TITLE
feat: adds onSaveWriteCreateInstallation action

### DIFF
--- a/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
@@ -45,15 +45,16 @@ type WriteObjects = {
  * @returns
  */
 const generateConfigWriteObjects = (configureState: ConfigureState) => {
-  const configWriteObjects: WriteObjects = {}; // any is listed type in generated spec
+  const configWriteObjects: WriteObjects = {}; // `any` is listed type in generated SDK
   const configStateWriteObjects = configureState.write?.writeObjects;
   if (configStateWriteObjects) {
     configStateWriteObjects.forEach((configStateWriteObject) => {
+      const obj = configStateWriteObject.objectName;
       // object exists in config form
-      if (configStateWriteObject.objectName) {
+      if (obj) {
         // insert objectName into configWriteObjects
-        configWriteObjects[configStateWriteObject.objectName] = {
-          objectName: configStateWriteObject.objectName,
+        configWriteObjects[obj] = {
+          objectName: obj,
         };
       }
     });

--- a/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
@@ -1,0 +1,150 @@
+import {
+  api, CreateInstallationOperationRequest,
+  CreateInstallationRequestConfig,
+  HydratedRevision,
+  Installation,
+} from '../../../services/api';
+import { ConfigureState } from '../types';
+
+/**
+   * gets write objects from hydratedRevision
+   * @param hydratedRevision
+   * @param objectName
+   * @returns
+   */
+const getWriteObjectsFromHydratedRevision = (
+  hydratedRevision: HydratedRevision,
+) => {
+  const writeAction = hydratedRevision.content.write;
+  return writeAction?.objects;
+};
+
+type WriteObject = {
+  objectName: string;
+};
+
+type WriteObjects = {
+  [objectName: string]: WriteObject;
+};
+
+/**
+ * example type
+ * "objects":
+ *  {
+    objects: {
+      account: {
+        objectName: 'account',
+      },
+      contact: {
+        objectName: 'contact',
+      },
+    },
+  }
+ * @param writeObjects
+ * @param configureState
+ * @returns
+ */
+const generateConfigWriteObjects = (configureState: ConfigureState) => {
+  const configWriteObjects: WriteObjects = {}; // any is listed type in generated spec
+  const configStateWriteObjects = configureState.write?.writeObjects;
+  if (configStateWriteObjects) {
+    configStateWriteObjects.forEach((configStateWriteObject) => {
+      // object exists in config form
+      if (configStateWriteObject.objectName) {
+        // insert objectName into configWriteObjects
+        configWriteObjects[configStateWriteObject.objectName] = {
+          objectName: configStateWriteObject.objectName,
+        };
+      }
+    });
+  }
+  return configWriteObjects;
+};
+
+/**
+   * given a configureState, objectName, hyrdatedRevision, and consumerRef
+   * generate the config object that is need for update installation request.
+   *
+   * 1. get required fields from configureState
+   * 2. get optional fields from configureState
+   * 3. merge required fields and optional fields into selectedFields
+   * 4. get required custom map fields from configureState
+   * 5. generate create config object
+   * @param configureState
+   * @param objectName
+   * @param hydratedRevision
+   * @param consumerRef
+   * @returns
+   */
+const generateCreateWriteConfigFromConfigureState = (
+  configureState: ConfigureState,
+  hydratedRevision: HydratedRevision,
+  consumerRef: string,
+): (CreateInstallationRequestConfig | null) => {
+  const writeObjects = getWriteObjectsFromHydratedRevision(hydratedRevision);
+  if (!writeObjects) {
+    console.error('Error when getting write objects from hydratedRevision');
+    return null;
+  }
+
+  const configWriteObjects = generateConfigWriteObjects(configureState);
+
+  // create config request object
+  const createConfigObj: CreateInstallationRequestConfig = {
+    revisionId: hydratedRevision.id,
+    createdBy: `consumer:${consumerRef}`,
+    content: {
+      provider: hydratedRevision.content.provider,
+      write: {
+        objects: configWriteObjects,
+      },
+    },
+  };
+
+  return createConfigObj;
+};
+
+export const onSaveWriteCreateInstallation = (
+  projectId: string,
+  integrationId: string,
+  groupRef: string,
+  consumerRef: string,
+  connectionId: string,
+  apiKey: string,
+  hydratedRevision: HydratedRevision,
+  configureState: ConfigureState,
+  setInstallation: (installationObj: Installation) => void,
+): Promise<void | null> => {
+  const createConfig = generateCreateWriteConfigFromConfigureState(
+    configureState,
+    hydratedRevision,
+    consumerRef,
+  );
+  if (!createConfig) {
+    console.error('Error when generating createConfig from configureState');
+    return Promise.resolve(null);
+  }
+  const createInstallationRequest: CreateInstallationOperationRequest = {
+    projectId,
+    integrationId,
+    installation: {
+      groupRef,
+      connectionId,
+      config: createConfig,
+    },
+  };
+
+  return api().installationApi.createInstallation(createInstallationRequest, {
+    headers: {
+      'X-Api-Key': apiKey,
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((installation) => {
+      // update local installation state
+      setInstallation(installation);
+    })
+    .catch((err) => {
+      console.error('ERROR: ', err);
+    });
+};

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -9,7 +9,7 @@ import {
   ErrorBoundary,
 } from '../../../context/ErrorContextProvider';
 import { onSaveReadCreateInstallation } from '../actions/onSaveReadCreateInstallation';
-// import { onSaveWriteCreateInstallation } from '../actions/onSaveWriteCreateInstallation';
+import { onSaveWriteCreateInstallation } from '../actions/onSaveWriteCreateInstallation';
 import { OTHER_CONST } from '../ObjectManagementNav/OtherTab';
 import { setHydrateConfigState } from '../state/utils';
 import { validateFieldMappings } from '../utils';
@@ -91,32 +91,29 @@ export function CreateInstallation() {
   };
 
   const onSaveWrite = () => {
-  // TODO: followup
-
     // check if fields with requirements are met
-    // if (selectedObjectName && selectedConnection?.id && apiKey && projectId
-    //   && integrationId && groupRef && consumerRef && hydratedRevision) {
-    //   setLoadingState(true);
-    //   const res = onSaveWriteCreateInstallation(
-    //     projectId,
-    //     integrationId,
-    //     groupRef,
-    //     consumerRef,
-    //     selectedConnection.id,
-    //     apiKey,
-    //     hydratedRevision,
-    //     configureState,
-    //     setInstallation,
-    //   );
+    if (selectedObjectName && selectedConnection?.id && apiKey && projectId
+      && integrationId && groupRef && consumerRef && hydratedRevision) {
+      setLoadingState(true);
+      const res = onSaveWriteCreateInstallation(
+        projectId,
+        integrationId,
+        groupRef,
+        consumerRef,
+        selectedConnection.id,
+        apiKey,
+        hydratedRevision,
+        configureState,
+        setInstallation,
+      );
 
-    //   res.finally(() => {
-    //     setLoadingState(false);
-    //     resetPendingConfigurationState(selectedObjectName);
-    // reset write pending/isModified state
-    //   });
-    // } else {
-    //   console.error('CreateInstallallation - onSaveWriteCreate: missing required props');
-    // }
+      res.finally(() => {
+        setLoadingState(false);
+        resetPendingConfigurationState(selectedObjectName);// reset write pending/isModified state
+      });
+    } else {
+      console.error('CreateInstallallation - onSaveWriteCreate: missing required props');
+    }
   };
 
   const onSave = (e: any) => {


### PR DESCRIPTION
### allows other tab to create installation
- submits create installation 
- adds reset pending setter for write state

note: does not support update, pending, or completed interactions well after submit state yet.

#### demo
![create-installation-write](https://github.com/amp-labs/react/assets/5396828/fb6f1ec5-ba53-4c8a-bbc3-7268c0790961)


#### steps
1. ~UI write tab + form~
2. ~refactor read state~
3. ~add write state to context~
4. ~connect data to write state slice~ 
4a. ~connect hydratedRevision data~
4b. connect config data
5. **submit write state slice**
5a. **submit create write installation**
5b. submit update write installation
6. ~add isModified / in progress state~
6b. complete, progress, empty state post submit.

