### PR TITLE
build: adds vite bundle analyzer

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,7 @@ module.exports = {
     'max-len': ['warn', { code: 125 }],
     'no-console': ['error', { allow: ['warn', 'error'] }],
     'import/no-unresolved': 0,
+    'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'react/jsx-one-expression-per-line': 0,
     'react/no-unescaped-entities': 0,
     'import/prefer-default-export': 0,

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build/
 src/services/version.ts
 
 .idea/
+
+# bundle analyzer report
+stats.html

--- a/package.json
+++ b/package.json
@@ -24,11 +24,14 @@
       "require": "./build/amp-react.cjs.js"
     }
   },
-  "files": [ "build"  ],
+  "files": [
+    "build"
+  ],
   "scripts": {
     "test": "jest",
     "watch": "npm run prepbuild && vite build --watch",
     "build": "npm run prepbuild && vite build",
+    "analyze": "npm run prepbuild && vite build --mode development",
     "prepbuild": "npm run clean && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" | sed \"s|\\\"|'|g\" > src/services/version.ts",
     "clean": "rm -rf ./build/",
     "assets": "mkdir ./build/ && cp -R ./src/public/ ./build/public/",
@@ -71,6 +74,7 @@
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "jest": "^29.7.0",
     "react-test-renderer": "^18.2.0",
+    "rollup-plugin-visualizer": "^5.12.0",
     "typescript": "^5.2.2",
     "vite": "^5.3.3",
     "vite-plugin-dts": "^3.9.1"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type PluginOption } from 'vite';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,21 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
+import { defineConfig, type PluginOption } from 'vite';
 import dts from 'vite-plugin-dts';
 
 import * as packageJson from './package.json';
 
-export default defineConfig({
-  plugins: [react(), dts({ rollupTypes: true })],
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    react(),
+    dts({ rollupTypes: true }),
+    // visualizer plugin only in development mode
+    mode === 'development' && visualizer({
+      open: true,
+      gzipSize: true,
+      brotliSize: true,
+    }) as PluginOption],
   build: {
     outDir: './build',
     lib: {
@@ -14,7 +24,8 @@ export default defineConfig({
       fileName: (format) => `amp-react.${format}.js`,
     },
     rollupOptions: {
-      external: [...Object.keys(packageJson.peerDependencies), 'react/jsx-runtime'],
+      external: [...Object.keys(packageJson.peerDependencies),
+        'react/jsx-runtime', '@chakra-ui/react'],
     },
   },
-});
+}));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => ({
     },
     rollupOptions: {
       external: [...Object.keys(packageJson.peerDependencies),
-        'react/jsx-runtime', '@chakra-ui/react'],
+        'react/jsx-runtime'],
     },
   },
 }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,6 +3902,11 @@ define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
@@ -5110,6 +5115,11 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -5270,6 +5280,13 @@ is-weakset@^2.0.1:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -6164,6 +6181,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^8.4.0:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
@@ -6624,6 +6650,16 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-visualizer@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz#661542191ce78ee4f378995297260d0c1efb1302"
+  integrity sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==
+  dependencies:
+    open "^8.4.0"
+    picomatch "^2.3.1"
+    source-map "^0.7.4"
+    yargs "^17.5.1"
+
 rollup@^4.13.0:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.18.1.tgz#18a606df5e76ca53b8a69f2d8eab256d69dda851"
@@ -6833,6 +6869,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 spawn-command@^0.0.2-1:
   version "0.0.2-1"
@@ -7543,7 +7584,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.3.1:
+yargs@^17.3.1, yargs@^17.5.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
### Summary 
adds a bundle analyze plugin to give us a bundle size snapshot
- adds `yarn analyze` script
- allows imports from [devDependencies in eslint](https://stackoverflow.com/questions/44939304/eslint-should-be-listed-in-the-projects-dependencies-not-devdependencies)

The bundle analyzer will give us a snapshot of what our library outputs. This is useful in seeing our own dependencies, code, and whether packages should be moved to peer dependences or imported directly.

#### Snapshot
run `yarn analyze` to see snapshot
<img width="1489" alt="Screenshot 2024-07-15 at 11 21 22 AM" src="https://github.com/user-attachments/assets/c82b0a5d-655e-40b9-8fdd-52e63a57c241">

#### Some References:
- React (core) + React DOM: ~120 KB (minified and gzipped)
- Clerk Bundle Size [~1mb.](https://github.com/clerk/javascript/issues/1578) - when importing react.

#### Possible followups
- remove `chakra-ui/icons` as a dependency. We use 1 icon and the package is 15% of our bundle size. We can either require it to be imported as a peer dependency like chakra or use our own icon now that scoped css should be supported via vite.
