### PR TITLE
[ENG-636] fix: replace loading with integration not found error message 

### DIFF
--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -138,13 +138,19 @@ export function InstallIntegrationProvider({
   }), [integrationObj, consumerRef, consumerName, groupRef,
     groupName, installation, setInstallation, resetInstallations]);
 
-  const errorMessage = `Error retrieving installation information for integration "${integrationObj?.name || 'unknown'}"`;
+  if (integrationObj !== null) {
+    const errorMessage = 'Error retrieving installation information for integration '
+     + `"${integrationObj?.name || 'unknown'}"`;
 
-  return (
-    isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey))
-    ? <ErrorTextBox message={errorMessage} /> : (
-      <InstallIntegrationContext.Provider value={props}>
-        {isLoading ? <LoadingIcon /> : children}
-      </InstallIntegrationContext.Provider>
-    );
+    return (
+      isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey))
+      ? <ErrorTextBox message={errorMessage} /> : (
+        <InstallIntegrationContext.Provider value={props}>
+          {isLoading ? <LoadingIcon /> : children}
+        </InstallIntegrationContext.Provider>
+      );
+  }
+
+  // if integration not found, return error message
+  return <ErrorTextBox message={`Integration "${integration}" not found`} />;
 }


### PR DESCRIPTION
### Summary
The page will forever load if integration list is loaded but does not match an integration name. We now replace the loading icon with an error dialogue. 

![Screenshot 2024-02-07 at 1 59 26 PM](https://github.com/amp-labs/react/assets/5396828/b861055d-116f-4945-8705-a37cbeafebc9)




