### PR TITLE
[ENG-655] feat: adds onInstallSuccess callback support

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -18,11 +18,12 @@ interface InstallIntegrationProps {
   groupRef: string,
   groupName?: string,
   onInstallSuccess?: (installationId: string, config: Config) => void,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 }
 
 export function InstallIntegration(
   {
-    integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess,
+    integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();
@@ -40,6 +41,7 @@ export function InstallIntegration(
       groupRef={groupRef}
       groupName={groupName}
       onInstallSuccess={onInstallSuccess}
+      onUpdateSuccess={onUpdateSuccess}
     >
       <ConnectionsProvider groupRef={groupRef}>
         <ProtectedConnectionLayout

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -2,6 +2,7 @@ import { ConnectionsProvider } from '../../context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from '../../context/ErrorContextProvider';
 import { InstallIntegrationProvider } from '../../context/InstallIntegrationContextProvider';
 import { useProject } from '../../context/ProjectContextProvider';
+import { Config } from '../../services/api';
 import { ErrorTextBox } from '../ErrorTextBox';
 
 import { InstallationContent } from './content/InstallationContent';
@@ -16,11 +17,12 @@ interface InstallIntegrationProps {
   consumerName?: string,
   groupRef: string,
   groupName?: string,
+  onInstallSuccess?: (installationId: string, config: Config) => void,
 }
 
 export function InstallIntegration(
   {
-    integration, consumerRef, consumerName, groupRef, groupName,
+    integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess,
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();
@@ -37,6 +39,7 @@ export function InstallIntegration(
       consumerName={consumerName}
       groupRef={groupRef}
       groupName={groupName}
+      onInstallSuccess={onInstallSuccess}
     >
       <ConnectionsProvider groupRef={groupRef}>
         <ProtectedConnectionLayout

--- a/src/components/Configure/actions/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/onSaveReadCreateInstallation.ts
@@ -1,5 +1,5 @@
 import {
-  api, CreateInstallationOperationRequest,
+  api, Config, CreateInstallationOperationRequest,
   CreateInstallationRequestConfig, HydratedRevision,
   Installation,
 } from '../../../services/api';
@@ -90,6 +90,7 @@ export const onSaveReadCreateInstallation = (
   hydratedRevision: HydratedRevision,
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
+  onInstallSuccess?: (installationId: string, config: Config) => void, // success callback function
 ): Promise<void | null> => {
   const createConfig = generateCreateReadConfigFromConfigureState(
     configureState,
@@ -120,6 +121,7 @@ export const onSaveReadCreateInstallation = (
     .then((installation) => {
       // update local installation state
       setInstallation(installation);
+      onInstallSuccess?.(installation.id, installation.config);
     })
     .catch((err) => {
       console.error('ERROR: ', err);

--- a/src/components/Configure/actions/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/onSaveReadUpdateInstallation.ts
@@ -1,5 +1,5 @@
 import {
-  api,
+  api, Config,
   HydratedIntegrationObject,
   Installation,
   UpdateInstallationOperationRequest,
@@ -68,6 +68,7 @@ export const onSaveReadUpdateInstallation = (
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
   hydratedObject: HydratedIntegrationObject,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   // get configuration state
   // transform configuration state to update shape
@@ -103,9 +104,10 @@ export const onSaveReadUpdateInstallation = (
       'X-Api-Key': apiKey,
       'Content-Type': 'application/json',
     },
-  }).then((data) => {
+  }).then((installation) => {
     // update local installation state
-    setInstallation(data);
+    setInstallation(installation);
+    onUpdateSuccess?.(installation.id, installation.config);
   }).catch((err) => {
     console.error('ERROR: ', err);
   });

--- a/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
@@ -1,5 +1,5 @@
 import {
-  api, CreateInstallationOperationRequest,
+  api, Config, CreateInstallationOperationRequest,
   CreateInstallationRequestConfig,
   HydratedRevision,
   Installation,
@@ -78,6 +78,7 @@ export const onSaveWriteCreateInstallation = (
   hydratedRevision: HydratedRevision,
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
+  onInstallSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   const createConfig = generateCreateWriteConfigFromConfigureState(
     configureState,
@@ -107,6 +108,7 @@ export const onSaveWriteCreateInstallation = (
     .then((installation) => {
       // update local installation state
       setInstallation(installation);
+      onInstallSuccess?.(installation.id, installation.config);
     })
     .catch((err) => {
       console.error('ERROR: ', err);

--- a/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
@@ -1,5 +1,6 @@
 import {
   api,
+  Config,
   Installation,
   UpdateInstallationOperationRequest,
   UpdateInstallationRequestInstallationConfig,
@@ -41,6 +42,7 @@ export const onSaveWriteUpdateInstallation = (
   apiKey: string,
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   // get configuration state
   // transform configuration state to update shape
@@ -71,9 +73,10 @@ export const onSaveWriteUpdateInstallation = (
       'X-Api-Key': apiKey,
       'Content-Type': 'application/json',
     },
-  }).then((data) => {
+  }).then((installation) => {
     // update local installation state
-    setInstallation(data);
+    setInstallation(installation);
+    onUpdateSuccess?.(installation.id, installation.config);
   }).catch((err) => {
     console.error('ERROR: ', err);
   });

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -27,6 +27,7 @@ export function CreateInstallation() {
     loading, selectedObjectName, selectedConnection, apiKey, projectId,
     resetBoundary, setErrors,
     resetConfigureState, objectConfigurationsState, resetPendingConfigurationState, configureState,
+    onInstallSuccess,
   } = useMutateInstallation();
   const [isLoading, setLoadingState] = useState<boolean>(false);
 
@@ -79,6 +80,7 @@ export function CreateInstallation() {
         hydratedRevision,
         configureState,
         setInstallation,
+        onInstallSuccess,
       );
 
       res.finally(() => {
@@ -105,6 +107,7 @@ export function CreateInstallation() {
         hydratedRevision,
         configureState,
         setInstallation,
+        onInstallSuccess,
       );
 
       res.finally(() => {

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -28,7 +28,7 @@ export function UpdateInstallation(
     setInstallation, hydratedRevision,
     loading, selectedObjectName, apiKey, projectId,
     resetBoundary, setErrors,
-    resetConfigureState, resetPendingConfigurationState, configureState,
+    resetConfigureState, resetPendingConfigurationState, configureState, onUpdateSuccess,
   } = useMutateInstallation();
 
   const [isLoading, setLoadingState] = useState<boolean>(false);
@@ -93,6 +93,7 @@ export function UpdateInstallation(
         configureState,
         setInstallation,
         hydratedObject,
+        onUpdateSuccess,
       );
 
       res.finally(() => {
@@ -114,6 +115,7 @@ export function UpdateInstallation(
         apiKey,
         configureState,
         setInstallation,
+        onUpdateSuccess,
       );
 
       res.finally(() => {

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -13,7 +13,7 @@ import { getConfigureState } from '../state/utils';
  * */
 export const useMutateInstallation = () => {
   const {
-    integrationId, groupRef, consumerRef, setInstallation,
+    integrationId, groupRef, consumerRef, setInstallation, onInstallSuccess,
   } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
@@ -43,5 +43,6 @@ export const useMutateInstallation = () => {
     objectConfigurationsState,
     resetPendingConfigurationState,
     configureState,
+    onInstallSuccess,
   };
 };

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -13,7 +13,7 @@ import { getConfigureState } from '../state/utils';
  * */
 export const useMutateInstallation = () => {
   const {
-    integrationId, groupRef, consumerRef, setInstallation, onInstallSuccess,
+    integrationId, groupRef, consumerRef, setInstallation, onInstallSuccess, onUpdateSuccess,
   } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
@@ -44,5 +44,6 @@ export const useMutateInstallation = () => {
     resetPendingConfigurationState,
     configureState,
     onInstallSuccess,
+    onUpdateSuccess,
   };
 };

--- a/src/components/Connect/useConnectionHandler.tsx
+++ b/src/components/Connect/useConnectionHandler.tsx
@@ -20,9 +20,7 @@ type ConnectionHandlerPropsProps = {
 
 /**
  * ConnectionHandler is a component that handles onSuccess and onError callbacks
- *
- * @param redirectURL
- * @param children
+ * @param onSuccess - callback function to be called when a connection is successful
  * @returns
  */
 export function useConnectionHandler({ onSuccess } : ConnectionHandlerPropsProps) {

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -28,6 +28,7 @@ interface InstallIntegrationContextValue {
   setInstallation: (installationObj: Installation) => void;
   resetInstallations: () => void;
   onInstallSuccess?: (installationId: string, config: Config) => void;
+  onUpdateSuccess?: (installationId: string, config: Config) => void;
 }
 // Create a context to pass down the props
 const InstallIntegrationContext = createContext<InstallIntegrationContextValue>({
@@ -42,6 +43,7 @@ const InstallIntegrationContext = createContext<InstallIntegrationContextValue>(
   setInstallation: () => { },
   resetInstallations: () => { },
   onInstallSuccess: undefined,
+  onUpdateSuccess: undefined,
 });
 
 // Create a custom hook to access the props
@@ -61,11 +63,12 @@ interface InstallIntegrationProviderProps {
   groupName?: string,
   children: React.ReactNode,
   onInstallSuccess?: (installationId: string, config: Config) => void,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 }
 
 // Wrap your parent component with the context provider
 export function InstallIntegrationProvider({
-  children, integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess,
+  children, integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
 }: InstallIntegrationProviderProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
@@ -141,8 +144,9 @@ export function InstallIntegrationProvider({
     setInstallation,
     resetInstallations,
     onInstallSuccess,
+    onUpdateSuccess,
   }), [integrationObj, consumerRef, consumerName, groupRef,
-    groupName, installation, setInstallation, resetInstallations, onInstallSuccess]);
+    groupName, installation, setInstallation, resetInstallations, onInstallSuccess, onUpdateSuccess]);
 
   const errorMessage = `Error retrieving installation information for integration "${integrationObj?.name || 'unknown'}"`;
 

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -5,7 +5,9 @@ import {
 
 import { LoadingIcon } from '../assets/LoadingIcon';
 import { ErrorTextBox } from '../components/ErrorTextBox';
-import { api, Installation, Integration } from '../services/api';
+import {
+  api, Config, Installation, Integration,
+} from '../services/api';
 import { findIntegrationFromList } from '../utils';
 
 import { useApiKey } from './ApiKeyContextProvider';
@@ -25,6 +27,7 @@ interface InstallIntegrationContextValue {
   installation?: Installation;
   setInstallation: (installationObj: Installation) => void;
   resetInstallations: () => void;
+  onInstallSuccess?: (installationId: string, config: Config) => void;
 }
 // Create a context to pass down the props
 const InstallIntegrationContext = createContext<InstallIntegrationContextValue>({
@@ -38,6 +41,7 @@ const InstallIntegrationContext = createContext<InstallIntegrationContextValue>(
   installation: undefined,
   setInstallation: () => { },
   resetInstallations: () => { },
+  onInstallSuccess: undefined,
 });
 
 // Create a custom hook to access the props
@@ -56,11 +60,12 @@ interface InstallIntegrationProviderProps {
   groupRef: string,
   groupName?: string,
   children: React.ReactNode,
+  onInstallSuccess?: (installationId: string, config: Config) => void,
 }
 
 // Wrap your parent component with the context provider
 export function InstallIntegrationProvider({
-  children, integration, consumerRef, consumerName, groupRef, groupName,
+  children, integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess,
 }: InstallIntegrationProviderProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
@@ -135,8 +140,9 @@ export function InstallIntegrationProvider({
     installation,
     setInstallation,
     resetInstallations,
+    onInstallSuccess,
   }), [integrationObj, consumerRef, consumerName, groupRef,
-    groupName, installation, setInstallation, resetInstallations]);
+    groupName, installation, setInstallation, resetInstallations, onInstallSuccess]);
 
   const errorMessage = `Error retrieving installation information for integration "${integrationObj?.name || 'unknown'}"`;
 


### PR DESCRIPTION
### Summary 
- adds success callback for when `<InstallIntegration/>` successfully calls createInstallation.   
- `read` and `write` support for onSaveCreateInstallation

#### read create installation
![install-read-success](https://github.com/amp-labs/react/assets/5396828/9c577334-2cbe-4d3c-8705-2a6379047b7e)

#### write create installation (under feature flag)
![install-write-success ](https://github.com/amp-labs/react/assets/5396828/f166a262-75a7-45c3-bf7e-5b90b062d5d3)




