### PR TITLE
[auto] Update openapi dependency

### DIFF
--- a/generated-sources/api/src/models/CreateIntegrationRequestLatestRevision.ts
+++ b/generated-sources/api/src/models/CreateIntegrationRequestLatestRevision.ts
@@ -14,7 +14,7 @@
 
 import { exists, mapValues } from '../runtime';
 /**
- * If included, creating this integration will also create a new revision of the integration. For LatestRevision, one of souceZipUrl or sourceYaml is required.
+ * If included, creating this integration will also create a new revision of the integration. For LatestRevision, one of sourceZipUrl or sourceYaml is required.
  * @export
  * @interface CreateIntegrationRequestLatestRevision
  */


### PR DESCRIPTION
This updates the dependency to version [46ebdd981ea9fd3138348375e1ba4f5294619eff](https://github.com/amp-labs/openapi/commit/46ebdd981ea9fd3138348375e1ba4f5294619eff) from [main](https://github.com/amp-labs/openapi/tree/main)