### PR TITLE
fix: remove headers from api service

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -84,10 +84,6 @@ export const AMP_API_ROOT = assignRoot();
 
 const config = new Configuration({
   basePath: AMP_API_ROOT,
-  headers: {
-    'X-Amp-Client': 'react',
-    'X-Amp-Client-Version': LIB_VERSION,
-  },
 });
 
 let apiValue = new ApiService(config);


### PR DESCRIPTION
### Summary
logging into mailmonkey has been broken.
- removes headers that do not work for the oauth requests

`
Access to fetch at 'https://dev-api.withampersand.com/v1/oauth-connect' from origin 'http://localhost:3001' has been blocked by CORS policy: Request header field x-amp-client is not allowed by Access-Control-Allow-Headers in preflight response.
`

<img width="1434" alt="Screenshot 2024-04-03 at 3 19 17 PM" src="https://github.com/amp-labs/react/assets/5396828/319c586f-8cfd-40f0-86ab-fe2836b579a5">


#### Ticket
[ENG-831] - tracks this issue.

