### PR TITLE
[ENG-524] feat: adds onSuccess connection handler

### DIFF
--- a/src/components/Configure/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/ProtectedConnectionLayout.tsx
@@ -14,15 +14,14 @@ interface ProtectedConnectionLayoutProps {
   groupRef: string,
   groupName?: string,
   onSuccess?: (connectionID: string) => void;
-  onError?: (error: string) => void;
   children: JSX.Element,
 }
 export function ProtectedConnectionLayout({
-  provider, consumerRef, consumerName, groupRef, groupName, children, onSuccess, onError,
+  provider, consumerRef, consumerName, groupRef, groupName, children, onSuccess,
 }: ProtectedConnectionLayoutProps) {
   const { provider: providerFromProps } = useInstallIntegrationProps();
   const { selectedConnection, setSelectedConnection, connections } = useConnections();
-  useConnectionHandler({ onSuccess, onError });
+  useConnectionHandler({ onSuccess });
 
   useEffect(() => {
     if (!selectedConnection && connections && connections.length > 0) {

--- a/src/components/Configure/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/ProtectedConnectionLayout.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { PROVIDER_SALESFORCE } from '../../constants';
 import { useConnections } from '../../context/ConnectionsContext';
 import { useInstallIntegrationProps } from '../../context/InstallIntegrationContext';
+import { useConnectionHandler } from '../Connect/useConnectionHandler';
 import { NoSubdomainOauthFlow } from '../Oauth/NoSubdomainEntry/NoSubdomainOauthFlow';
 import { SalesforceOauthFlow } from '../Oauth/Salesforce/SalesforceOauthFlow';
 
@@ -12,12 +13,16 @@ interface ProtectedConnectionLayoutProps {
   consumerName?: string,
   groupRef: string,
   groupName?: string,
+  onSuccess?: (connectionID: string) => void;
+  onError?: (error: string) => void;
   children: JSX.Element,
 }
 export function ProtectedConnectionLayout({
-  provider, consumerRef, consumerName, groupRef, groupName, children,
+  provider, consumerRef, consumerName, groupRef, groupName, children, onSuccess, onError,
 }: ProtectedConnectionLayoutProps) {
+  const { provider: providerFromProps } = useInstallIntegrationProps();
   const { selectedConnection, setSelectedConnection, connections } = useConnections();
+  useConnectionHandler({ onSuccess, onError });
 
   useEffect(() => {
     if (!selectedConnection && connections && connections.length > 0) {
@@ -26,7 +31,6 @@ export function ProtectedConnectionLayout({
     }
   }, [connections, selectedConnection, setSelectedConnection]);
 
-  const { provider: providerFromProps } = useInstallIntegrationProps();
   if (!provider && !providerFromProps) {
     throw new Error('ProtectedConnectionLayout must be given a provider prop or be used within InstallIntegrationProvider');
   }

--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -11,13 +11,12 @@ interface ConnectProviderProps {
   groupRef: string,
   groupName?: string,
   redirectUrl?: string,
-  onSuccess: (connectionID: string) => void;
-  onError: (error: string) => void;
+  onSuccess?: (connectionID: string) => void;
 }
 
 export function ConnectProvider(
   {
-    provider, consumerRef, consumerName, groupRef, groupName, redirectUrl, onSuccess, onError,
+    provider, consumerRef, consumerName, groupRef, groupName, redirectUrl, onSuccess,
   }: ConnectProviderProps,
 ) {
   return (
@@ -29,7 +28,6 @@ export function ConnectProvider(
         groupRef={groupRef}
         groupName={groupName}
         onSuccess={onSuccess}
-        onError={onError}
       >
         <RedirectHandler redirectURL={redirectUrl}>
           <ConnectedSuccessBox provider={provider} />

--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -1,33 +1,8 @@
-import {
-  Box, Container,
-} from '@chakra-ui/react';
-
-import { CheckMarkIcon } from '../../assets/NavIcon';
 import { ConnectionsProvider } from '../../context/ConnectionsContext';
-import { useProject } from '../../context/ProjectContext';
-import { capitalize } from '../../utils';
 import { ProtectedConnectionLayout } from '../Configure/ProtectedConnectionLayout';
 import { RedirectHandler } from '../RedirectHandler';
 
-interface ConnectedSuccessBoxProps {
-  provider: string;
-}
-function ConnectedSuccessBox({ provider }: ConnectedSuccessBoxProps) {
-  const { appName } = useProject();
-
-  return (
-    <Container>
-      <Box p={8} maxWidth="600px" minHeight="290px" borderWidth={1} borderRadius={8} boxShadow="lg" margin="auto" marginTop="40px" bgColor="white" paddingTop="100px">
-        <Box width="100%" display="flex" alignContent="center" justifyContent="center">
-          <Box margin="auto">{CheckMarkIcon}</Box>
-        </Box>
-        <Box textAlign="center" paddingTop="25px">
-          {`You've successfully connected ${capitalize(provider)} to ${appName}.`}
-        </Box>
-      </Box>
-    </Container>
-  );
-}
+import { ConnectedSuccessBox } from './ConnectedSuccessBox';
 
 interface ConnectProviderProps {
   provider: string,
@@ -36,11 +11,13 @@ interface ConnectProviderProps {
   groupRef: string,
   groupName?: string,
   redirectUrl?: string,
+  onSuccess: (connectionID: string) => void;
+  onError: (error: string) => void;
 }
 
 export function ConnectProvider(
   {
-    provider, consumerRef, consumerName, groupRef, groupName, redirectUrl,
+    provider, consumerRef, consumerName, groupRef, groupName, redirectUrl, onSuccess, onError,
   }: ConnectProviderProps,
 ) {
   return (
@@ -51,6 +28,8 @@ export function ConnectProvider(
         consumerName={consumerName}
         groupRef={groupRef}
         groupName={groupName}
+        onSuccess={onSuccess}
+        onError={onError}
       >
         <RedirectHandler redirectURL={redirectUrl}>
           <ConnectedSuccessBox provider={provider} />

--- a/src/components/Connect/ConnectedSuccessBox.tsx
+++ b/src/components/Connect/ConnectedSuccessBox.tsx
@@ -1,0 +1,25 @@
+import { Box, Container } from '@chakra-ui/react';
+
+import { CheckMarkIcon } from '../../assets/NavIcon';
+import { useProject } from '../../context/ProjectContext';
+import { capitalize } from '../../utils';
+
+interface ConnectedSuccessBoxProps {
+  provider: string;
+}
+export function ConnectedSuccessBox({ provider }: ConnectedSuccessBoxProps) {
+  const { appName } = useProject();
+
+  return (
+    <Container>
+      <Box p={8} maxWidth="600px" minHeight="290px" borderWidth={1} borderRadius={8} boxShadow="lg" margin="auto" marginTop="40px" bgColor="white" paddingTop="100px">
+        <Box width="100%" display="flex" alignContent="center" justifyContent="center">
+          <Box margin="auto">{CheckMarkIcon}</Box>
+        </Box>
+        <Box textAlign="center" paddingTop="25px">
+          {`You've successfully connected ${capitalize(provider)} to ${appName}.`}
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/src/components/Connect/useConnectionHandler.tsx
+++ b/src/components/Connect/useConnectionHandler.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react';
 
 import { useConnections } from '../../context/ConnectionsContext';
-import { ErrorBoundary, useErrorState } from '../../context/ErrorContextProvider';
-import { useProject } from '../../context/ProjectContext';
 
 function useOnSuccessHandler(onSuccess?: (connectionID: string) => void) {
   const { selectedConnection } = useConnections();
@@ -15,26 +13,9 @@ function useOnSuccessHandler(onSuccess?: (connectionID: string) => void) {
   }, [onSuccess, selectedConnection]);
 }
 
-/**
- * only supports connection list error at this time
- * @param onError
- */
-function useOnErrorHandler(onError?: (error: string) => void) {
-  const { isError } = useErrorState();
-  const { projectId } = useProject();
-  useEffect(() => {
-    const isConnectionListError = isError(ErrorBoundary.CONNECTION_LIST, projectId);
-    // Check if a onError callback is present
-    if (onError && isConnectionListError) {
-      // call callback when error is present
-      onError('ConnectionList Error');
-    }
-  }, [onError, projectId, isError]);
-}
-
 type ConnectionHandlerPropsProps = {
   onSuccess?: (connectionID: string) => void;
-  onError?: (error: string) => void;
+  // onError?: (error: string) => void; // not supported yet
 };
 
 /**
@@ -44,7 +25,6 @@ type ConnectionHandlerPropsProps = {
  * @param children
  * @returns
  */
-export function useConnectionHandler({ onSuccess, onError } : ConnectionHandlerPropsProps) {
+export function useConnectionHandler({ onSuccess } : ConnectionHandlerPropsProps) {
   useOnSuccessHandler(onSuccess);
-  useOnErrorHandler(onError);
 }

--- a/src/components/Connect/useConnectionHandler.tsx
+++ b/src/components/Connect/useConnectionHandler.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+
+import { useConnections } from '../../context/ConnectionsContext';
+import { ErrorBoundary, useErrorState } from '../../context/ErrorContextProvider';
+import { useProject } from '../../context/ProjectContext';
+
+function useOnSuccessHandler(onSuccess?: (connectionID: string) => void) {
+  const { selectedConnection } = useConnections();
+  useEffect(() => {
+    // Check if a onSuccess callback is present
+    if (onSuccess && selectedConnection) {
+      // call callback when connection is selected
+      onSuccess(selectedConnection.id);
+    }
+  }, [onSuccess, selectedConnection]);
+}
+
+/**
+ * only supports connection list error at this time
+ * @param onError
+ */
+function useOnErrorHandler(onError?: (error: string) => void) {
+  const { isError } = useErrorState();
+  const { projectId } = useProject();
+  useEffect(() => {
+    const isConnectionListError = isError(ErrorBoundary.CONNECTION_LIST, projectId);
+    // Check if a onError callback is present
+    if (onError && isConnectionListError) {
+      // call callback when error is present
+      onError('ConnectionList Error');
+    }
+  }, [onError, projectId, isError]);
+}
+
+type ConnectionHandlerPropsProps = {
+  onSuccess?: (connectionID: string) => void;
+  onError?: (error: string) => void;
+};
+
+/**
+ * ConnectionHandler is a component that handles onSuccess and onError callbacks
+ *
+ * @param redirectURL
+ * @param children
+ * @returns
+ */
+export function useConnectionHandler({ onSuccess, onError } : ConnectionHandlerPropsProps) {
+  useOnSuccessHandler(onSuccess);
+  useOnErrorHandler(onError);
+}


### PR DESCRIPTION
### summary
creates onSuccess and onError hooks based on whether a connection has been established and whether a boundary error is triggered. 
- adds onSuccess connection handler
- adds onError connection handler for ConnectionList error

error only works for ConnectionList error. onErrors don't support other errors like subdomain errors, closing dialogue too early, etc... expected experience needs more clarity or to be returned back to support more onError scenarios.

#### testing
- test by passing in an onSuccess in mailmonkey
- onError not fully tested yet

*NOTE: onError removed from PR*

