### PR TITLE
[ENG-587] feat: support only read and only write actions

### DIFF
--- a/src/components/Configure/ObjectManagementNav/NavObjectItem.tsx
+++ b/src/components/Configure/ObjectManagementNav/NavObjectItem.tsx
@@ -10,10 +10,13 @@ interface NavObjectItemProps {
   objectName: string;
   completed: boolean;
   pending?: boolean;
+  displayName?: string; // overrides objectName as the display name when present
 }
 
 export const NavObjectItem = forwardRef<HTMLButtonElement, NavObjectItemProps>(
-  ({ objectName, completed, pending }, ref) => {
+  ({
+    objectName, completed, pending, displayName,
+  }, ref) => {
     // 1. Reuse the `useTab` hook
     const tabProps = useTab({ ref });
 
@@ -31,7 +34,7 @@ export const NavObjectItem = forwardRef<HTMLButtonElement, NavObjectItemProps>(
         >
           {NavIcon(completed, pending)}
           <Box textAlign="left">
-            <Text>{objectName}</Text>
+            <Text>{displayName || objectName}</Text>
             {pending && <Text fontSize={10} fontStyle="italic">pending</Text>}
           </Box>
         </Box>

--- a/src/components/Configure/ObjectManagementNav/OtherTab.tsx
+++ b/src/components/Configure/ObjectManagementNav/OtherTab.tsx
@@ -7,9 +7,10 @@ export const OTHER_CONST = 'other';
 type OtherTabProps = {
   pending?: boolean,
   completed: boolean,
+  displayName?: 'other' | 'write',
 };
 
-export function OtherTab({ pending, completed }: OtherTabProps) {
+export function OtherTab({ pending, completed, displayName }: OtherTabProps) {
   return (
     <>
       <Divider marginY={3} />
@@ -18,6 +19,7 @@ export function OtherTab({ pending, completed }: OtherTabProps) {
         objectName={OTHER_CONST}
         completed={completed}
         pending={pending}
+        displayName={displayName}
       />
     </>
 

--- a/src/components/Configure/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/ObjectManagementNav/index.tsx
@@ -55,18 +55,21 @@ export function ObjectManagementNav({
   const { installation, provider } = useInstallIntegrationProps();
   const { hydratedRevision } = useHydratedRevision();
   const { objectConfigurationsState } = useObjectsConfigureState();
-  const config = installation?.config;
-  const navObjects = hydratedRevision && generateNavObjects(config, hydratedRevision);
 
+  // Object Nav Tab Index
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabsChange = (index: number) => { setTabIndex(index); };
+
+  const appName = project?.appName || '';
+  const config = installation?.config;
+  const readNavObjects = hydratedRevision && generateNavObjects(config, hydratedRevision);
+  const isNavObjectsReady = readNavObjects !== null; // null = hydratedRevision/config is not ready
 
   const isWriteSupported = !!hydratedRevision?.content?.write;
   const otherNavObject = WRITE_FEATURE_FLAG && isWriteSupported
     ? generateOtherNavObject(config) : undefined;
 
-  const appName = project?.appName || '';
-  const allNavObjects = [...(navObjects || [])];
+  const allNavObjects = [...(readNavObjects || [])];
   if (otherNavObject && isWriteSupported) { allNavObjects.push(otherNavObject); }
   const selectedObject = getSelectedObject(allNavObjects, tabIndex);
 
@@ -87,14 +90,14 @@ export function ObjectManagementNav({
         <Box width="20rem">
           <Text>{capitalize(provider)} integration</Text>
           <Text marginBottom="20px" fontSize="1.125rem" fontWeight="500">{appName}</Text>
-          {navObjects && (
+          {isNavObjectsReady && (
             <Tabs
               index={tabIndex}
               onChange={handleTabsChange}
               orientation="horizontal"
             >
               {/* Read tab */}
-              {navObjects.map((object) => (
+              {readNavObjects.map((object) => (
                 <NavObjectItem
                   key={object.name}
                   objectName={object.name}
@@ -111,6 +114,7 @@ export function ObjectManagementNav({
                 <OtherTab
                   completed={otherNavObject.completed}
                   pending={objectConfigurationsState?.other?.write?.isWriteModified}
+                  displayName={readNavObjects?.length ? 'other' : 'write'}
                 />
               ) }
 


### PR DESCRIPTION
### Summary
supports when only write is supported by the builder. 

### screenshots

#### only write
text changes from 'other' to 'write'

![Screenshot 2024-02-01 at 2 18 47 PM](https://github.com/amp-labs/react/assets/5396828/272659c6-0a20-43c9-9df3-7d98b92a4818)

#### only read
![Screenshot 2024-02-01 at 2 19 39 PM](https://github.com/amp-labs/react/assets/5396828/ab80ed63-54f6-40de-a6ea-33bce5cf9c9d)

#### read & write
![Screenshot 2024-02-01 at 2 19 10 PM](https://github.com/amp-labs/react/assets/5396828/f60f72a2-f06e-4a0b-8e69-ecbb7b034596)


