### PR TITLE
[ENG-512]feat: adds config pre-fill support

### DIFF
--- a/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
@@ -96,6 +96,10 @@ const generateCreateWriteConfigFromConfigureState = (
     createdBy: `consumer:${consumerRef}`,
     content: {
       provider: hydratedRevision.content.provider,
+      // need empty read.standarObjects for update read
+      read: {
+        standardObjects: {},
+      },
       write: {
         objects: configWriteObjects,
       },

--- a/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/onSaveWriteCreateInstallation.ts
@@ -96,7 +96,7 @@ const generateCreateWriteConfigFromConfigureState = (
     createdBy: `consumer:${consumerRef}`,
     content: {
       provider: hydratedRevision.content.provider,
-      // need empty read.standarObjects for update read
+      // need empty read.standardObjects for update read
       read: {
         standardObjects: {},
       },

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -12,6 +12,7 @@ import {
   ConfigureStateRead,
   ConfigureStateWrite,
   ObjectConfigurationsState,
+  SelectedNonConfigurableWriteFields,
   SelectMappingFields,
   SelectOptionalFields,
 } from '../types';
@@ -79,7 +80,11 @@ const generateConfigurationStateWrite = (
     return null;
   }
 
-  const selectedWriteFields = config?.content?.write?.selectedNonConfigurableWriteFields || {};
+  const writeObjects = config?.content?.write?.objects;
+  const fields = Object.keys(writeObjects || {});
+
+  const selectedWriteFields: SelectedNonConfigurableWriteFields = {};
+  fields.forEach((field) => { selectedWriteFields[field] = true; });
   const savedFields = { ...selectedWriteFields };
 
   return {

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -5,7 +5,7 @@ import {
   IntegrationFieldMapping,
 } from '../../services/api';
 
-type SelectedNonConfigurableWriteFields = {
+export type SelectedNonConfigurableWriteFields = {
   [key: string]: boolean,
 };
 


### PR DESCRIPTION
### Summary
This PR adds support for config pre-fill. When the component is refreshed, the form will pull data from both hydratedRevision and config now. 

![write-prefill-config](https://github.com/amp-labs/react/assets/5396828/5d8a3a83-90f4-4e79-8367-3a966c7b79de)


#### steps
1. ~UI write tab + form~
2. ~refactor read state~
3. ~add write state to context~
4. ~connect data to write state slice~ 
4a. ~connect hydratedRevision data~
4b. **connect config data**
5. ~submit write state slice~
5a. ~submit create write installation~
5b. submit update write installation
7. ~add isModified / in progress state~
7b. progress, completed, non-completed state 