### PR TITLE
[ENG-733] fix: process.env.variable reference

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -35,15 +35,12 @@ import { ApiService } from './ApiService';
    *
    * */
 const VERSION = 'v1';
+const prodEndpoint = 'https://api.withampersand.com';
 
 function getApiEndpoint(): string {
-  const prodEndpoint = 'https://api.withampersand.com';
+  const ENV_SERVER = process.env.REACT_APP_AMP_SERVER || 'prod';
 
-  if (typeof process === 'undefined') {
-    return prodEndpoint;
-  }
-
-  switch (process?.env?.REACT_APP_AMP_SERVER) {
+  switch (ENV_SERVER) {
     case 'local':
       return 'http://localhost:8080';
     case 'dev':

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -38,25 +38,28 @@ const VERSION = 'v1';
 const prodEndpoint = 'https://api.withampersand.com';
 
 function getApiEndpoint(): string {
-  const ENV_SERVER = process.env.REACT_APP_AMP_SERVER || 'prod';
-
-  switch (ENV_SERVER) {
-    case 'local':
-      return 'http://localhost:8080';
-    case 'dev':
-      return 'https://dev-api.withampersand.com';
-    case 'staging':
-      return 'https://staging-api.withampersand.com';
-    case 'prod':
-      return prodEndpoint;
-    case 'mock':
-      return 'http://127.0.0.1:4010';
-    case '':
-      return prodEndpoint;
-    default:
-      // The user may provide an arbitrary URL here if they want to, or else the
-      // default prod url will be used.
-      return process?.env?.REACT_APP_AMP_SERVER ?? prodEndpoint;
+  try {
+    const ENV_SERVER = process.env.REACT_APP_AMP_SERVER;
+    switch (ENV_SERVER) {
+      case 'local':
+        return 'http://localhost:8080';
+      case 'dev':
+        return 'https://dev-api.withampersand.com';
+      case 'staging':
+        return 'https://staging-api.withampersand.com';
+      case 'prod':
+        return prodEndpoint;
+      case 'mock':
+        return 'http://127.0.0.1:4010';
+      case '':
+        return prodEndpoint;
+      default:
+        // The user may provide an arbitrary URL here if they want to, or else the
+        // default prod url will be used.
+        return ENV_SERVER ?? prodEndpoint;
+    }
+  } catch (e) {
+    return prodEndpoint;
   }
 }
 


### PR DESCRIPTION
### bug
process is always undefined, current fix breaks local server development. 

### solution
we add try catch block to read env or return prod url if evaluation fails. not tested in embedded client yet. 





