### PR TITLE
fix: button not active when re-submitting update installation

### DIFF
--- a/src/components/Configure/actions/write/generateConfigWriteObjects.ts
+++ b/src/components/Configure/actions/write/generateConfigWriteObjects.ts
@@ -26,11 +26,14 @@ type WriteObjects = {
 export const generateConfigWriteObjects = (configureState: ConfigureState) => {
   const configWriteObjects: WriteObjects = {}; // `any` is listed type in generated SDK
   const configStateWriteObjects = configureState.write?.writeObjects;
+  const selected = configureState.write?.selectedNonConfigurableWriteFields;
+  const selectedKeys = selected ? Object.keys(selected) : [];
+
   if (configStateWriteObjects) {
     configStateWriteObjects.forEach((configStateWriteObject) => {
       const obj = configStateWriteObject.objectName;
       // object exists in config form
-      if (obj) {
+      if (selectedKeys.includes(obj)) {
         // insert objectName into configWriteObjects
         configWriteObjects[obj] = {
           objectName: obj,

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -34,7 +34,8 @@ export function ConfigureInstallationBase(
   // has the form been modified?
   const isReadModified = configureState?.read?.isOptionalFieldsModified
   || configureState?.read?.isRequiredMapFieldsModified;
-  const isModified = isReadModified || configureState?.write?.isWriteModified;
+  const isWriteModified = configureState?.write?.isWriteModified;
+  const isModified = isReadModified || isWriteModified;
 
   // is this a new state (modified or creating a new state)
   const isStateNew = isModified || isCreateMode;

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -57,6 +57,11 @@ export function UpdateInstallation(
     if (!configureState) { resetState(); }
   }, [configureState, resetState]);
 
+  // reset state when installation (i.e. config) is reloaded.
+  useEffect(() => {
+    if (installation) resetState();
+  }, [installation, resetState]);
+
   const hydratedObject = useMemo(() => {
     const hydrated = hydratedRevision?.content?.read?.standardObjects?.find(
       (obj) => obj?.objectName === selectedObjectName,


### PR DESCRIPTION
### problem
The save changes button doesn't work after the first time the update call is made. 

### solution
- update logic to add write fields which are in both the selected config and hydrated revision field list
- adds in a reset state when installation is updated (i.e. after a update installation returns successfully)