### PR TITLE
fix: allow groupName and consumerName to be optional

### DIFF
--- a/src/components/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -36,22 +36,21 @@ export function NoWorkspaceOauthFlow({
   //  fetch OAuth callback URL from connection so that oath popup can be launched
   const handleSubmit = async () => {
     setError(null);
-    if (consumerName && groupName && apiKey) {
-      try {
-        const url = await fetchOAuthCallbackURL(
-          projectId,
-          consumerRef,
-          groupRef,
-          consumerName,
-          groupName,
-          apiKey,
-          provider,
-        );
-        setOAuthCallbackURL(url);
-      } catch (err: any) {
-        console.error(err);
-        setError(err.message ?? 'Unexpected error');
-      }
+    try {
+      const url = await fetchOAuthCallbackURL(
+        projectId,
+        consumerRef,
+        groupRef,
+        apiKey,
+        provider,
+        undefined,
+        consumerName,
+        groupName,
+      );
+      setOAuthCallbackURL(url);
+    } catch (err: any) {
+      console.error(err);
+      setError(err.message ?? 'Unexpected error');
     }
   };
 

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -41,23 +41,22 @@ export function WorkspaceOauthFlow({
       setError('Workspace is required');
       return;
     }
-    if (consumerName && groupName && apiKey && workspace) {
-      try {
-        const url = await fetchOAuthCallbackURL(
-          projectId,
-          consumerRef,
-          groupRef,
-          consumerName,
-          groupName,
-          apiKey,
-          provider,
-          workspace,
-        );
-        setOAuthCallbackURL(url);
-      } catch (err: any) {
-        console.error(err);
-        setError(err?.message ?? 'Unexpected error');
-      }
+
+    try {
+      const url = await fetchOAuthCallbackURL(
+        projectId,
+        consumerRef,
+        groupRef,
+        apiKey,
+        provider,
+        workspace,
+        consumerName,
+        groupName,
+      );
+      setOAuthCallbackURL(url);
+    } catch (err: any) {
+      console.error(err);
+      setError(err?.message ?? 'Unexpected error');
     }
   };
 

--- a/src/components/Oauth/fetchOAuthCallbackURL.ts
+++ b/src/components/Oauth/fetchOAuthCallbackURL.ts
@@ -5,11 +5,11 @@ export const fetchOAuthCallbackURL = async (
   projectId: string,
   consumerRef: string,
   groupRef: string,
-  consumerName: string,
-  groupName: string,
   apiKey: string,
   provider: string,
   workspace?: string,
+  consumerName?: string,
+  groupName?: string,
 ): Promise<string> => {
   const providerApps = await api().providerAppApi.listProviderApps({ projectId }, {
     headers: { 'X-Api-Key': apiKey ?? '' },


### PR DESCRIPTION
### Summary
When component did not have `consumerName` the app failed to launch the Oauthflow. We remove the if checks and go to the try catch so errors will be handled in the catch loop. We also make `groupName` optional. 

#### testing
![Screenshot 2024-04-18 at 4 49 06 PM](https://github.com/amp-labs/react/assets/5396828/6d5340c3-1af1-4ecc-b8f6-c14aaff89bb2)
