### PR TITLE
[ENG-1407] fix: allow required only reads to be saved

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -6,10 +6,12 @@ import {
 } from '@chakra-ui/react';
 
 import { LoadingIcon } from 'assets/LoadingIcon';
+import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 
 import { OTHER_CONST } from '../nav/ObjectManagementNav/constant';
 import { UNINSTALL_INSTALLATION_CONST } from '../nav/ObjectManagementNav/UninstallInstallation';
 import { useHydratedRevision } from '../state/HydratedRevisionContext';
+import { getReadObject } from '../utils';
 
 import { ReadFields } from './fields/ReadFields';
 import { WriteFields } from './fields/WriteFields';
@@ -29,8 +31,14 @@ export function ConfigureInstallationBase(
     onSave, onReset, isLoading, isCreateMode = false,
   }: ConfigureInstallationBaseProps,
 ) {
+  const { installation } = useInstallIntegrationProps();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { configureState, selectedObjectName } = useSelectedConfigureState();
+
+  // check if selected object is completed.
+  const config = installation?.config;
+  const isSelectedReadConfigComplete = (config && selectedObjectName
+    && !!getReadObject(config, selectedObjectName)) || false;
 
   // has the form been modified?
   const isReadModified = configureState?.read?.isOptionalFieldsModified
@@ -39,7 +47,8 @@ export function ConfigureInstallationBase(
   const isModified = isReadModified || isWriteModified;
 
   // is this a new state (modified or creating a new state)
-  const isStateNew = isModified || isCreateMode;
+  // if the read object is not completed, it is a new state
+  const isStateNew = isModified || isCreateMode || (selectedObjectName !== OTHER_CONST && !isSelectedReadConfigComplete);
 
   // should the save button be disabled?
   const isDisabled = loading || isLoading || !configureState || !selectedObjectName
@@ -62,7 +71,7 @@ export function ConfigureInstallationBase(
               type="submit"
               isDisabled={isDisabled}
             >
-              { isCreateMode ? 'Install' : 'Save'}
+              {isCreateMode ? 'Install' : 'Save'}
             </Button>
             <Button
               backgroundColor="gray.200"

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -46,9 +46,10 @@ export function ConfigureInstallationBase(
   const isWriteModified = configureState?.write?.isWriteModified;
   const isModified = isReadModified || isWriteModified;
 
-  // is this a new state (modified or creating a new state)
   // if the read object is not completed, it is a new state
-  const isStateNew = isModified || isCreateMode || (selectedObjectName !== OTHER_CONST && !isSelectedReadConfigComplete);
+  const isSelectedReadObjectComplete = (selectedObjectName !== OTHER_CONST && !isSelectedReadConfigComplete);
+  // is this a new state (modified or creating a new state)
+  const isStateNew = isModified || isCreateMode || isSelectedReadObjectComplete;
 
   // should the save button be disabled?
   const isDisabled = loading || isLoading || !configureState || !selectedObjectName


### PR DESCRIPTION
### Summary
The current configure component requires a dirty state or create state to enable submit. This PR adds a check to see if the object has been completed, if not completed as a read state, it will be considered a new state so disable will not be activated
- adds check if selected object is completed, before enabling disable.
#### testing

`amp.yaml`
```
specVersion: 1.0.0
integrations:
  - name: readHubspotContactsRequiredOnly2
    displayName: Read Hubspot Contacts
    provider: hubspot
    read:
      objects:
        - objectName: contact
          destination: defaultWebhook
          schedule: "*/30 * * * *" # Every 30 minutes
          requiredFields:
            # First required field is "name"
            - fieldName: name    
        - objectName: account
          destination: defaultWebhook
          schedule: "*/30 * * * *" # Every 30 minutes
          requiredFields:
            # First required field is "name"
            - fieldName: name
  ```

#### demo
##### before
<img width="888" alt="Screenshot 2024-08-08 at 6 24 45 PM" src="https://github.com/user-attachments/assets/35b135e3-87e8-4b86-8cc4-f50fd6ec13be">

##### after
![enable-require-only-saves](https://github.com/user-attachments/assets/041db20e-4864-46f2-861a-fb83f89bc405)

#### todo 
tests working with other optional read/ write configurations

