### PR TITLE
[ENG-1453] feat: add scopes support for Oauth client credentials flow

### DIFF
--- a/src/components/Oauth/NoWorkspaceEntry/ClientCredentialsContent.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/ClientCredentialsContent.tsx
@@ -8,38 +8,57 @@ import {
   InputGroup,
   InputRightElement,
   Stack,
+  Textarea,
 } from '@chakra-ui/react';
 
 import { OauthCardLayout } from 'components/Oauth/OauthCardLayout';
 import { OAuthErrorAlert } from 'components/Oauth/OAuthErrorAlert';
+import { convertTextareaToArray } from 'src/utils';
 
 export type ClientCredentialsCreds = {
   clientId: string;
   clientSecret: string;
+  scopes?: string[];
 };
 
 type LandingContentProps = {
   handleSubmit: (creds: ClientCredentialsCreds) => void;
   error: string | null;
+  explicitScopesRequired?: boolean;
   isButtonDisabled?: boolean;
   providerName?: string;
 };
 
 export function ClientCredentialsContent({
-  handleSubmit, error, isButtonDisabled, providerName,
+  handleSubmit, error, explicitScopesRequired, isButtonDisabled, providerName,
 }: LandingContentProps) {
   const [show, setShow] = useState(false);
   const [clientSecret, setClientSecret] = useState('');
   const [clientId, setClientId] = useState('');
+  const [scopes, setScopes] = useState('');
 
   const onToggleShowHide = () => setShow(!show);
 
   const handleClientSecretChange = (event: React.FormEvent<HTMLInputElement>) => setClientSecret(event.currentTarget.value);
   const handleClientIdChange = (event: React.FormEvent<HTMLInputElement>) => setClientId(event.currentTarget.value);
+  const handleScopesChange = (event: React.FormEvent<HTMLTextAreaElement>) => setScopes(event.currentTarget.value);
 
   const isClientSecretValid = clientSecret.length > 0;
   const isClientIdValid = clientId.length > 0;
   const isSubmitDisabled = isButtonDisabled || !isClientSecretValid || !isClientIdValid;
+
+  const onHandleSubmit = () => {
+    const req: ClientCredentialsCreds = {
+      clientId,
+      clientSecret,
+    };
+
+    if (explicitScopesRequired && scopes.length > 0) {
+      req.scopes = convertTextareaToArray(scopes);
+    }
+
+    handleSubmit(req);
+  };
 
   return (
     <OauthCardLayout>
@@ -65,17 +84,20 @@ export function ClientCredentialsContent({
               </Button>
             </InputRightElement>
           </InputGroup>
+          {explicitScopesRequired && (
+            <Textarea
+              placeholder="Scopes separated by new line"
+              onChange={handleScopesChange}
+            />
+          )}
         </Stack>
-
         <br />
 
         <Button
           isDisabled={isSubmitDisabled}
           width="100%"
           type="submit"
-          onClick={() => {
-            handleSubmit({ clientId, clientSecret });
-          }}
+          onClick={onHandleSubmit}
         >
           Next
         </Button>

--- a/src/components/Oauth/NoWorkspaceEntry/NoWorkspaceOauthClientCredsFlow.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/NoWorkspaceOauthClientCredsFlow.tsx
@@ -21,6 +21,7 @@ interface NoWorkspaceOauthClientCredsFlowProps {
   groupRef: string;
   groupName?: string;
   providerName?: string;
+  explicitScopesRequired?: boolean;
   selectedConnection: Connection | null;
   setSelectedConnection: (connection: Connection | null) => void;
 }
@@ -30,7 +31,8 @@ interface NoWorkspaceOauthClientCredsFlowProps {
  * then launches a popup with the OAuth flow.
  */
 export function NoWorkspaceOauthClientCredsFlow({
-  provider, consumerRef, consumerName, groupRef, groupName, selectedConnection, setSelectedConnection, providerName,
+  provider, consumerRef, consumerName, groupRef, groupName, explicitScopesRequired, providerName,
+  selectedConnection, setSelectedConnection,
 }: NoWorkspaceOauthClientCredsFlowProps) {
   const { projectId } = useProject();
   const apiKey = useApiKey();
@@ -48,6 +50,7 @@ export function NoWorkspaceOauthClientCredsFlow({
       oauth2ClientCredentials: {
         clientId: creds.clientId,
         clientSecret: creds.clientSecret,
+        scopes: creds.scopes,
       },
     };
 
@@ -62,7 +65,14 @@ export function NoWorkspaceOauthClientCredsFlow({
   };
 
   if (selectedConnection === null) {
-    return <ClientCredentialsContent handleSubmit={handleSubmit} error={error} providerName={providerName} />;
+    return (
+      <ClientCredentialsContent
+        providerName={providerName}
+        handleSubmit={handleSubmit}
+        error={error}
+        explicitScopesRequired={explicitScopesRequired}
+      />
+    );
   }
 
   return <LoadingIcon />;

--- a/src/components/Oauth/OauthFlow/OauthFlow.tsx
+++ b/src/components/Oauth/OauthFlow/OauthFlow.tsx
@@ -9,6 +9,9 @@ import { WorkspaceOauthFlow } from 'components/Oauth/WorkspaceEntry/WorkspaceOau
 import { Connection, ProviderInfo } from 'services/api';
 import { getProviderName } from 'src/utils';
 
+const AUTHORIZATION_CODE = 'authorizationCode';
+const CLIENT_CREDENTIALS = 'clientCredentials';
+
 type OauthFlowProps = {
   provider: string;
   providerInfo: ProviderInfo;
@@ -27,13 +30,12 @@ export function OauthFlow({
     return <em>Provider is missing OAuth2 options</em>;
   }
 
-  const { grantType } = providerInfo.oauth2Opts;
-  const workspaceRequired = providerInfo.oauth2Opts.explicitWorkspaceRequired;
+  const { grantType, explicitScopesRequired, explicitWorkspaceRequired } = providerInfo.oauth2Opts;
   const providerName = getProviderName(provider, providerInfo);
 
-  if (grantType === 'authorizationCode') {
+  if (grantType === AUTHORIZATION_CODE) {
     // required workspace
-    if (workspaceRequired) {
+    if (explicitWorkspaceRequired) {
       return (
         <WorkspaceOauthFlow
           provider={provider}
@@ -59,8 +61,8 @@ export function OauthFlow({
     );
   }
 
-  if (grantType === 'clientCredentials') {
-    if (workspaceRequired) {
+  if (grantType === CLIENT_CREDENTIALS) {
+    if (explicitWorkspaceRequired) {
       return (
         <WorkspaceOauthClientCredsFlow
           provider={provider}
@@ -68,6 +70,7 @@ export function OauthFlow({
           consumerName={consumerName}
           groupRef={groupRef}
           groupName={groupName}
+          explicitScopesRequired={explicitScopesRequired}
           setSelectedConnection={setSelectedConnection}
           selectedConnection={selectedConnection}
           providerName={providerName}
@@ -82,6 +85,7 @@ export function OauthFlow({
         consumerName={consumerName}
         groupRef={groupRef}
         groupName={groupName}
+        explicitScopesRequired={explicitScopesRequired}
         setSelectedConnection={setSelectedConnection}
         selectedConnection={selectedConnection}
         providerName={providerName}

--- a/src/components/Oauth/WorkspaceEntry/ClientCredentialsContent.tsx
+++ b/src/components/Oauth/WorkspaceEntry/ClientCredentialsContent.tsx
@@ -8,41 +8,62 @@ import {
   InputGroup,
   InputRightElement,
   Stack,
+  Textarea,
 } from '@chakra-ui/react';
 
 import { OauthCardLayout } from 'components/Oauth/OauthCardLayout';
 import { OAuthErrorAlert } from 'components/Oauth/OAuthErrorAlert';
+import { convertTextareaToArray } from 'src/utils';
 
 export type WorkspaceClientCredentialsCreds = {
   workspace: string;
   clientId: string;
   clientSecret: string;
+  scopes?: string[];
 };
 
 type LandingContentProps = {
   handleSubmit: (creds: WorkspaceClientCredentialsCreds) => void;
   error: string | null;
+  explicitScopesRequired?: boolean;
   isButtonDisabled?: boolean;
   providerName?: string;
 };
 
 export function ClientCredentialsContent({
   handleSubmit, error, isButtonDisabled, providerName,
+  explicitScopesRequired,
 }: LandingContentProps) {
   const [show, setShow] = useState(false);
   const [clientSecret, setClientSecret] = useState('');
   const [clientId, setClientId] = useState('');
   const [workspace, setWorkspace] = useState('');
+  const [scopes, setScopes] = useState('');
 
   const onToggleShowHide = () => setShow(!show);
   const handleClientSecretChange = (event: React.FormEvent<HTMLInputElement>) => setClientSecret(event.currentTarget.value);
   const handleClientIdChange = (event: React.FormEvent<HTMLInputElement>) => setClientId(event.currentTarget.value);
   const handleWorkspaceChange = (event: React.FormEvent<HTMLInputElement>) => setWorkspace(event.currentTarget.value);
+  const handleScopesChange = (event: React.FormEvent<HTMLTextAreaElement>) => setScopes(event.currentTarget.value);
 
   const isClientSecretValid = clientSecret.length > 0;
   const isClientIdValid = clientId.length > 0;
   const isWorkspaceValid = workspace.length > 0;
   const isSubmitDisabled = isButtonDisabled || !isClientSecretValid || !isClientIdValid || !isWorkspaceValid;
+
+  const onHandleSubmit = () => {
+    const req: WorkspaceClientCredentialsCreds = {
+      workspace,
+      clientId,
+      clientSecret,
+    };
+
+    if (explicitScopesRequired && scopes.length > 0) {
+      req.scopes = convertTextareaToArray(scopes);
+    }
+
+    handleSubmit(req);
+  };
 
   return (
     <OauthCardLayout>
@@ -72,6 +93,12 @@ export function ClientCredentialsContent({
               </Button>
             </InputRightElement>
           </InputGroup>
+          {explicitScopesRequired && (
+            <Textarea
+              placeholder="Scopes separated by new line"
+              onChange={handleScopesChange}
+            />
+          )}
         </Stack>
 
         <br />
@@ -80,9 +107,7 @@ export function ClientCredentialsContent({
           isDisabled={isSubmitDisabled}
           width="100%"
           type="submit"
-          onClick={() => {
-            handleSubmit({ workspace, clientId, clientSecret });
-          }}
+          onClick={onHandleSubmit}
         >
           Next
         </Button>

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceOauthClientCredsFlow.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceOauthClientCredsFlow.tsx
@@ -21,6 +21,7 @@ interface NoWorkspaceOauthClientCredsFlowProps {
   groupRef: string;
   groupName?: string;
   providerName?: string;
+  explicitScopesRequired?: boolean;
   selectedConnection: Connection | null;
   setSelectedConnection: (connection: Connection | null) => void;
 }
@@ -30,7 +31,9 @@ interface NoWorkspaceOauthClientCredsFlowProps {
  * then launches a popup with the OAuth flow.
  */
 export function WorkspaceOauthClientCredsFlow({
-  provider, consumerRef, consumerName, groupRef, groupName, selectedConnection, setSelectedConnection, providerName,
+  provider, providerName,
+  consumerRef, consumerName, groupRef, groupName, explicitScopesRequired,
+  selectedConnection, setSelectedConnection,
 }: NoWorkspaceOauthClientCredsFlowProps) {
   const { projectId } = useProject();
   const apiKey = useApiKey();
@@ -49,6 +52,7 @@ export function WorkspaceOauthClientCredsFlow({
       oauth2ClientCredentials: {
         clientId: creds.clientId,
         clientSecret: creds.clientSecret,
+        scopes: creds.scopes,
       },
     };
 
@@ -63,7 +67,14 @@ export function WorkspaceOauthClientCredsFlow({
   };
 
   if (selectedConnection === null) {
-    return <ClientCredentialsContent handleSubmit={handleSubmit} error={error} providerName={providerName} />;
+    return (
+      <ClientCredentialsContent
+        providerName={providerName}
+        handleSubmit={handleSubmit}
+        error={error}
+        explicitScopesRequired={explicitScopesRequired}
+      />
+    );
   }
 
   return <LoadingIcon />;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,15 @@ export function getProviderName(provider: string, providerInfo?: ProviderInfo) {
 }
 
 /**
+ * Converts a textarea input into an array of strings
+ */
+export const convertTextareaToArray = (inputValue: string) => {
+  // Split the input into an array of strings using newline as the separator
+  const newArray = inputValue.split('\n').filter((str) => str.trim() !== '');
+  return newArray;
+};
+
+/**
  * Given the name of an integration, return the integration object
  *
  * @param integrationName {string} Name of the integration.


### PR DESCRIPTION
### Summary
Adds scopes support to UI Oauth client credentials flow.
- add scopes to NoWorkspaceEntry, WorkspaceEntry
- add convertTextareaToArray to utils
- moves magic strings into variables


#### Screenshot
![Screenshot 2024-08-21 at 3 46 18 PM](https://github.com/user-attachments/assets/b8637697-3d4c-48ce-b156-cf9aae0ac623)

#### Followup
There's similar code that can be refactored across the flows. 

