### PR TITLE
[ENG-655] feat: adds onUpdateSuccess to InstallIntegration

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -18,11 +18,12 @@ interface InstallIntegrationProps {
   groupRef: string,
   groupName?: string,
   onInstallSuccess?: (installationId: string, config: Config) => void,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 }
 
 export function InstallIntegration(
   {
-    integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess,
+    integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();
@@ -40,6 +41,7 @@ export function InstallIntegration(
       groupRef={groupRef}
       groupName={groupName}
       onInstallSuccess={onInstallSuccess}
+      onUpdateSuccess={onUpdateSuccess}
     >
       <ConnectionsProvider groupRef={groupRef}>
         <ProtectedConnectionLayout

--- a/src/components/Configure/actions/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/onSaveReadUpdateInstallation.ts
@@ -1,5 +1,5 @@
 import {
-  api,
+  api, Config,
   HydratedIntegrationObject,
   Installation,
   UpdateInstallationOperationRequest,
@@ -68,6 +68,7 @@ export const onSaveReadUpdateInstallation = (
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
   hydratedObject: HydratedIntegrationObject,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   // get configuration state
   // transform configuration state to update shape
@@ -103,9 +104,10 @@ export const onSaveReadUpdateInstallation = (
       'X-Api-Key': apiKey,
       'Content-Type': 'application/json',
     },
-  }).then((data) => {
+  }).then((installation) => {
     // update local installation state
-    setInstallation(data);
+    setInstallation(installation);
+    onUpdateSuccess?.(installation.id, installation.config);
   }).catch((err) => {
     console.error('ERROR: ', err);
   });

--- a/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
@@ -1,5 +1,6 @@
 import {
   api,
+  Config,
   Installation,
   UpdateInstallationOperationRequest,
   UpdateInstallationRequestInstallationConfig,
@@ -41,6 +42,7 @@ export const onSaveWriteUpdateInstallation = (
   apiKey: string,
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   // get configuration state
   // transform configuration state to update shape
@@ -71,9 +73,10 @@ export const onSaveWriteUpdateInstallation = (
       'X-Api-Key': apiKey,
       'Content-Type': 'application/json',
     },
-  }).then((data) => {
+  }).then((installation) => {
     // update local installation state
-    setInstallation(data);
+    setInstallation(installation);
+    onUpdateSuccess?.(installation.id, installation.config);
   }).catch((err) => {
     console.error('ERROR: ', err);
   });

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -28,7 +28,7 @@ export function UpdateInstallation(
     setInstallation, hydratedRevision,
     loading, selectedObjectName, apiKey, projectId,
     resetBoundary, setErrors,
-    resetConfigureState, resetPendingConfigurationState, configureState,
+    resetConfigureState, resetPendingConfigurationState, configureState, onUpdateSuccess,
   } = useMutateInstallation();
 
   const [isLoading, setLoadingState] = useState<boolean>(false);
@@ -93,6 +93,7 @@ export function UpdateInstallation(
         configureState,
         setInstallation,
         hydratedObject,
+        onUpdateSuccess,
       );
 
       res.finally(() => {
@@ -114,6 +115,7 @@ export function UpdateInstallation(
         apiKey,
         configureState,
         setInstallation,
+        onUpdateSuccess,
       );
 
       res.finally(() => {

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -13,7 +13,7 @@ import { getConfigureState } from '../state/utils';
  * */
 export const useMutateInstallation = () => {
   const {
-    integrationId, groupRef, consumerRef, setInstallation, onInstallSuccess,
+    integrationId, groupRef, consumerRef, setInstallation, onInstallSuccess, onUpdateSuccess,
   } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { selectedObjectName } = useSelectedObjectName();
@@ -44,5 +44,6 @@ export const useMutateInstallation = () => {
     resetPendingConfigurationState,
     configureState,
     onInstallSuccess,
+    onUpdateSuccess,
   };
 };

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -28,6 +28,7 @@ interface InstallIntegrationContextValue {
   setInstallation: (installationObj: Installation) => void;
   resetInstallations: () => void;
   onInstallSuccess?: (installationId: string, config: Config) => void;
+  onUpdateSuccess?: (installationId: string, config: Config) => void;
 }
 // Create a context to pass down the props
 const InstallIntegrationContext = createContext<InstallIntegrationContextValue>({
@@ -42,6 +43,7 @@ const InstallIntegrationContext = createContext<InstallIntegrationContextValue>(
   setInstallation: () => { },
   resetInstallations: () => { },
   onInstallSuccess: undefined,
+  onUpdateSuccess: undefined,
 });
 
 // Create a custom hook to access the props
@@ -61,11 +63,12 @@ interface InstallIntegrationProviderProps {
   groupName?: string,
   children: React.ReactNode,
   onInstallSuccess?: (installationId: string, config: Config) => void,
+  onUpdateSuccess?: (installationId: string, config: Config) => void,
 }
 
 // Wrap your parent component with the context provider
 export function InstallIntegrationProvider({
-  children, integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess,
+  children, integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
 }: InstallIntegrationProviderProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
@@ -141,8 +144,9 @@ export function InstallIntegrationProvider({
     setInstallation,
     resetInstallations,
     onInstallSuccess,
+    onUpdateSuccess,
   }), [integrationObj, consumerRef, consumerName, groupRef,
-    groupName, installation, setInstallation, resetInstallations, onInstallSuccess]);
+    groupName, installation, setInstallation, resetInstallations, onInstallSuccess, onUpdateSuccess]);
 
   const errorMessage = `Error retrieving installation information for integration "${integrationObj?.name || 'unknown'}"`;
 


### PR DESCRIPTION
### Summary
adds support for onUpdateSuccess callback when update installation is successful. 
- supports read and write update installation

#### demo
![onUpdateSucess-install-integration](https://github.com/amp-labs/react/assets/5396828/e9d190d8-fa91-4081-9075-88356a64e230)


