### PR TITLE
fix: pending state reset needs objectname

### DIFF
--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -103,10 +103,10 @@ export function ConfigurationProvider(
     );
   }, [setObjectConfigurationsState]);
 
-  const resetReadPendingConfigurationState = useCallback(() => {
+  const resetReadPendingConfigurationState = useCallback((objectName: string) => {
     setObjectConfigurationsState(
       produce((draft) => {
-        const readDraft = draft.other.read;
+        const readDraft = draft[objectName]?.read;
         if (readDraft) {
           readDraft.isOptionalFieldsModified = false;
           readDraft.isRequiredMapFieldsModified = false;
@@ -124,7 +124,7 @@ export function ConfigurationProvider(
       resetWritePendingConfigurationState();
     } else {
       // read case
-      resetReadPendingConfigurationState();
+      resetReadPendingConfigurationState(objectName);
     }
   }, [resetReadPendingConfigurationState, resetWritePendingConfigurationState]);
 


### PR DESCRIPTION
### fix
read state needs the objectname to change the form per object. 

`draft.other.read` does not exists.