### PR TITLE
[ENG-732] feat: support proxy enabled read / write

### DIFF
--- a/src/components/Configure/actions/proxy/isProxyEnabled.ts
+++ b/src/components/Configure/actions/proxy/isProxyEnabled.ts
@@ -1,0 +1,5 @@
+import { HydratedRevision } from '../../../../services/api';
+
+export function getIsProxyEnabled(hydratedRevision: HydratedRevision) {
+  return hydratedRevision.content.proxy?.enabled;
+}

--- a/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
@@ -76,6 +76,12 @@ const generateCreateReadConfigFromConfigureState = (
     },
   };
 
+  // insert proxy into config if it is enabled
+  const isProxyEnabled = hydratedRevision.content.proxy?.enabled;
+  if (isProxyEnabled) {
+    createConfigObj.content.proxy = { enabled: true };
+  }
+
   return createConfigObj;
 };
 

--- a/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
@@ -9,6 +9,7 @@ import {
 } from '../../state/utils';
 import { ConfigureState } from '../../types';
 import { createInstallationAndSetState } from '../mutateAndSetState/createInstallationAndSetState';
+import { getIsProxyEnabled } from '../proxy/isProxyEnabled';
 /**
  * gets matching object from hydratedRevision
  * @param hydratedRevision
@@ -77,7 +78,7 @@ const generateCreateReadConfigFromConfigureState = (
   };
 
   // insert proxy into config if it is enabled
-  const isProxyEnabled = hydratedRevision.content.proxy?.enabled;
+  const isProxyEnabled = getIsProxyEnabled(hydratedRevision);
   if (isProxyEnabled) {
     createConfigObj.content.proxy = { enabled: true };
   }

--- a/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
@@ -11,6 +11,7 @@ import {
 } from '../../state/utils';
 import { ConfigureState } from '../../types';
 import { updateInstallationAndSetState } from '../mutateAndSetState/updateInstallationAndSetState';
+import { getIsProxyEnabled } from '../proxy/isProxyEnabled';
 
 /**
  * given a configureState, config, and objectName, generate the config object that is need for
@@ -59,7 +60,7 @@ const generateUpdateReadConfigFromConfigureState = (
   };
 
   // insert proxy into config if it is enabled
-  const isProxyEnabled = hydratedRevision?.content?.proxy?.enabled;
+  const isProxyEnabled = getIsProxyEnabled(hydratedRevision);
 
   if (isProxyEnabled) {
     if (!updateConfigObject.content) updateConfigObject.content = {};

--- a/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
@@ -1,6 +1,7 @@
 import {
   Config,
   HydratedIntegrationObject,
+  HydratedRevision,
   Installation,
   UpdateInstallationRequestInstallationConfig,
 } from '../../../../services/api';
@@ -32,6 +33,7 @@ const generateUpdateReadConfigFromConfigureState = (
   objectName: string,
   hydratedObject: HydratedIntegrationObject,
   schedule: string,
+  hydratedRevision: HydratedRevision,
 ): UpdateInstallationRequestInstallationConfig => {
   const selectedFields = generateSelectedFieldsFromConfigureState(configureState);
   const selectedFieldMappings = generateSelectedFieldMappingsFromConfigureState(
@@ -56,6 +58,14 @@ const generateUpdateReadConfigFromConfigureState = (
     },
   };
 
+  // insert proxy into config if it is enabled
+  const isProxyEnabled = hydratedRevision?.content?.proxy?.enabled;
+
+  if (isProxyEnabled) {
+    if (!updateConfigObject.content) updateConfigObject.content = {};
+    updateConfigObject.content.proxy = { enabled: true };
+  }
+
   return updateConfigObject;
 };
 
@@ -68,6 +78,7 @@ export const onSaveReadUpdateInstallation = (
   configureState: ConfigureState,
   setInstallation: (installationObj: Installation) => void,
   hydratedObject: HydratedIntegrationObject,
+  hydratedRevision: HydratedRevision,
   onUpdateSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   // get configuration state
@@ -77,6 +88,7 @@ export const onSaveReadUpdateInstallation = (
     selectedObjectName || '',
     hydratedObject,
     hydratedObject.schedule,
+    hydratedRevision,
   );
 
   if (!updateConfig) {

--- a/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../services/api';
 import { ConfigureState } from '../../types';
 import { createInstallationAndSetState } from '../mutateAndSetState/createInstallationAndSetState';
+import { getIsProxyEnabled } from '../proxy/isProxyEnabled';
 
 import { generateConfigWriteObjects } from './generateConfigWriteObjects';
 
@@ -56,7 +57,8 @@ const generateCreateWriteConfigFromConfigureState = (
     createdBy: `consumer:${consumerRef}`,
     content: {
       provider: hydratedRevision.content.provider,
-      // need empty read.standardObjects for update read
+      // hack: need empty read.standardObjects to be initialized for update read
+      // https://linear.app/ampersand/issue/ENG-780/bug-write-createupdate-installation-without-read
       read: {
         standardObjects: {},
       },
@@ -67,7 +69,7 @@ const generateCreateWriteConfigFromConfigureState = (
   };
 
   // insert proxy into config if it is enabled
-  const isProxyEnabled = hydratedRevision.content.proxy?.enabled;
+  const isProxyEnabled = getIsProxyEnabled(hydratedRevision);
   if (isProxyEnabled) {
     createConfigObj.content.proxy = { enabled: true };
   }

--- a/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
@@ -66,6 +66,12 @@ const generateCreateWriteConfigFromConfigureState = (
     },
   };
 
+  // insert proxy into config if it is enabled
+  const isProxyEnabled = hydratedRevision.content.proxy?.enabled;
+  if (isProxyEnabled) {
+    createConfigObj.content.proxy = { enabled: true };
+  }
+
   return createConfigObj;
 };
 

--- a/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
@@ -1,6 +1,7 @@
 import {
   api,
   Config,
+  HydratedRevision,
   Installation,
   UpdateInstallationOperationRequest,
   UpdateInstallationRequestInstallationConfig,
@@ -20,6 +21,7 @@ import {
    */
 const generateUpdateWriteConfigFromConfigureState = (
   configureState: ConfigureState,
+  hydratedRevision: HydratedRevision,
 ): UpdateInstallationRequestInstallationConfig => {
   const configWriteObjects = generateConfigWriteObjects(configureState);
 
@@ -32,6 +34,13 @@ const generateUpdateWriteConfigFromConfigureState = (
     },
   };
 
+  // insert proxy into config if it is enabled
+  const isProxyEnabled = hydratedRevision.content.proxy?.enabled;
+  if (isProxyEnabled) {
+    if (!updateConfigObject.content) updateConfigObject.content = {};
+    updateConfigObject.content.proxy = { enabled: true };
+  }
+
   return updateConfigObject;
 };
 
@@ -41,12 +50,13 @@ export const onSaveWriteUpdateInstallation = (
   installationId: string,
   apiKey: string,
   configureState: ConfigureState,
+  hydratedRevision: HydratedRevision,
   setInstallation: (installationObj: Installation) => void,
   onUpdateSuccess?: (installationId: string, config: Config) => void,
 ): Promise<void | null> => {
   // get configuration state
   // transform configuration state to update shape
-  const updateConfig = generateUpdateWriteConfigFromConfigureState(configureState);
+  const updateConfig = generateUpdateWriteConfigFromConfigureState(configureState, hydratedRevision);
 
   if (!updateConfig) {
     console.error('Error when generating write updateConfig from configureState');

--- a/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
@@ -7,6 +7,7 @@ import {
   UpdateInstallationRequestInstallationConfig,
 } from '../../../../services/api';
 import { ConfigureState } from '../../types';
+import { getIsProxyEnabled } from '../proxy/isProxyEnabled';
 
 import {
   generateConfigWriteObjects,
@@ -35,7 +36,7 @@ const generateUpdateWriteConfigFromConfigureState = (
   };
 
   // insert proxy into config if it is enabled
-  const isProxyEnabled = hydratedRevision.content.proxy?.enabled;
+  const isProxyEnabled = getIsProxyEnabled(hydratedRevision);
   if (isProxyEnabled) {
     if (!updateConfigObject.content) updateConfigObject.content = {};
     updateConfigObject.content.proxy = { enabled: true };

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -107,7 +107,7 @@ export function UpdateInstallation(
   };
 
   const onSaveWrite = () => {
-    if (installation && selectedObjectName && apiKey && projectId) {
+    if (installation && selectedObjectName && apiKey && projectId && hydratedRevision) {
       setLoadingState(true);
       const res = onSaveWriteUpdateInstallation(
         projectId,
@@ -115,6 +115,7 @@ export function UpdateInstallation(
         installation.id,
         apiKey,
         configureState,
+        hydratedRevision,
         setInstallation,
         onUpdateSuccess,
       );

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -82,7 +82,7 @@ export function UpdateInstallation(
       return;
     }
 
-    if (installation && selectedObjectName && apiKey && projectId && hydratedObject) {
+    if (hydratedRevision && installation && selectedObjectName && apiKey && projectId && hydratedObject) {
       setLoadingState(true);
       const res = onSaveReadUpdateInstallation(
         projectId,
@@ -93,6 +93,7 @@ export function UpdateInstallation(
         configureState,
         setInstallation,
         hydratedObject,
+        hydratedRevision,
         onUpdateSuccess,
       );
 


### PR DESCRIPTION
### Summary
We need to support proxy when read and write are configured. 8 cases of combinations to be supported
- support **read create installation** with/without proxy enabled
- support **write create installation** with/without proxy
- support **read update installation** with/without proxy
- support **write update installation** with/without proxy

#### Demo
UI should have no visible changes

#### Tested 
- locally: read/write create/update with proxy. 
- production: read/write create/update without proxy.