### PR TITLE
[ENG-1350] fix: bring back more granular error handling for auth errors

### DIFF
--- a/src/components/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -55,7 +55,7 @@ export function NoWorkspaceOauthFlow({
     }
   };
 
-  const onClose = useCallback((err: string | null) => {
+  const onError = useCallback((err: string | null) => {
     setError(err);
     setOAuthPopupURL(null);
   }, []);
@@ -64,7 +64,7 @@ export function NoWorkspaceOauthFlow({
     <OAuthWindow
       windowTitle={`Connect to ${providerName}`}
       oauthUrl={oAuthPopupURL}
-      onClose={onClose}
+      onError={onError}
     >
       <LandingContent handleSubmit={handleSubmit} error={error} providerName={providerName} />
     </OAuthWindow>

--- a/src/components/Oauth/OAuthWindow/windowHelpers.tsx
+++ b/src/components/Oauth/OAuthWindow/windowHelpers.tsx
@@ -62,6 +62,7 @@ export function useOpenWindowHandler(
   */
 export function useReceiveMessageEventHandler(
   setConnectionId: React.Dispatch<React.SetStateAction<null>>,
+  onError?: (err: string | null) => void,
 ) {
   return useCallback((event: MessageEvent) => {
     // Ignore messages from unexpected origins
@@ -83,7 +84,10 @@ export function useReceiveMessageEventHandler(
     // failure case
     if (event.data.eventType === FAILURE_EVENT) {
       console.error('OAuth failed: ', { event });
+      // event.data.message sent by server message
+      // See `server/shared/oauth/connection.go` for the HTML that the server sends back to the UI library.
+      onError?.(event?.data?.message ?? 'OAuth failed. Please try again.');
       // do not close the window if error occurs
     }
-  }, [setConnectionId]);
+  }, [onError, setConnectionId]);
 }

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -61,7 +61,7 @@ export function WorkspaceOauthFlow({
     }
   };
 
-  const onClose = useCallback((err: string | null) => {
+  const onError = useCallback((err: string | null) => {
     setError(err);
     setOAuthCallbackURL(null);
   }, []);
@@ -90,7 +90,7 @@ export function WorkspaceOauthFlow({
     <OAuthWindow
       windowTitle={`Connect to ${providerName}`}
       oauthUrl={oAuthCallbackURL}
-      onClose={onClose}
+      onError={onError}
     >
       {workspaceEntryComponent}
     </OAuthWindow>


### PR DESCRIPTION
### Summary 
Bring back granular error handling. 
- renames onClose to onError since we can perform errors without closing the window.

note: did not replicate, will need help to set up local env to mimic this error. 