### PR TITLE
[ENG-726] ci: check that the project is buildable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,5 @@ jobs:
       run: yarn
     - name: Run linter
       run: yarn lint:dry
+    - name: Build project
+      run: yarn build


### PR DESCRIPTION
In #272, code that did not build (outside of my machine) managed to land in main because we didn't check that the code was buildable in the CI environment. This PR simply checks that the code is able to build correctly during linting.