### PR TITLE
[ENG-1475] feat: support proxy onInstallSuccess

### DIFF
--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -34,7 +34,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
   const apiKey = useApiKey();
   const { hydratedRevision, loading: hydratedRevisionLoading } = useHydratedRevision();
   const {
-    integrationObj, installation, groupRef, consumerRef, setInstallation,
+    integrationObj, installation, groupRef, consumerRef, setInstallation, onInstallSuccess,
   } = useInstallIntegrationProps();
   const { selectedConnection } = useConnections();
   const [createInstallLoading, setCreateInstallLoading] = useState(false);
@@ -56,6 +56,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
         connectionId: selectedConnection?.id,
         hydratedRevision,
         setInstallation,
+        onInstallSuccess,
       }).then(() => {
         setCreateInstallLoading(false);
       }).catch((e) => {
@@ -63,8 +64,8 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
         console.error('Error when creating proxy installation:', e);
       });
     }
-  }, [hydratedRevision, isProxyOnly, installation,
-    selectedConnection, apiKey, projectId, integrationObj?.id, groupRef, consumerRef, setInstallation, isLoading]);
+  }, [hydratedRevision, isProxyOnly, installation, selectedConnection, apiKey, projectId,
+    integrationObj?.id, groupRef, consumerRef, setInstallation, isLoading, onInstallSuccess]);
 
   if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
   if (isLoading) return <LoadingIcon />;


### PR DESCRIPTION
### Summary
`onInstallSuccess` side effect is not activated in proxy yet. This PR adds support for calling the side effect.

#### mailmonkey code
```
<InstallIntegration
                    integration={integration}
                    consumerName={userName}
                    consumerRef={userId}
                    groupRef={groupId}
                    groupName={groupName}
                    onInstallSuccess= {(installationId: string, configObject: any) => {
                      console.log("TESTING INSTALLATION: proxy enabled.");
                      console.log(`Successfully installed ${installationId} with configuration ${JSON.stringify(configObject, null, 2)}`)}                              
                    }
                    onUpdateSuccess = {(installationId: string, configObject: any) =>{
                      console.log(`Successfully updated ${installationId} with configuration ${JSON.stringify(configObject, null, 2)}`)}
                    }                    
 />
```

#### demo
![proxy-enabled-install-success](https://github.com/user-attachments/assets/4c27a924-6723-4449-bca9-266f1205a50e)
