### PR TITLE
fix: nav objects were not resetting write state on load

### DIFF
--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -11,7 +11,7 @@ import { capitalize } from '../../../../utils';
 import { useObjectsConfigureState } from '../../state/ConfigurationStateProvider';
 import { useHydratedRevision } from '../../state/HydratedRevisionContext';
 import { NavObject } from '../../types';
-import { generateNavObjects, generateOtherNavObject } from '../../utils';
+import { generateOtherNavObject, generateReadNavObjects } from '../../utils';
 
 import { NavObjectItem } from './NavObjectItem';
 import { OtherTab } from './OtherTab';
@@ -59,7 +59,7 @@ export function ObjectManagementNav({
 
   const appName = project?.appName || '';
   const config = installation?.config;
-  const readNavObjects = hydratedRevision && generateNavObjects(config, hydratedRevision);
+  const readNavObjects = hydratedRevision && generateReadNavObjects(config, hydratedRevision);
   const isNavObjectsReady = readNavObjects !== null; // null = hydratedRevision/config is not ready
 
   const isWriteSupported = !!hydratedRevision?.content?.write;

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -17,7 +17,7 @@ import {
   SelectOptionalFields,
 } from '../types';
 import {
-  generateNavObjects,
+  generateAllNavObjects,
   getFieldKeyValue, getOptionalFieldsFromObject,
   getRequiredFieldsFromObject, getRequiredMapFieldsFromObject,
   getStandardObjectFromAction,
@@ -135,7 +135,8 @@ export const resetAllObjectsConfigurationState = (
   config: Config | undefined,
   setObjectConfiguresState: React.Dispatch<React.SetStateAction<ObjectConfigurationsState>>,
 ) => {
-  const navObjects = generateNavObjects(config, hydratedRevision);
+  // read nav objects from hydrated revision
+  const navObjects = generateAllNavObjects(config, hydratedRevision);
   const objectConfigurationsState: ObjectConfigurationsState = {};
   navObjects.forEach(({ name, completed }) => {
     if (completed) {
@@ -146,6 +147,7 @@ export const resetAllObjectsConfigurationState = (
       );
     }
   });
+
   setObjectConfiguresState(objectConfigurationsState);
 };
 

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -82,7 +82,7 @@ export function getFieldKeyValue(field: HydratedIntegrationField): string {
  * @param hydratedRevision
  * @returns NavObject[]
  */
-const generateReadNavObjects = (config: Config | undefined, hydratedRevision: HydratedRevision) => {
+export const generateReadNavObjects = (config: Config | undefined, hydratedRevision: HydratedRevision) => {
   const navObjects: NavObject[] = [];
   hydratedRevision.content?.read?.standardObjects?.forEach((object) => {
     navObjects.push(
@@ -109,11 +109,14 @@ export const generateOtherNavObject = (
 };
 
 // generates standard objects and whether they are complete based on config and hydrated revision
-export function generateNavObjects(
+export function generateAllNavObjects(
   config: Config | undefined,
   hydratedRevision: HydratedRevision,
 ) {
   const navObjects: NavObject[] = generateReadNavObjects(config, hydratedRevision);
+  const isWriteSupported = !!hydratedRevision?.content?.write;
+  const otherNavObject = isWriteSupported ? generateOtherNavObject(config) : undefined;
+  if (otherNavObject) { navObjects.push(otherNavObject); }
   return navObjects;
 }
 


### PR DESCRIPTION
### Summary
Customer bug: when write is the only tab, the object state is not reset properly. 
Root problem: reseting state made a call to `generateNavObjects` which under the hood only fetched read nav objects. We rename this and also fetch all objects under the new function. We keep the nav objects separate for the tab divider in the left hand selector.

- changes tested under both `write only` (`writeSalesforceCustomObjects`) and `read and write`(`name:p0-i3`) salesforce integrations in dev.

#### Test on Dev
```
const projectId = '5e4f06ca-445f-43ea-943e-78465ee1bb7a';
const apiKey = 'TASW3OD2BOY252UQHFUK53FHHFDXBP6YHQFKN2A';
const integration = 'writeSalesforceCustomObjects'; 
```

#### Screenshot problem
<img width="953" alt="Screenshot 2024-04-23 at 3 59 00 PM" src="https://github.com/amp-labs/react/assets/5396828/c1fd92f9-ea1d-467f-be5e-2a15d091fa05">

#### Demo fixed when reloading window

![load-write-only](https://github.com/amp-labs/react/assets/5396828/7e89a64e-6d86-405b-8b6e-3e35906851a7)
