### PR TITLE
feat: add select all button to write fields

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -83,6 +83,7 @@ export function ConfigureInstallationBase(
             bgColor="white"
             maxHeight="100%"
             overflowY="scroll"
+            minHeight={300}
           >
             {loading && <LoadingIcon />}
             {hydratedRevision && !isUninstall && !isNonConfigurableWrite && <ReadFields />}

--- a/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
@@ -29,6 +29,9 @@ export function WriteFields() {
   };
 
   const shouldRender = !!(writeObjects);
+  const isAllChecked = Object.keys(selectedWriteFields || {}).length === configureState?.write?.writeObjects?.length;
+  const isIndeterminate = !isAllChecked && Object.keys(selectedWriteFields || {}).length > 0;
+
   return (
     shouldRender && (
       <>
@@ -42,13 +45,13 @@ export function WriteFields() {
           gap={0}
         >
           {(writeObjects?.length || 0) >= 2 && (
-          <Box backgroundColor="gray.100" paddingX={4} paddingTop={2}>
+          <Box backgroundColor="gray.50" paddingX={4} paddingY={2}>
             <Checkbox
               name="selectAll"
               id="selectAll"
               onChange={onSelectAllCheckboxChange}
-              isChecked={Object.keys(selectedWriteFields || {}).length === configureState?.write?.writeObjects?.length}
-              style={{ marginBottom: '10px' }}
+              isIndeterminate={isIndeterminate}
+              isChecked={isAllChecked}
             >
               Select all
             </Checkbox>

--- a/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
@@ -18,11 +18,29 @@ export function WriteFields() {
     }
   };
 
+  const onSelectAllCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { checked } = e.target;
+    if (selectedObjectName && configureState) {
+      configureState?.write?.writeObjects?.forEach((field) => {
+        setNonConfigurableWriteField(selectedObjectName, setConfigureState, field.objectName, checked);
+      });
+    }
+  };
+
   const shouldRender = !!(configureState?.write?.writeObjects);
   return (
     shouldRender && (
       <>
         <FieldHeader string={`Allow ${appName} to write to these object`} />
+        <Checkbox
+          name="selectAll"
+          id="selectAll"
+          onChange={onSelectAllCheckboxChange}
+          isChecked={Object.keys(selectedWriteFields || {}).length === configureState?.write?.writeObjects?.length}
+          style={{ marginBottom: '10px' }}
+        >
+          Select All Fields
+        </Checkbox>
         <Stack
           marginBottom={10}
           height={300}

--- a/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFields.tsx
@@ -10,6 +10,7 @@ export function WriteFields() {
     appName, selectedObjectName, configureState, setConfigureState,
   } = useSelectedConfigureState();
   const selectedWriteFields = configureState?.write?.selectedNonConfigurableWriteFields;
+  const writeObjects = configureState?.write?.writeObjects;
 
   const onCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = e.target;
@@ -27,30 +28,42 @@ export function WriteFields() {
     }
   };
 
-  const shouldRender = !!(configureState?.write?.writeObjects);
+  const shouldRender = !!(writeObjects);
   return (
     shouldRender && (
       <>
         <FieldHeader string={`Allow ${appName} to write to these object`} />
-        <Checkbox
-          name="selectAll"
-          id="selectAll"
-          onChange={onSelectAllCheckboxChange}
-          isChecked={Object.keys(selectedWriteFields || {}).length === configureState?.write?.writeObjects?.length}
-          style={{ marginBottom: '10px' }}
-        >
-          Select All Fields
-        </Checkbox>
         <Stack
           marginBottom={10}
-          height={300}
+          maxHeight={300}
           overflowY="scroll"
           border="2px solid #EFEFEF"
           borderRadius={8}
-          padding={4}
+          gap={0}
         >
-          {configureState?.write?.writeObjects?.map((field) => (
-            <Box key={field.objectName} display="flex" gap="5px" borderBottom="1px" borderColor="gray.100">
+          {(writeObjects?.length || 0) >= 2 && (
+          <Box backgroundColor="gray.100" paddingX={4} paddingTop={2}>
+            <Checkbox
+              name="selectAll"
+              id="selectAll"
+              onChange={onSelectAllCheckboxChange}
+              isChecked={Object.keys(selectedWriteFields || {}).length === configureState?.write?.writeObjects?.length}
+              style={{ marginBottom: '10px' }}
+            >
+              Select all
+            </Checkbox>
+          </Box>
+          )}
+          {writeObjects.map((field) => (
+            <Box
+              key={field.objectName}
+              display="flex"
+              alignItems="center"
+              borderBottom="1px"
+              borderColor="gray.100"
+              paddingX={4}
+              paddingY={2}
+            >
               <Checkbox
                 name={field.objectName}
                 id={field.objectName}
@@ -61,7 +74,6 @@ export function WriteFields() {
               </Checkbox>
             </Box>
           ))}
-
         </Stack>
       </>
     )


### PR DESCRIPTION
### Summary
Customer is asking to support select all support for write fields since there are a lot of fields. We add this option for 2 or more fields in selection
- adds select all functionality
- adds indeterminate state
- adds isAllChecked state
- modifies spacing so there is no awkward space in checkbox list and creates min height in outer box. 
- fix checkmark box styling and padding

#### demo
![select-all-support](https://github.com/amp-labs/react/assets/5396828/edc10f7f-ec57-4d13-81c2-e593f1f29b85)

#### before
<img width="521" alt="Screenshot 2024-04-25 at 11 55 34 AM" src="https://github.com/amp-labs/react/assets/5396828/f0fc4349-6281-4396-88ab-0c039efdc790">

#### after
<img width="508" alt="Screenshot 2024-04-25 at 12 15 50 PM" src="https://github.com/amp-labs/react/assets/5396828/3e0f6ace-86cb-4a08-9e4c-e0e2c5734b63">



