### PR TITLE
[ENG-931] refactor: Oauthflow logic from ProtectedConnectionLayout

### DIFF
--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -1,14 +1,9 @@
 import { useEffect } from 'react';
 
-import { PROVIDER_SALESFORCE } from '../../../constants';
 import { useConnections } from '../../../context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from '../../../context/InstallIntegrationContextProvider';
 import { useConnectionHandler } from '../../Connect/useConnectionHandler';
-import { NoSubdomainOauthFlow } from '../../Oauth/NoSubdomainEntry/NoSubdomainOauthFlow';
-import { SalesforceOauthFlow } from '../../Oauth/Salesforce/SalesforceOauthFlow';
-import { WorkspaceOauthFlow } from '../../Oauth/WorkspaceEntry/WorkspaceOauthFlow';
-
-const GENERIC_WORKSPACE_FEATURE_FLAG = false;
+import { OauthFlow } from '../../Oauth/OauthFlow/OauthFlow';
 
 interface ProtectedConnectionLayoutProps {
   provider?: string,
@@ -37,36 +32,14 @@ export function ProtectedConnectionLayout({
   if (!provider && !providerFromProps) {
     throw new Error('ProtectedConnectionLayout must be given a provider prop or be used within InstallIntegrationProvider');
   }
+
   // a selected connection exists, render children
   if (selectedConnection) return children;
 
   const selectedProvider = provider || providerFromProps;
 
-  if (GENERIC_WORKSPACE_FEATURE_FLAG && selectedProvider === PROVIDER_SALESFORCE) {
-    return (
-      <WorkspaceOauthFlow
-        provider={selectedProvider}
-        consumerRef={consumerRef}
-        consumerName={consumerName}
-        groupRef={groupRef}
-        groupName={groupName}
-      />
-    );
-  }
-
-  if (selectedProvider === PROVIDER_SALESFORCE) {
-    return (
-      <SalesforceOauthFlow
-        consumerRef={consumerRef}
-        consumerName={consumerName}
-        groupRef={groupRef}
-        groupName={groupName}
-      />
-    );
-  }
-
   return (
-    <NoSubdomainOauthFlow
+    <OauthFlow
       provider={selectedProvider}
       consumerRef={consumerRef}
       consumerName={consumerName}

--- a/src/components/Oauth/OauthFlow/OauthFlow.tsx
+++ b/src/components/Oauth/OauthFlow/OauthFlow.tsx
@@ -1,0 +1,51 @@
+import { PROVIDER_SALESFORCE } from '../../../constants';
+import { NoSubdomainOauthFlow } from '../NoSubdomainEntry/NoSubdomainOauthFlow';
+import { SalesforceOauthFlow } from '../Salesforce/SalesforceOauthFlow';
+import { WorkspaceOauthFlow } from '../WorkspaceEntry/WorkspaceOauthFlow';
+
+const GENERIC_WORKSPACE_FEATURE_FLAG = false;
+
+type OauthFlowProps = {
+  provider: string;
+  consumerRef: string;
+  consumerName?: string;
+  groupRef: string;
+  groupName?: string;
+};
+
+export function OauthFlow({
+  provider, consumerRef, consumerName, groupRef, groupName,
+}: OauthFlowProps) {
+  if (GENERIC_WORKSPACE_FEATURE_FLAG && provider === PROVIDER_SALESFORCE) {
+    return (
+      <WorkspaceOauthFlow
+        provider={provider}
+        consumerRef={consumerRef}
+        consumerName={consumerName}
+        groupRef={groupRef}
+        groupName={groupName}
+      />
+    );
+  }
+
+  if (provider === PROVIDER_SALESFORCE) {
+    return (
+      <SalesforceOauthFlow
+        consumerRef={consumerRef}
+        consumerName={consumerName}
+        groupRef={groupRef}
+        groupName={groupName}
+      />
+    );
+  }
+
+  return (
+    <NoSubdomainOauthFlow
+      provider={provider}
+      consumerRef={consumerRef}
+      consumerName={consumerName}
+      groupRef={groupRef}
+      groupName={groupName}
+    />
+  );
+}


### PR DESCRIPTION
### Summary
Separate the Oauth flow logic from the connections logic. We will be able to add our provider api calls and logic to choose which flow to render in this new component. 

preps for [ENG-931]

no visible UI changes to demo.