### PR TITLE
Add rule-of-hooks linter and make exhaustive-hooks linter error not warn

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,7 +28,8 @@ module.exports = {
     'import/prefer-default-export': 0,
     'react/jsx-props-no-spreading': 0,
     'react/require-default-props': 0,
-    'react-hooks/exhaustive-deps': 'warn',
+    'react-hooks/exhaustive-deps': 'error',
+    'react-hooks/rules-of-hooks': 'error',
     '@typescript-eslint/no-unused-vars': 'warn', // TODO: delete this once codebase is more stable.
   },
   overrides: [

--- a/src/components/Oauth/OAuthWindow/OAuthWindow.tsx
+++ b/src/components/Oauth/OAuthWindow/OAuthWindow.tsx
@@ -5,9 +5,9 @@ import { useConnections } from 'context/ConnectionsContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 
 import {
-  getOpenWindowHandler,
-  getReceiveMessageEventHandler,
-  getRefreshConnectionHandler,
+  useOpenWindowHandler,
+  useReceiveMessageEventHandler,
+  useRefreshConnectionHandler,
 } from './windowHelpers';
 
 type OAuthWindowProps = {
@@ -31,9 +31,9 @@ export function OAuthWindow({
   const [oauthWindow, setOauthWindow] = useState<Window | null>(null);
   const { setSelectedConnection } = useConnections();
 
-  const receiveMessage = getReceiveMessageEventHandler(setConnectionId);
-  const openOAuthWindow = getOpenWindowHandler(windowTitle, setOauthWindow, receiveMessage, oauthUrl);
-  const refreshConnections = getRefreshConnectionHandler(projectId, apiKey, setSelectedConnection);
+  const receiveMessage = useReceiveMessageEventHandler(setConnectionId);
+  const openOAuthWindow = useOpenWindowHandler(windowTitle, setOauthWindow, receiveMessage, oauthUrl);
+  const refreshConnections = useRefreshConnectionHandler(projectId, apiKey, setSelectedConnection);
 
   // open the OAuth window on mount and prop change
   useEffect(() => {

--- a/src/components/Oauth/OAuthWindow/windowHelpers.tsx
+++ b/src/components/Oauth/OAuthWindow/windowHelpers.tsx
@@ -15,7 +15,7 @@ const FAILURE_EVENT = 'AUTHORIZATION_FAILED';
  * @param setSelectedConnection
  * @returns
  */
-export function getRefreshConnectionHandler(
+export function useRefreshConnectionHandler(
   projectId: string,
   apiKey: string,
   setSelectedConnection: React.Dispatch<React.SetStateAction<Connection | null>>,
@@ -37,7 +37,7 @@ export function getRefreshConnectionHandler(
  * @param receiveMessage
  * @returns a function to open the oauth window
  */
-export function getOpenWindowHandler(
+export function useOpenWindowHandler(
   windowTitle: string,
   setOauthWindow: React.Dispatch<React.SetStateAction<Window | null>>,
   receiveMessage: (event: MessageEvent) => void,
@@ -60,7 +60,7 @@ export function getOpenWindowHandler(
 /**
   * returns a function to handle the message event
   */
-export function getReceiveMessageEventHandler(
+export function useReceiveMessageEventHandler(
   setConnectionId: React.Dispatch<React.SetStateAction<null>>,
 ) {
   return useCallback((event: MessageEvent) => {


### PR DESCRIPTION
Now that there's more people contributing to the codebase, we should make our linters more strict to catch potential errors. I've added the `react-hooks/rules-of-hooks` linter and made `react-hooks/exhaustive-deps` error instead of warn because warn doesn't get caught by Github Actions, and if there's a legitimate reason for not having exhaustive deps in a `useEffect` a `nolint` line can be added.