### PR TITLE
[ENG-731] fix: styling issue with text color on white background

### DIFF
--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -82,6 +82,8 @@ export function ObjectManagementNav({
         display="flex"
         gap="6"
         minHeight="100%"
+        color="gray.800"
+        fontSize="md"
       >
         <Box width="20rem">
           <Text>{capitalize(provider)} integration</Text>

--- a/src/components/ErrorTextBox.tsx
+++ b/src/components/ErrorTextBox.tsx
@@ -37,7 +37,7 @@ export function ErrorTextBox({ message }: ErrorTextBoxProps) {
         border="2px solid #FECACA"
         background="#FEF2F2"
       >
-        <Text color="#991B1B">
+        <Text color="#991B1B" fontSize="md">
           {message}
         </Text>
       </Box>

--- a/src/components/Oauth/OauthCardLayout.tsx
+++ b/src/components/Oauth/OauthCardLayout.tsx
@@ -17,6 +17,7 @@ export function OauthCardLayout({ children }: OauthCardLayoutProps) {
         margin="auto"
         marginTop="40px"
         bgColor="white"
+        color="gray.800"
       >
         {children}
       </Box>

--- a/src/components/Oauth/OauthCardLayout.tsx
+++ b/src/components/Oauth/OauthCardLayout.tsx
@@ -18,6 +18,7 @@ export function OauthCardLayout({ children }: OauthCardLayoutProps) {
         marginTop="40px"
         bgColor="white"
         color="gray.800"
+        fontSize="md"
       >
         {children}
       </Box>

--- a/src/components/SuccessTextBox.tsx
+++ b/src/components/SuccessTextBox.tsx
@@ -19,6 +19,8 @@ export function SuccessTextBox({ text }: ConnectedSuccessBoxProps) {
         marginTop="40px"
         bgColor="white"
         paddingTop="100px"
+        color="gray.800"
+        fontSize="md"
       >
         <Box width="100%" display="flex" alignContent="center" justifyContent="center">
           <Box margin="auto"><SuccessCheckmarkIcon /></Box>


### PR DESCRIPTION
When embedders use @amp-labs/react, the styling of their website leaked into the components in such a way that text could appear invisible (white-on-white). 

Before:
<img width="1436" alt="image" src="https://github.com/amp-labs/react/assets/11367844/45bcdb8b-2a2e-41d5-9faf-33eb45a1c252">
<img width="1440" alt="image" src="https://github.com/amp-labs/react/assets/11367844/3198daa7-a70c-400e-a1a7-217a9e6e172f">

After:
<img width="1440" alt="image" src="https://github.com/amp-labs/react/assets/11367844/6599a6a1-b6af-418f-a5cb-bcb10487ae59">
<img width="1438" alt="image" src="https://github.com/amp-labs/react/assets/11367844/c3c8cd3e-137c-4f4a-b443-5f1fab3faea1">

