### PR TITLE
[ENG-654] feat: add conditional proxy layout

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -6,6 +6,7 @@ import { Config } from '../../services/api';
 import { ErrorTextBox } from '../ErrorTextBox';
 
 import { InstallationContent } from './content/InstallationContent';
+import { ConditionalProxyLayout } from './layout/ConditionalProxyLayout';
 import { ProtectedConnectionLayout } from './layout/ProtectedConnectionLayout';
 import { ObjectManagementNav } from './nav/ObjectManagementNav';
 import { ConfigurationProvider } from './state/ConfigurationStateProvider';
@@ -51,11 +52,13 @@ export function InstallIntegration(
           groupName={groupName}
         >
           <HydratedRevisionProvider projectId={projectId}>
-            <ConfigurationProvider>
-              <ObjectManagementNav>
-                <InstallationContent />
-              </ObjectManagementNav>
-            </ConfigurationProvider>
+            <ConditionalProxyLayout>
+              <ConfigurationProvider>
+                <ObjectManagementNav>
+                  <InstallationContent />
+                </ObjectManagementNav>
+              </ConfigurationProvider>
+            </ConditionalProxyLayout>
           </HydratedRevisionProvider>
         </ProtectedConnectionLayout>
       </ConnectionsProvider>

--- a/src/components/Configure/layout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout.tsx
@@ -1,0 +1,25 @@
+import { LoadingIcon } from '../../../assets/LoadingIcon';
+import { useHydratedRevision } from '../state/HydratedRevisionContext';
+
+interface ConditionalProxyLayoutProps {
+  children: React.ReactNode;
+}
+
+/**
+ * if the hydratedRevision does not have read or write,
+ * then it will not render the ConfigureInstallation
+ * @returns
+ */
+export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps) {
+  const { hydratedRevision, loading } = useHydratedRevision();
+  const isProxy = !hydratedRevision?.content.read && hydratedRevision?.content.write;
+
+  if (loading) return <LoadingIcon />;
+  if (isProxy) return <div>Proxy Success</div>;
+
+  return (
+    <div>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
### Summary 
We need control logic to allow `<InstallIntegration/>` to skip configuration step if an installation only has proxy actions. This control sequence should activate if no read and no write is present in the hydratedRevision, but proxy actions also occur.

This PR creates the layout based which future PR's will 
- [x] **add conditional layout render for proxy support** 
- [ ] add the `SuccessTextBox`
- [ ] add control logic for only proxy present
- [ ] add the createInstallation call