### PR TITLE
[ENG-524] feat: adds redirectUrl support to Connections Provider

### DIFF
--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -7,6 +7,7 @@ import { ConnectionsProvider } from '../../context/ConnectionsContext';
 import { useProject } from '../../context/ProjectContext';
 import { capitalize } from '../../utils';
 import { ProtectedConnectionLayout } from '../Configure/ProtectedConnectionLayout';
+import { RedirectHandler } from '../RedirectHandler';
 
 interface ConnectedSuccessBoxProps {
   provider: string;
@@ -34,11 +35,12 @@ interface ConnectProviderProps {
   consumerName?: string,
   groupRef: string,
   groupName?: string,
+  redirectUrl?: string,
 }
 
 export function ConnectProvider(
   {
-    provider, consumerRef, consumerName, groupRef, groupName,
+    provider, consumerRef, consumerName, groupRef, groupName, redirectUrl,
   }: ConnectProviderProps,
 ) {
   return (
@@ -50,7 +52,9 @@ export function ConnectProvider(
         groupRef={groupRef}
         groupName={groupName}
       >
-        <ConnectedSuccessBox provider={provider} />
+        <RedirectHandler redirectURL={redirectUrl}>
+          <ConnectedSuccessBox provider={provider} />
+        </RedirectHandler>
       </ProtectedConnectionLayout>
     </ConnectionsProvider>
   );

--- a/src/components/Connect/OAuthPopup.tsx
+++ b/src/components/Connect/OAuthPopup.tsx
@@ -65,9 +65,7 @@ function OAuthPopup({
 
   const refreshConnections = useCallback(async (connectionId: string) => {
     const connection = await api().connectionApi.getConnection({ projectId, connectionId }, {
-      headers: {
-        'X-Api-Key': apiKey ?? '',
-      },
+      headers: { 'X-Api-Key': apiKey ?? '' },
     });
     setSelectedConnection(connection);
   }, [projectId, apiKey, setSelectedConnection]);

--- a/src/components/RedirectHandler/RedirectHandler.tsx
+++ b/src/components/RedirectHandler/RedirectHandler.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Text } from '@chakra-ui/react';
 
 type RedirectHandlerProps = {
   redirectURL?: string;
@@ -23,7 +24,7 @@ export function RedirectHandler({ redirectURL, children } : RedirectHandlerProps
   }, [redirectURL]);
 
   // show a loading message if a redirect URL is present
-  if (redirectURL) return <div>redirecting...</div>;
+  if (redirectURL) return <Text textAlign="center">redirecting...</Text>;
 
   // render children if no redirect URL is present
   return children;

--- a/src/components/RedirectHandler/RedirectHandler.tsx
+++ b/src/components/RedirectHandler/RedirectHandler.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect } from 'react';
-import { Text } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
+
+import { LoadingIcon } from '../../assets/LoadingIcon';
 
 type RedirectHandlerProps = {
   redirectURL?: string;
@@ -24,7 +26,13 @@ export function RedirectHandler({ redirectURL, children } : RedirectHandlerProps
   }, [redirectURL]);
 
   // show a loading message if a redirect URL is present
-  if (redirectURL) return <Text textAlign="center">redirecting...</Text>;
+  if (redirectURL) {
+    return (
+      <Box display="flex" alignItems="center" justifyContent="center">
+        <LoadingIcon message="Redirecting..." />
+      </Box>
+    );
+  }
 
   // render children if no redirect URL is present
   return children;

--- a/src/components/RedirectHandler/RedirectHandler.tsx
+++ b/src/components/RedirectHandler/RedirectHandler.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+
+type RedirectHandlerProps = {
+  redirectURL?: string;
+  children: React.ReactNode;
+};
+
+/**
+ * RedirectHandler is a component that redirects to a specified URL when mounted or
+ * will render the childen if no redirect URL is present.
+ *
+ * @param redirectURL
+ * @param children
+ * @returns
+ */
+export function RedirectHandler({ redirectURL, children } : RedirectHandlerProps) {
+  useEffect(() => {
+    // Check if a redirect URL is present
+    if (redirectURL) {
+      // Redirect to the specified URL
+      window.location.replace(redirectURL);
+    }
+  }, [redirectURL]);
+
+  // show a loading message if a redirect URL is present
+  if (redirectURL) return <div>redirecting...</div>;
+
+  // render children if no redirect URL is present
+  return children;
+}

--- a/src/components/RedirectHandler/index.ts
+++ b/src/components/RedirectHandler/index.ts
@@ -1,0 +1,1 @@
+export { RedirectHandler } from './RedirectHandler';


### PR DESCRIPTION
### summary
When redirectUrl param is present, the component will render a loading screen while redirecting to the URL. Otherwise, the child component will render.
- creates redirect handler component

#### test in mailmonkey
1. enter in a relative url (i.e. `my.redirect.url`)
2. go to `http://localhost:3001/connect`
3. fill out provider credentials
4. observe loading and redirect when credentials accepted

#### demo

![redirect-handler](https://github.com/amp-labs/react/assets/5396828/0b8c7e21-ee4e-4878-8753-f5836a1b172f)
