### PR TITLE
style: update checkbox spacing in optional fields

### DIFF
--- a/src/components/Configure/content/fields/OptionalFields/OptionalFields.tsx
+++ b/src/components/Configure/content/fields/OptionalFields/OptionalFields.tsx
@@ -28,16 +28,16 @@ export function OptionalFields() {
         <FieldHeader string={`${appName} reads the following optional fields`} />
         <Stack
           marginBottom={10}
-          height={300}
+          maxHeight={300}
           overflowY="scroll"
           border="2px solid #EFEFEF"
           borderRadius={8}
-          padding={4}
+          gap={0}
         >
           {configureState?.read?.optionalFields?.map((field) => {
             if (!isIntegrationFieldMapping(field)) {
               return (
-                <Box key={field.fieldName} display="flex" gap="5px" borderBottom="1px" borderColor="gray.100">
+                <Box key={field.fieldName} paddingX={4} paddingY={2} borderBottom="1px" borderColor="gray.100">
                   <Checkbox
                     name={field.fieldName}
                     id={field.fieldName}


### PR DESCRIPTION
### Summary
Checkbox spacing looks uneven. We adjust styles to match spacing update in read fields.

To test you can use `const integration = 'name:p0-i3'` in mailmonkey.

#### Before
<img width="521" alt="Screenshot 2024-04-25 at 11 55 34 AM" src="https://github.com/amp-labs/react/assets/5396828/396e26c4-ba69-48cb-ad5c-e4e2f19804f8">

#### After
<img width="539" alt="Screenshot 2024-04-25 at 12 19 27 PM" src="https://github.com/amp-labs/react/assets/5396828/57c08666-48be-4e75-a4bb-54be2afec4ec">

<img width="529" alt="Screenshot 2024-04-25 at 12 19 33 PM" src="https://github.com/amp-labs/react/assets/5396828/00427987-abd6-4c69-b90d-2bb473e3774c">


