### PR TITLE
[ENG-916] breaking: transition from `read.standardObjects` to `read.objects`

### DIFF
--- a/generated-sources/api/.openapi-generator/FILES
+++ b/generated-sources/api/.openapi-generator/FILES
@@ -29,7 +29,7 @@ src/models/AuthType.ts
 src/models/BaseConfigContent.ts
 src/models/BaseProxyConfig.ts
 src/models/BaseReadConfig.ts
-src/models/BaseReadConfigStandardObject.ts
+src/models/BaseReadConfigObject.ts
 src/models/BaseWriteConfig.ts
 src/models/BaseWriteConfigObject.ts
 src/models/BatchUpsertIntegrationsRequest.ts

--- a/generated-sources/api/src/models/BaseReadConfig.ts
+++ b/generated-sources/api/src/models/BaseReadConfig.ts
@@ -13,12 +13,12 @@
  */
 
 import { exists, mapValues } from '../runtime';
-import type { BaseReadConfigStandardObject } from './BaseReadConfigStandardObject';
+import type { BaseReadConfigObject } from './BaseReadConfigObject';
 import {
-    BaseReadConfigStandardObjectFromJSON,
-    BaseReadConfigStandardObjectFromJSONTyped,
-    BaseReadConfigStandardObjectToJSON,
-} from './BaseReadConfigStandardObject';
+    BaseReadConfigObjectFromJSON,
+    BaseReadConfigObjectFromJSONTyped,
+    BaseReadConfigObjectToJSON,
+} from './BaseReadConfigObject';
 
 /**
  * 
@@ -28,10 +28,10 @@ import {
 export interface BaseReadConfig {
     /**
      * This is a map of object names to their configuration.
-     * @type {{ [key: string]: BaseReadConfigStandardObject; }}
+     * @type {{ [key: string]: BaseReadConfigObject; }}
      * @memberof BaseReadConfig
      */
-    standardObjects?: { [key: string]: BaseReadConfigStandardObject; };
+    objects?: { [key: string]: BaseReadConfigObject; };
 }
 
 /**
@@ -53,7 +53,7 @@ export function BaseReadConfigFromJSONTyped(json: any, ignoreDiscriminator: bool
     }
     return {
         
-        'standardObjects': !exists(json, 'standardObjects') ? undefined : (mapValues(json['standardObjects'], BaseReadConfigStandardObjectFromJSON)),
+        'objects': !exists(json, 'objects') ? undefined : (mapValues(json['objects'], BaseReadConfigObjectFromJSON)),
     };
 }
 
@@ -66,7 +66,7 @@ export function BaseReadConfigToJSON(value?: BaseReadConfig | null): any {
     }
     return {
         
-        'standardObjects': value.standardObjects === undefined ? undefined : (mapValues(value.standardObjects, BaseReadConfigStandardObjectToJSON)),
+        'objects': value.objects === undefined ? undefined : (mapValues(value.objects, BaseReadConfigObjectToJSON)),
     };
 }
 

--- a/generated-sources/api/src/models/BaseReadConfigObject.ts
+++ b/generated-sources/api/src/models/BaseReadConfigObject.ts
@@ -16,55 +16,55 @@ import { exists, mapValues } from '../runtime';
 /**
  * 
  * @export
- * @interface BaseReadConfigStandardObject
+ * @interface BaseReadConfigObject
  */
-export interface BaseReadConfigStandardObject {
+export interface BaseReadConfigObject {
     /**
      * The name of the object to read from.
      * @type {string}
-     * @memberof BaseReadConfigStandardObject
+     * @memberof BaseReadConfigObject
      */
     objectName?: string;
     /**
      * The schedule for reading the object, in cron syntax.
      * @type {string}
-     * @memberof BaseReadConfigStandardObject
+     * @memberof BaseReadConfigObject
      */
     schedule?: string;
     /**
      * The name of the destination that the result should be sent to.
      * @type {string}
-     * @memberof BaseReadConfigStandardObject
+     * @memberof BaseReadConfigObject
      */
     destination?: string;
     /**
      * This is a map of field names to booleans indicating whether they should be read.
      * @type {{ [key: string]: boolean; }}
-     * @memberof BaseReadConfigStandardObject
+     * @memberof BaseReadConfigObject
      */
     selectedFields?: { [key: string]: boolean; };
     /**
      * This is a map of mapToNames to field names. (A mapTo name is the name the builder wants to map a field to when it lands in their destination.)
      * @type {{ [key: string]: string; }}
-     * @memberof BaseReadConfigStandardObject
+     * @memberof BaseReadConfigObject
      */
     selectedFieldMappings?: { [key: string]: string; };
 }
 
 /**
- * Check if a given object implements the BaseReadConfigStandardObject interface.
+ * Check if a given object implements the BaseReadConfigObject interface.
  */
-export function instanceOfBaseReadConfigStandardObject(value: object): boolean {
+export function instanceOfBaseReadConfigObject(value: object): boolean {
     let isInstance = true;
 
     return isInstance;
 }
 
-export function BaseReadConfigStandardObjectFromJSON(json: any): BaseReadConfigStandardObject {
-    return BaseReadConfigStandardObjectFromJSONTyped(json, false);
+export function BaseReadConfigObjectFromJSON(json: any): BaseReadConfigObject {
+    return BaseReadConfigObjectFromJSONTyped(json, false);
 }
 
-export function BaseReadConfigStandardObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): BaseReadConfigStandardObject {
+export function BaseReadConfigObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): BaseReadConfigObject {
     if ((json === undefined) || (json === null)) {
         return json;
     }
@@ -78,7 +78,7 @@ export function BaseReadConfigStandardObjectFromJSONTyped(json: any, ignoreDiscr
     };
 }
 
-export function BaseReadConfigStandardObjectToJSON(value?: BaseReadConfigStandardObject | null): any {
+export function BaseReadConfigObjectToJSON(value?: BaseReadConfigObject | null): any {
     if (value === undefined) {
         return undefined;
     }

--- a/generated-sources/api/src/models/HydratedIntegrationRead.ts
+++ b/generated-sources/api/src/models/HydratedIntegrationRead.ts
@@ -31,7 +31,7 @@ export interface HydratedIntegrationRead {
      * @type {Array<HydratedIntegrationObject>}
      * @memberof HydratedIntegrationRead
      */
-    standardObjects?: Array<HydratedIntegrationObject>;
+    objects?: Array<HydratedIntegrationObject>;
 }
 
 /**
@@ -53,7 +53,7 @@ export function HydratedIntegrationReadFromJSONTyped(json: any, ignoreDiscrimina
     }
     return {
         
-        'standardObjects': !exists(json, 'standardObjects') ? undefined : ((json['standardObjects'] as Array<any>).map(HydratedIntegrationObjectFromJSON)),
+        'objects': !exists(json, 'objects') ? undefined : ((json['objects'] as Array<any>).map(HydratedIntegrationObjectFromJSON)),
     };
 }
 
@@ -66,7 +66,7 @@ export function HydratedIntegrationReadToJSON(value?: HydratedIntegrationRead | 
     }
     return {
         
-        'standardObjects': value.standardObjects === undefined ? undefined : ((value.standardObjects as Array<any>).map(HydratedIntegrationObjectToJSON)),
+        'objects': value.objects === undefined ? undefined : ((value.objects as Array<any>).map(HydratedIntegrationObjectToJSON)),
     };
 }
 

--- a/generated-sources/api/src/models/IntegrationRead.ts
+++ b/generated-sources/api/src/models/IntegrationRead.ts
@@ -31,7 +31,7 @@ export interface IntegrationRead {
      * @type {Array<IntegrationObject>}
      * @memberof IntegrationRead
      */
-    standardObjects?: Array<IntegrationObject>;
+    objects?: Array<IntegrationObject>;
 }
 
 /**
@@ -53,7 +53,7 @@ export function IntegrationReadFromJSONTyped(json: any, ignoreDiscriminator: boo
     }
     return {
         
-        'standardObjects': !exists(json, 'standardObjects') ? undefined : ((json['standardObjects'] as Array<any>).map(IntegrationObjectFromJSON)),
+        'objects': !exists(json, 'objects') ? undefined : ((json['objects'] as Array<any>).map(IntegrationObjectFromJSON)),
     };
 }
 
@@ -66,7 +66,7 @@ export function IntegrationReadToJSON(value?: IntegrationRead | null): any {
     }
     return {
         
-        'standardObjects': value.standardObjects === undefined ? undefined : ((value.standardObjects as Array<any>).map(IntegrationObjectToJSON)),
+        'objects': value.objects === undefined ? undefined : ((value.objects as Array<any>).map(IntegrationObjectToJSON)),
     };
 }
 

--- a/generated-sources/api/src/models/index.ts
+++ b/generated-sources/api/src/models/index.ts
@@ -8,7 +8,7 @@ export * from './AuthType';
 export * from './BaseConfigContent';
 export * from './BaseProxyConfig';
 export * from './BaseReadConfig';
-export * from './BaseReadConfigStandardObject';
+export * from './BaseReadConfigObject';
 export * from './BaseWriteConfig';
 export * from './BaseWriteConfigObject';
 export * from './BatchUpsertIntegrationsRequest';

--- a/src/components/Configure/actions/mutateAndSetState/updateInstallationAndSetState.ts
+++ b/src/components/Configure/actions/mutateAndSetState/updateInstallationAndSetState.ts
@@ -26,7 +26,7 @@ export function updateInstallationAndSetState({
     installationUpdate: {
       // update mask will recurse to the object path and replace the object at the object path
       // this example will replace the object at the object (i.e. accounts)
-      updateMask: [`config.content.read.standardObjects.${selectedObjectName}`],
+      updateMask: [`config.content.read.objects.${selectedObjectName}`],
       installation: {
         config: updateConfig,
       },

--- a/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
@@ -21,8 +21,8 @@ const getObjectFromHydratedRevision = (
   objectName: string,
 ) => {
   const readAction = hydratedRevision.content.read;
-  const standardObjects = readAction?.standardObjects;
-  return standardObjects?.find((obj) => obj.objectName === objectName);
+  const objects = readAction?.objects;
+  return objects?.find((obj) => obj.objectName === objectName);
 };
 
 /**
@@ -64,7 +64,7 @@ const generateCreateReadConfigFromConfigureState = (
     content: {
       provider: hydratedRevision.content.provider,
       read: {
-        standardObjects: {
+        objects: {
           [objectName]: {
             objectName,
             schedule: obj.schedule,

--- a/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
@@ -45,7 +45,7 @@ const generateUpdateReadConfigFromConfigureState = (
   const updateConfigObject: UpdateInstallationRequestInstallationConfig = {
     content: {
       read: {
-        standardObjects: {
+        objects: {
           [objectName]: {
             objectName,
             // these two fields are copied from previous config, otherwise they will override null

--- a/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
@@ -57,10 +57,10 @@ const generateCreateWriteConfigFromConfigureState = (
     createdBy: `consumer:${consumerRef}`,
     content: {
       provider: hydratedRevision.content.provider,
-      // hack: need empty read.standardObjects to be initialized for update read
+      // hack: need empty read.objects to be initialized for update read
       // https://linear.app/ampersand/issue/ENG-780/bug-write-createupdate-installation-without-read
       read: {
-        standardObjects: {},
+        objects: {},
       },
       write: {
         objects: configWriteObjects,

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -63,7 +63,7 @@ export function UpdateInstallation(
   }, [installation, resetState]);
 
   const hydratedObject = useMemo(() => {
-    const hydrated = hydratedRevision?.content?.read?.standardObjects?.find(
+    const hydrated = hydratedRevision?.content?.read?.objects?.find(
       (obj) => obj?.objectName === selectedObjectName,
     );
 

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -18,9 +18,9 @@ import {
 } from '../types';
 import {
   generateAllNavObjects,
-  getFieldKeyValue, getOptionalFieldsFromObject,
+  getFieldKeyValue, getObjectFromAction,
+  getOptionalFieldsFromObject,
   getRequiredFieldsFromObject, getRequiredMapFieldsFromObject,
-  getStandardObjectFromAction,
 } from '../utils';
 
 // uses lodash deep equality check to compare two saved fields objects
@@ -40,7 +40,7 @@ const generateConfigurationStateRead = (
     return null;
   }
   // refactor this section to be immutable at hydrated revision level
-  const object = getStandardObjectFromAction(readAction, objectName);
+  const object = getObjectFromAction(readAction, objectName);
   const requiredFields = object && getRequiredFieldsFromObject(object);
   const optionalFields = object && getOptionalFieldsFromObject(object);
   const requiredMapFields = object && getRequiredMapFieldsFromObject(object);
@@ -48,8 +48,8 @@ const generateConfigurationStateRead = (
 
   const allFields = object?.allFields as HydratedIntegrationFieldExistent[] || [];
   const content = config?.content;
-  const readSelectedFields = content?.read?.standardObjects?.[objectName]?.selectedFields || {};
-  const selectedFieldMappings = content?.read?.standardObjects?.
+  const readSelectedFields = content?.read?.objects?.[objectName]?.selectedFields || {};
+  const selectedFieldMappings = content?.read?.objects?.
     [objectName]?.selectedFieldMappings || {};
 
   const optionalFieldsSaved = { ...readSelectedFields };

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -26,16 +26,16 @@ export function isIntegrationFieldMapping(field: HydratedIntegrationField):
   return (field as IntegrationFieldMapping).mapToName !== undefined;
 }
 
-// 1. get standard object
+// 1. get object
 /**
  *
  * @param action HydratedIntegrationAction
  * @param objectName string (account, contact, etc...)
  * @returns HydratedIntegrationObject | null
  */
-export function getStandardObjectFromAction(action: HydratedIntegrationRead, objectName: string)
+export function getObjectFromAction(action: HydratedIntegrationRead, objectName: string)
   : HydratedIntegrationObject | null {
-  return action?.standardObjects?.find((object) => object.objectName === objectName) || null;
+  return action?.objects?.find((object) => object.objectName === objectName) || null;
 }
 
 // 2a. get required fields
@@ -66,7 +66,7 @@ export function getOptionalFieldsFromObject(object: HydratedIntegrationObject)
 export const getReadObject = (
   config: Config,
   objectName: string,
-) => config?.content?.read?.standardObjects?.[objectName];
+) => config?.content?.read?.objects?.[objectName];
 
 // aux. get field value based on type guard
 export function getFieldKeyValue(field: HydratedIntegrationField): string {
@@ -84,7 +84,8 @@ export function getFieldKeyValue(field: HydratedIntegrationField): string {
  */
 export const generateReadNavObjects = (config: Config | undefined, hydratedRevision: HydratedRevision) => {
   const navObjects: NavObject[] = [];
-  hydratedRevision.content?.read?.standardObjects?.forEach((object) => {
+  console.log('hydratedRevision', JSON.stringify(hydratedRevision, null, 2));
+  hydratedRevision.content?.read?.objects?.forEach((object) => {
     navObjects.push(
       {
         name: object?.objectName,

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -84,7 +84,6 @@ export function getFieldKeyValue(field: HydratedIntegrationField): string {
  */
 export const generateReadNavObjects = (config: Config | undefined, hydratedRevision: HydratedRevision) => {
   const navObjects: NavObject[] = [];
-  console.log('hydratedRevision', JSON.stringify(hydratedRevision, null, 2));
   hydratedRevision.content?.read?.objects?.forEach((object) => {
     navObjects.push(
       {


### PR DESCRIPTION
See [ Slab doc](https://ampersand.slab.com/posts/changing-read-standard-objects-to-read-objects-38flho3m) for context. 

This PR was tested against https://github.com/amp-labs/server/pull/964 and I manually verified:
- creating installation
- updating installation

![Screenshot 2024-05-16 at 3 56 23 PM](https://github.com/amp-labs/react/assets/3990804/b7db5753-a695-42d8-8e06-bd5e200ffa64)
![Screenshot 2024-05-16 at 3 56 40 PM](https://github.com/amp-labs/react/assets/3990804/5f1266e8-9044-4b89-94df-8db8c0d72bbf)
