### PR TITLE
fix: assumptions around process.env and typos

### DIFF
--- a/src/components/Configure/nav/ObjectManagementNav/UninstallInstallation.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/UninstallInstallation.tsx
@@ -9,7 +9,7 @@ interface NavObjectItemProps {
   text?: string;
 }
 
-export const UNINSTALL_INSTALLATION_CONST = 'uninstall-intallation';
+export const UNINSTALL_INSTALLATION_CONST = 'uninstall-installation';
 
 export const UninstallInstallation = forwardRef<HTMLButtonElement, NavObjectItemProps>(
   ({ text = 'Uninstall' }, ref) => {

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -122,7 +122,7 @@ export function ObjectManagementNav({
                 <>
                   <Divider marginTop={10} marginBottom={3} />
                   <UninstallInstallation
-                    key="uninstall-intallation"
+                    key="uninstall-installation"
                     text="Uninstall"
                   />
                 </>

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -30,7 +30,7 @@ export function isIntegrationFieldMapping(field: HydratedIntegrationField):
 /**
  *
  * @param action HydratedIntegrationAction
- * @param objectName string (account, contect, etc...)
+ * @param objectName string (account, contact, etc...)
  * @returns HydratedIntegrationObject | null
  */
 export function getStandardObjectFromAction(action: HydratedIntegrationRead, objectName: string)
@@ -73,7 +73,7 @@ export function getFieldKeyValue(field: HydratedIntegrationField): string {
   if (isIntegrationFieldMapping(field)) {
     return field.mapToName; // custom mapping
   }
-  return field.fieldName; // existant field
+  return field.fieldName; // existent field
 }
 
 /**

--- a/src/components/RedirectHandler/RedirectHandler.tsx
+++ b/src/components/RedirectHandler/RedirectHandler.tsx
@@ -10,7 +10,7 @@ type RedirectHandlerProps = {
 
 /**
  * RedirectHandler is a component that redirects to a specified URL when mounted or
- * will render the childen if no redirect URL is present.
+ * will render the children if no redirect URL is present.
  *
  * @param redirectURL
  * @param children

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -37,7 +37,7 @@ import { ApiService } from './ApiService';
 const VERSION = 'v1';
 
 function getApiEndpoint(): string {
-  switch (process.env?.REACT_APP_AMP_SERVER) {
+  switch (process?.env?.REACT_APP_AMP_SERVER) {
     case 'local':
       return 'http://localhost:8080';
     case 'dev':
@@ -53,7 +53,7 @@ function getApiEndpoint(): string {
     default:
       // The user may provide an arbitrary URL here if they want to, or else the
       // default prod url will be used.
-      return process.env?.REACT_APP_AMP_SERVER ?? 'https://api.withampersand.com';
+      return process?.env?.REACT_APP_AMP_SERVER ?? 'https://api.withampersand.com';
   }
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -48,6 +48,8 @@ function getApiEndpoint(): string {
       return 'https://api.withampersand.com';
     case 'mock':
       return 'http://127.0.0.1:4010';
+    case '':
+      return 'https://api.withampersand.com';
     default:
       // The user may provide an arbitrary URL here if they want to, or else the
       // default prod url will be used.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -48,8 +48,6 @@ function getApiEndpoint(): string {
       return 'https://api.withampersand.com';
     case 'mock':
       return 'http://127.0.0.1:4010';
-    case '':
-      return 'https://api.withampersand.com';
     default:
       // The user may provide an arbitrary URL here if they want to, or else the
       // default prod url will be used.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -37,7 +37,7 @@ import { ApiService } from './ApiService';
 const VERSION = 'v1';
 
 function getApiEndpoint(): string {
-  switch (process.env.REACT_APP_AMP_SERVER) {
+  switch (process.env?.REACT_APP_AMP_SERVER) {
     case 'local':
       return 'http://localhost:8080';
     case 'dev':
@@ -53,7 +53,7 @@ function getApiEndpoint(): string {
     default:
       // The user may provide an arbitrary URL here if they want to, or else the
       // default prod url will be used.
-      return process.env.REACT_APP_AMP_SERVER ?? 'https://api.withampersand.com';
+      return process.env?.REACT_APP_AMP_SERVER ?? 'https://api.withampersand.com';
   }
 }
 


### PR DESCRIPTION
Without special framework polyfilling, the react component doesn't work because of it's assumption that `process.env` exists. This PR fixes this as well as some typos I found.