### PR TITLE
build: add path alias for vite to tsconfig

### DIFF
--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -2,10 +2,11 @@ import {
   createContext,
   useContext, useEffect, useMemo, useState,
 } from 'react';
+import { api, Connection } from 'services/api';
+
+import { ErrorTextBox } from 'components/ErrorTextBox';
 
 import { LoadingIcon } from '../assets/LoadingIcon';
-import { ErrorTextBox } from '../components/ErrorTextBox';
-import { api, Connection } from '../services/api';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import {

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -2,13 +2,13 @@ import {
   createContext, useCallback,
   useContext, useEffect, useMemo, useState,
 } from 'react';
-
-import { LoadingIcon } from '../assets/LoadingIcon';
-import { ErrorTextBox } from '../components/ErrorTextBox';
+import { LoadingIcon } from 'assets/LoadingIcon';
 import {
   api, Config, Installation, Integration,
-} from '../services/api';
-import { findIntegrationFromList } from '../utils';
+} from 'services/api';
+import { findIntegrationFromList } from 'src/utils';
+
+import { ErrorTextBox } from 'components/ErrorTextBox';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -2,10 +2,10 @@ import {
   createContext, useContext, useEffect,
   useMemo, useState,
 } from 'react';
+import { LoadingIcon } from 'assets/LoadingIcon';
+import { api, Integration } from 'services/api';
 
-import { LoadingIcon } from '../assets/LoadingIcon';
-import { ErrorTextBox } from '../components/ErrorTextBox';
-import { api, Integration } from '../services/api';
+import { ErrorTextBox } from 'components/ErrorTextBox';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -1,10 +1,10 @@
 import {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
+import { LoadingIcon } from 'assets/LoadingIcon';
+import { api, Project } from 'services/api';
 
-import { LoadingIcon } from '../assets/LoadingIcon';
-import { ErrorTextBox } from '../components/ErrorTextBox';
-import { api, Project } from '../services/api';
+import { ErrorTextBox } from 'components/ErrorTextBox';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import {

--- a/src/hooks/useIsIntegrationInstalled.ts
+++ b/src/hooks/useIsIntegrationInstalled.ts
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-
-import { useApiKey } from '../context/ApiKeyContextProvider';
-import { useIntegrationList } from '../context/IntegrationListContextProvider';
-import { useProject } from '../context/ProjectContextProvider';
-import { api, Installation, Integration } from '../services/api';
+import { useApiKey } from 'context/ApiKeyContextProvider';
+import { useIntegrationList } from 'context/IntegrationListContextProvider';
+import { useProject } from 'context/ProjectContextProvider';
+import { api, Installation, Integration } from 'services/api';
 
 interface UseIsIntegrationInstalledResult {
   isLoaded: boolean;

--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -5,7 +5,7 @@ import {
   DestinationApi, GroupApi, InstallationApi, IntegrationApi,
   OAuthApi, OperationApi, ProjectApi, ProviderApi,
   ProviderAppApi, RevisionApi, UploadURLApi,
-} from '../../generated-sources/api/src';
+} from '@generated/api/src';
 
 /**
  * ApiService is a wrapper around the generated API client, which exposes

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -20,7 +20,7 @@ import {
   ProviderInfo,
   UpdateInstallationOperationRequest,
   UpdateInstallationRequestInstallationConfig,
-} from '../../generated-sources/api/src';
+} from '@generated/api/src';
 
 import { ApiService } from './ApiService';
 import { LIB_VERSION } from './version';

--- a/src/services/version.ts
+++ b/src/services/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = 'git';
+export const LIB_VERSION = '1.5.3';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
         "./src/*"
       ],
       "assets/*": [
-        "./assets/*"
+        "./src/assets/*"
       ],
       "components/*": [
         "./src/components/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,29 @@
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "paths": {
+      "@generated/*": [
+        "./generated-sources/*"
+      ],
+      "src/*": [
+        "./src/*"
+      ],
+      "assets/*": [
+        "./assets/*"
+      ],
+      "components/*": [
+        "./src/components/*"
+      ],
+      "context/*": [
+        "./src/context/*"
+      ],
+      "hooks/*": [
+        "./src/hooks/*"
+      ],
+      "services/*": [
+        "./src/services/*"
+      ],
+    },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import path from 'path';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, type PluginOption } from 'vite';
 import dts from 'vite-plugin-dts';
@@ -6,6 +7,17 @@ import dts from 'vite-plugin-dts';
 import * as packageJson from './package.json';
 
 export default defineConfig(({ mode }) => ({
+  resolve: {
+    alias: {
+      '@generated': path.resolve(__dirname, './generated-sources'),
+      src: path.resolve(__dirname, './src'),
+      assets: path.resolve(__dirname, './src/assets'),
+      components: path.resolve(__dirname, './src/components'),
+      context: path.resolve(__dirname, './src/context'),
+      hooks: path.resolve(__dirname, './src/hooks'),
+      services: path.resolve(__dirname, './src/services'),
+    },
+  },
   plugins: [
     react(),
     dts({ rollupTypes: true }),


### PR DESCRIPTION
### Summary
- adds alias for generated-sources
- adds alias for components, hooks, services, context

Adds alias for non-component folders. 

### Followup 
Will add aliases to component folder.
