### PR TITLE
fix: infinite loop if empty configuration state

### DIFF
--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -24,7 +24,7 @@ export const useMutateInstallation = () => {
   const {
     resetConfigureState, objectConfigurationsState, resetPendingConfigurationState,
   } = useObjectsConfigureState();
-  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState ?? {});
 
   return {
     integrationId,

--- a/src/components/Configure/content/useSelectedConfigureState.tsx
+++ b/src/components/Configure/content/useSelectedConfigureState.tsx
@@ -11,7 +11,7 @@ export const useSelectedConfigureState = () => {
   const { appName } = useProject();
   const { objectConfigurationsState, setConfigureState } = useObjectsConfigureState();
   const { selectedObjectName } = useSelectedObjectName();
-  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
+  const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState ?? {});
 
   return {
     appName,

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -99,8 +99,8 @@ export function ObjectManagementNav({
                   objectName={object.name}
                   completed={object.completed}
                   pending={
-                    objectConfigurationsState[object.name]?.read?.isOptionalFieldsModified
-                    || objectConfigurationsState[object.name]?.read?.isRequiredMapFieldsModified
+                    objectConfigurationsState?.[object.name]?.read?.isOptionalFieldsModified
+                    || objectConfigurationsState?.[object.name]?.read?.isRequiredMapFieldsModified
                   }
                 />
               ))}

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -13,14 +13,12 @@ import {
 } from './utils';
 // Create a context for the configuration state
 export const ConfigurationContext = createContext<{
-  objectConfigurationsState: ObjectConfigurationsState;
-  setObjectConfigurationsState: React.Dispatch<React.SetStateAction<ObjectConfigurationsState>>;
+  objectConfigurationsState: ObjectConfigurationsState | null;
+  setObjectConfigurationsState: React.Dispatch<React.SetStateAction<ObjectConfigurationsState | null>>;
   setConfigureState:(objectName: string, producer: (draft: Draft<ConfigureState>) => void,) => void;
   resetConfigureState:(objectName: string, configureState: ConfigureState) => void;
   resetPendingConfigurationState:(objectName: string) => void;
 } | undefined>(undefined);
-
-const initialObjectConfigurationsState: ObjectConfigurationsState = {};
 
 /**
  * Custom hook to access and update the configuration state for all objects
@@ -51,14 +49,13 @@ export function ConfigurationProvider(
   const [
     objectConfigurationsState,
     setObjectConfigurationsState,
-  ] = useState<ObjectConfigurationsState>(initialObjectConfigurationsState);
+  ] = useState<ObjectConfigurationsState | null>(null);
   const config = installation?.config;
 
   useEffect(() => {
     // set configurationState when hydratedRevision is loaded
     // only reset when objectConfigurationsState does not exist
-    if (hydratedRevision?.content && !loading
-      && config && !(Object.entries(objectConfigurationsState).length > 0)) {
+    if (hydratedRevision?.content && !loading && config && objectConfigurationsState === null) {
       resetAllObjectsConfigurationState(
         hydratedRevision,
         config,
@@ -74,6 +71,7 @@ export function ConfigurationProvider(
   ) => {
     // consider moving check modified state here
     setObjectConfigurationsState((currentState) => produce(currentState, (draft) => {
+      if (!draft) return;
       // immer exception when mutating a draft
       // eslint-disable-next-line no-param-reassign
       draft[objectName] = produce(draft[objectName], producer);
@@ -86,8 +84,9 @@ export function ConfigurationProvider(
     configureState: ConfigureState,
   ) => {
     setObjectConfigurationsState((currentState) => produce(currentState, (draft) => {
-    // immer exception when mutating a draft
-    // eslint-disable-next-line no-param-reassign
+      if (!draft) return;
+      // immer exception when mutating a draft
+      // eslint-disable-next-line no-param-reassign
       draft[objectName] = configureState;
     }));
   }, [setObjectConfigurationsState]);
@@ -95,6 +94,7 @@ export function ConfigurationProvider(
   const resetWritePendingConfigurationState = useCallback(() => {
     setObjectConfigurationsState(
       produce((draft) => {
+        if (!draft) return;
         const writeDraft = draft.other.write;
         if (writeDraft) {
           writeDraft.isWriteModified = false;
@@ -106,6 +106,7 @@ export function ConfigurationProvider(
   const resetReadPendingConfigurationState = useCallback((objectName: string) => {
     setObjectConfigurationsState(
       produce((draft) => {
+        if (!draft) return;
         const readDraft = draft[objectName]?.read;
         if (readDraft) {
           readDraft.isOptionalFieldsModified = false;

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -133,7 +133,7 @@ export const setHydrateConfigState = (
 export const resetAllObjectsConfigurationState = (
   hydratedRevision: HydratedRevision,
   config: Config | undefined,
-  setObjectConfiguresState: React.Dispatch<React.SetStateAction<ObjectConfigurationsState>>,
+  setObjectConfiguresState: React.Dispatch<React.SetStateAction<ObjectConfigurationsState | null>>,
 ) => {
   const navObjects = generateNavObjects(config, hydratedRevision);
   const objectConfigurationsState: ObjectConfigurationsState = {};


### PR DESCRIPTION
If the user had a configuration that was empty, we would break react by creating an infinite loop. This has been resolved by adding a "null" state to differentiate between an unloaded object and an empty loaded object.