### PR TITLE
[ENG-930, ENG-932] feat: add generic WorkspaceOauthFlow component 

### DIFF
--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -6,6 +6,9 @@ import { useInstallIntegrationProps } from '../../../context/InstallIntegrationC
 import { useConnectionHandler } from '../../Connect/useConnectionHandler';
 import { NoSubdomainOauthFlow } from '../../Oauth/NoSubdomainEntry/NoSubdomainOauthFlow';
 import { SalesforceOauthFlow } from '../../Oauth/Salesforce/SalesforceOauthFlow';
+import { WorkspaceOauthFlow } from '../../Oauth/WorkspaceEntry/WorkspaceOauthFlow';
+
+const GENERIC_WORKSPACE_FEATURE_FLAG = false;
 
 interface ProtectedConnectionLayoutProps {
   provider?: string,
@@ -16,6 +19,7 @@ interface ProtectedConnectionLayoutProps {
   onSuccess?: (connectionID: string) => void;
   children: JSX.Element,
 }
+
 export function ProtectedConnectionLayout({
   provider, consumerRef, consumerName, groupRef, groupName, children, onSuccess,
 }: ProtectedConnectionLayoutProps) {
@@ -37,6 +41,18 @@ export function ProtectedConnectionLayout({
   if (selectedConnection) return children;
 
   const selectedProvider = provider || providerFromProps;
+
+  if (GENERIC_WORKSPACE_FEATURE_FLAG && selectedProvider === PROVIDER_SALESFORCE) {
+    return (
+      <WorkspaceOauthFlow
+        provider={selectedProvider}
+        consumerRef={consumerRef}
+        consumerName={consumerName}
+        groupRef={groupRef}
+        groupName={groupName}
+      />
+    );
+  }
 
   if (selectedProvider === PROVIDER_SALESFORCE) {
     return (

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceEntry.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceEntry.tsx
@@ -1,28 +1,22 @@
-import { ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   Box, Button, Container, Flex, FormControl,
-  FormLabel, Heading, Input, Link, Text,
+  FormLabel, Heading, Input,
 } from '@chakra-ui/react';
 
+import { capitalize } from '../../../utils';
 import { OAuthErrorAlert } from '../OAuthErrorAlert';
 
-const SALESFORCE_HELP_URL = 'https://help.salesforce.com/s/articleView?id=sf.faq_domain_name_what.htm&type=5';
-
-type SubdomainEntryProps = {
+type WorkspaceEntryProps = {
+  provider: string,
   handleSubmit: () => void;
   setWorkspace: (workspace: string) => void;
   error: string | null;
   isButtonDisabled?: boolean;
 };
 
-/**
- * Salesforce specific subdomain entry component, use workspace entry for other providers.
- * @param param0
- * @returns
- */
-export function SubdomainEntry({
-  handleSubmit, setWorkspace, error, isButtonDisabled,
-}: SubdomainEntryProps) {
+export function WorkspaceEntry({
+  provider, handleSubmit, setWorkspace, error, isButtonDisabled,
+}: WorkspaceEntryProps) {
   return (
     <Container>
       <Box
@@ -38,19 +32,14 @@ export function SubdomainEntry({
       >
         <FormControl>
           <FormLabel marginTop="16" marginBottom="0">
-            <Heading as="h4" size="md">Enter your Salesforce subdomain</Heading>
+            <Heading as="h4" size="md">Enter your {capitalize(provider)} workspace</Heading>
           </FormLabel>
-          <Link href={SALESFORCE_HELP_URL} color="blackAlpha.600" isExternal>
-            What is my Salesforce subdomain?
-            <ExternalLinkIcon mx="2px" />
-          </Link>
           <OAuthErrorAlert error={error} />
           <Flex marginTop="1em">
             <Input
-              placeholder="MyDomain"
+              placeholder="MyWorkspace"
               onChange={(event) => setWorkspace(event.currentTarget.value)}
             />
-            <Text lineHeight="2.2em" marginLeft="0.4em">.my.salesforce.com</Text>
           </Flex>
           <br />
           <Button

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -1,0 +1,80 @@
+/**
+ * OAuth flow for any providers that do not require the consumer to enter a subdomain first.
+ */
+
+import { useCallback, useState } from 'react';
+
+import { useApiKey } from '../../../context/ApiKeyContextProvider';
+import { useProject } from '../../../context/ProjectContextProvider';
+import { capitalize } from '../../../utils';
+import { fetchOAuthCallbackURL } from '../fetchOAuthCallbackURL';
+import OAuthPopup from '../OAuthPopup';
+
+import { WorkspaceEntry } from './WorkspaceEntry';
+
+interface NoSubdomainOauthFlowProps {
+  provider: string;
+  consumerRef: string;
+  consumerName?: string;
+  groupRef: string;
+  groupName?: string;
+}
+
+/**
+ * WorkspaceEntry is generic for any provider that requires a workspace to be entered first,
+ * then launches a popup with the OAuth flow.
+ */
+export function WorkspaceOauthFlow({
+  provider, consumerRef, consumerName, groupRef, groupName,
+}: NoSubdomainOauthFlowProps) {
+  const { projectId } = useProject();
+  const apiKey = useApiKey();
+
+  const [workspace, setWorkspace] = useState<string>('');
+  const [oAuthCallbackURL, setOAuthCallbackURL] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  //  fetch OAuth callback URL from connection so that oath popup can be launched
+  const handleSubmit = async () => {
+    setError(null);
+    if (consumerName && groupName && apiKey && workspace) {
+      try {
+        const url = await fetchOAuthCallbackURL(
+          projectId,
+          consumerRef,
+          groupRef,
+          consumerName,
+          groupName,
+          apiKey,
+          provider,
+          workspace,
+        );
+        setOAuthCallbackURL(url);
+      } catch (err: any) {
+        console.error(err);
+        setError(err?.message ?? 'Unexpected error');
+      }
+    }
+  };
+
+  const onClose = useCallback((err: string | null) => {
+    setError(err);
+    setOAuthCallbackURL(null);
+  }, []);
+
+  return (
+    <OAuthPopup
+      title={`Connect to ${capitalize(provider)}`}
+      url={oAuthCallbackURL}
+      onClose={onClose}
+    >
+      <WorkspaceEntry
+        provider={provider}
+        handleSubmit={handleSubmit}
+        setWorkspace={setWorkspace}
+        error={error}
+        isButtonDisabled={workspace.length === 0}
+      />
+    </OAuthPopup>
+  );
+}


### PR DESCRIPTION
### Summary
We want to support generic providers that require workspaces. We will keep parts of the SalesforceEntry as having a custom entry for large provider may prove useful.
- add `WorkspaceEntry` component
- adds `WorkspaceOauthFlow` and feature flag

#### demo
When we turn on the flag, salesforce will use the generic WorkspaceEntryFlow component instead of the existing custom flow. 

![workspace-entry-demo](https://github.com/amp-labs/react/assets/5396828/51bc0eef-1bb9-44bf-bd82-825be526951c)

#### followup
Some of the forms can be refactored and deleted so there is less copy pasted styles.

