### PR TITLE
[ENG-831] feat: automatically add a few headers to client calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "jest",
     "watch": "npm run prepbuild && tsc -p tsconfig.json --watch",
     "build": "npm run prepbuild && tsc -p tsconfig.json",
-    "prepbuild": "npm run clean",
+    "prepbuild": "npm run clean && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" | sed \"s|\\\"|'|g\" > src/services/version.ts",
     "clean": "rm -rf ./build/",
     "assets": "mkdir ./build/ && cp -R ./src/public/ ./build/public/",
     "lint": "eslint --ext .ts,.tsx -c .eslintrc.cjs src/ --fix",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,6 +21,7 @@ import {
 } from '../../generated-sources/api/src';
 
 import { ApiService } from './ApiService';
+import { LIB_VERSION } from './version';
 
 /**
    * To update the api you need to
@@ -83,6 +84,10 @@ export const AMP_API_ROOT = assignRoot();
 
 const config = new Configuration({
   basePath: AMP_API_ROOT,
+  headers: {
+    'X-Amp-Client': 'react',
+    'X-Amp-Client-Version': LIB_VERSION,
+  },
 });
 
 let apiValue = new ApiService(config);

--- a/src/services/version.ts
+++ b/src/services/version.ts
@@ -1,0 +1,1 @@
+export const LIB_VERSION = 'git';


### PR DESCRIPTION
NOTE: I wrote this to match the header names being sent by the cli application. It's important to keep the names consistent.

Once we have our UI libraries out in the wild, we want to keep track of the versions that are still being used. Similar to how the CLI always adds a header to indicate which CLI version made an API call, we should do the same in the React SDK. 

The first task here is the centralize how API request are made in the UI library, we probably need to introduce a uesAPI method [similar to the one in the Console](https://github.com/amp-labs/client/blob/07032b2469b1d60d19369a0bfd2d5cef8136e157/src/data/api.ts#L13), then that method can always add the following headers:

X-Amp-Client-Application : React

alternatives: X-Amp-Client-Platform, X-Amp-Client-Flavor, X-Amp-Client-Framework

X-Amp-Client-Version (See https://stackoverflow.com/questions/41123631/how-to-get-the-version-from-the-package-json-in-typescript for one way to get the version number of the SDK)