### PR TITLE
[ENG-1515] feat: add backfill support to update read installation

### DIFF
--- a/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
@@ -1,4 +1,5 @@
 import {
+  BackfillConfig,
   Config,
   HydratedIntegrationObject,
   HydratedRevision,
@@ -36,6 +37,7 @@ const generateUpdateReadConfigFromConfigureState = (
   hydratedObject: HydratedIntegrationObject,
   schedule: string,
   hydratedRevision: HydratedRevision,
+  backfill?: BackfillConfig,
 ): UpdateInstallationRequestInstallationConfig => {
   const selectedFields = generateSelectedFieldsFromConfigureState(configureState);
   const selectedFieldMappings = generateSelectedFieldMappingsFromConfigureState(
@@ -54,6 +56,7 @@ const generateUpdateReadConfigFromConfigureState = (
             destination: hydratedObject?.destination || '',
             selectedFields,
             selectedFieldMappings,
+            backfill,
           },
         },
       },
@@ -91,6 +94,7 @@ export const onSaveReadUpdateInstallation = (
     hydratedObject,
     hydratedObject.schedule,
     hydratedRevision,
+    hydratedObject.backfill,
   );
 
   if (!updateConfig) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-relative-packages */
 // currently not using a bundler to support alias imports
 import {
+  BackfillConfig,
   Config,
   Configuration, Connection,
   CreateInstallationOperationRequest,
@@ -105,6 +106,7 @@ export const api = () => apiValue;
    * Types exported from generated api
    */
 export type {
+  BackfillConfig,
   Config,
   Connection,
   CreateInstallationOperationRequest,


### PR DESCRIPTION
### Summary
backfill is supported in createInstallation (proxy and read), but not update. 
- add backfill support to updateInstallation (read), proxy has no update 
- followup to https://github.com/amp-labs/react/pull/451

#### followup: 
I'm unsure if write create/update installation backfill needs support in ui library. This support would be a separate ticket if so.

#### demo 
<img width="857" alt="Screenshot 2024-08-28 at 4 22 05 PM" src="https://github.com/user-attachments/assets/2e6e076e-b72c-4b08-ae2b-4ad692d11879">

![Screenshot 2024-08-28 at 4 22 01 PM](https://github.com/user-attachments/assets/4e8a1fd8-b4e6-4f0e-aa0f-828d90400da8)
