### PR TITLE
[ENG-1296] feat: deprecate `projectId` for `project`

### DIFF
--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -13,24 +13,45 @@ import { ApiKeyProvider } from '../ApiKeyContextProvider';
 import { ErrorStateProvider } from '../ErrorContextProvider';
 import { IntegrationListProvider } from '../IntegrationListContextProvider';
 import { ProjectProvider } from '../ProjectContextProvider';
+import { deprecate } from 'util';
 
 interface AmpersandProviderProps {
   options: {
     apiKey: string,
-    projectId: string,
+    /**
+     * Use `project` instead of `projectId`. 
+     * @deprecated
+     */
+    projectId?: string,
+    /**
+     * `project` is the project ID or name.
+     */
+    project?: string,
     styles?: object,
   },
   children: React.ReactNode
 }
 
 export function AmpersandProvider(props: AmpersandProviderProps) {
-  const { options: { apiKey, projectId }, children } = props;
+  const { options: { apiKey, projectId, project }, children } = props;
+  const projectIdOrName = project || projectId;
+  if (projectId && project) {
+    throw new Error(`Use AmpersandProvider either with projectId or project but not both.`);
+  }
+  if (!projectIdOrName) {
+    throw new Error(`Cannot use AmpersandProvider without a projectId or name.`);
+  }
+  
+  if(!apiKey) {
+    throw new Error(`Cannot use AmpersandProvider without an apiKey.`);
+  }
+
   return (
     <ThemeProvider>
       <ErrorStateProvider>
         <ApiKeyProvider value={apiKey}>
-          <ProjectProvider projectId={projectId}>
-            <IntegrationListProvider projectId={projectId}>
+          <ProjectProvider projectIdOrName={projectIdOrName}>
+            <IntegrationListProvider projectIdOrName={projectIdOrName}>
               {children}
             </IntegrationListProvider>
           </ProjectProvider>

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -13,7 +13,6 @@ import { ApiKeyProvider } from '../ApiKeyContextProvider';
 import { ErrorStateProvider } from '../ErrorContextProvider';
 import { IntegrationListProvider } from '../IntegrationListContextProvider';
 import { ProjectProvider } from '../ProjectContextProvider';
-import { deprecate } from 'util';
 
 interface AmpersandProviderProps {
   options: {
@@ -41,7 +40,7 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
   if (!projectIdOrName) {
     throw new Error(`Cannot use AmpersandProvider without a projectId or name.`);
   }
-  
+
   if(!apiKey) {
     throw new Error(`Cannot use AmpersandProvider without an apiKey.`);
   }

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -18,7 +18,7 @@ interface AmpersandProviderProps {
   options: {
     apiKey: string,
     /**
-     * Use `project` instead of `projectId`. 
+     * Use `project` instead of `projectId`.
      * @deprecated
      */
     projectId?: string,
@@ -35,14 +35,14 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
   const { options: { apiKey, projectId, project }, children } = props;
   const projectIdOrName = project || projectId;
   if (projectId && project) {
-    throw new Error(`Use AmpersandProvider either with projectId or project but not both.`);
+    throw new Error('Use AmpersandProvider either with projectId or project but not both.');
   }
   if (!projectIdOrName) {
-    throw new Error(`Cannot use AmpersandProvider without a projectId or name.`);
+    throw new Error('Cannot use AmpersandProvider without a projectId or name.');
   }
 
-  if(!apiKey) {
-    throw new Error(`Cannot use AmpersandProvider without an apiKey.`);
+  if (!apiKey) {
+    throw new Error('Cannot use AmpersandProvider without an apiKey.');
   }
 
   return (

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -42,7 +42,7 @@ export function IntegrationListProvider(
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {
-    api().integrationApi.listIntegrations({ projectIdOrName: projectIdOrName }, {
+    api().integrationApi.listIntegrations({ projectIdOrName }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -29,12 +29,12 @@ export const useIntegrationList = (): IntegrationListContextValue => {
 };
 
 type IntegrationListContextProviderProps = {
-  projectId: string,
+  projectIdOrName: string,
   children?: React.ReactNode;
 };
 
 export function IntegrationListProvider(
-  { projectId, children }: IntegrationListContextProviderProps,
+  { projectIdOrName, children }: IntegrationListContextProviderProps,
 ) {
   const apiKey = useApiKey();
   const { setError, isError } = useErrorState();
@@ -42,7 +42,7 @@ export function IntegrationListProvider(
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {
-    api().integrationApi.listIntegrations({ projectIdOrName: projectId }, {
+    api().integrationApi.listIntegrations({ projectIdOrName: projectIdOrName }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },
@@ -51,17 +51,17 @@ export function IntegrationListProvider(
       setIntegrations(_integrations || []);
     }).catch((err) => {
       setLoadingState(false);
-      setError(ErrorBoundary.INTEGRATION_LIST, projectId);
+      setError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName);
       console.error('Error retrieving integration information for : ', err);
     });
-  }, [projectId, apiKey, setError]);
+  }, [projectIdOrName, apiKey, setError]);
 
   const contextValue = useMemo(() => ({
     integrations,
   }), [integrations]);
 
   return (
-    isError(ErrorBoundary.INTEGRATION_LIST, projectId)
+    isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
       ? <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />
       : (
         <IntegrationListContext.Provider value={contextValue}>

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -47,7 +47,7 @@ export function ProjectProvider(
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {
-    api().projectApi.getProject({ projectIdOrName: projectIdOrName }, {
+    api().projectApi.getProject({ projectIdOrName }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -34,12 +34,12 @@ export const useProject = (): ProjectContextValue => {
 };
 
 type ProjectProviderProps = {
-  projectId: string,
+  projectIdOrName: string,
   children?: React.ReactNode;
 };
 
 export function ProjectProvider(
-  { projectId, children }: ProjectProviderProps,
+  { projectIdOrName, children }: ProjectProviderProps,
 ) {
   const apiKey = useApiKey();
   const { isError, setError } = useErrorState();
@@ -47,7 +47,7 @@ export function ProjectProvider(
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
   useEffect(() => {
-    api().projectApi.getProject({ projectIdOrName: projectId }, {
+    api().projectApi.getProject({ projectIdOrName: projectIdOrName }, {
       headers: {
         'X-Api-Key': apiKey ?? '',
       },
@@ -55,19 +55,19 @@ export function ProjectProvider(
       setLoadingState(false);
       setProject(_project);
     }).catch((err) => {
-      setError(ErrorBoundary.PROJECT, projectId);
+      setError(ErrorBoundary.PROJECT, projectIdOrName);
       setLoadingState(false);
       console.error('Error loading Ampersand project: ', err);
     });
-  }, [projectId, apiKey, setLoadingState, setError]);
+  }, [projectIdOrName, apiKey, setLoadingState, setError]);
 
   const contextValue = useMemo(() => ({
-    projectId, project, appName: project?.appName || '',
-  }), [projectId, project]);
+    projectId: projectIdOrName, project, appName: project?.appName || '',
+  }), [projectIdOrName, project]);
 
   return (
-    isError(ErrorBoundary.PROJECT, projectId)
-      ? <ErrorTextBox message={`Error loading project ${projectId}`} />
+    isError(ErrorBoundary.PROJECT, projectIdOrName)
+      ? <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
       : (
         <ProjectContext.Provider value={contextValue}>
           {isLoading ? <LoadingIcon /> : children}


### PR DESCRIPTION
Now `projectId` is deprecated (optional) for `project`. 


<img width="800" alt="Screenshot 2024-08-06 at 4 17 57 PM" src="https://github.com/user-attachments/assets/a40496f1-d0e8-4141-9ea2-0999eaf1e744">

Also added runtime console errors when no `project` or `apiKey` is provided 

<img width="595" alt="Screenshot 2024-08-06 at 4 19 27 PM" src="https://github.com/user-attachments/assets/44b7b049-69b5-435e-8847-d6a5ce7f24a4">

<img width="563" alt="Screenshot 2024-08-06 at 4 21 28 PM" src="https://github.com/user-attachments/assets/b00e3628-df67-4cd2-8509-8b097169c998">

