### PR TITLE
style: update defaults to be less bold

### DIFF
--- a/src/components/ApiKeyAuth/ApiKeyAuthFlow/LandingContent.tsx
+++ b/src/components/ApiKeyAuth/ApiKeyAuthFlow/LandingContent.tsx
@@ -72,6 +72,7 @@ export function LandingContent({
         <br />
 
         <Button
+          variant="primary"
           isDisabled={isSubmitDisabled}
           width="100%"
           type="submit"

--- a/src/components/BasicAuth/BasicAuthCardLayout.tsx
+++ b/src/components/BasicAuth/BasicAuthCardLayout.tsx
@@ -11,13 +11,9 @@ export function BasicAuthCardLayout({ children }: BasicAuthCardLayoutProps) {
         p={8}
         maxWidth="600px"
         borderWidth={1}
-        borderRadius={8}
-        boxShadow="lg"
-        textAlign={['left']}
+        borderRadius={4}
         margin="auto"
         marginTop="40px"
-        bgColor="white"
-        color="gray.800"
         fontSize="md"
       >
         {children}

--- a/src/components/BasicAuth/BasicAuthFlow/LandingContent.tsx
+++ b/src/components/BasicAuth/BasicAuthFlow/LandingContent.tsx
@@ -82,6 +82,7 @@ export function LandingContent({
         <br />
 
         <Button
+          variant="primary"
           isDisabled={isSubmitDisabled}
           width="100%"
           type="submit"

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -67,17 +67,13 @@ export function ConfigureInstallationBase(
         <form style={{ width: '100%', maxWidth: '50rem' }} onSubmit={onSave}>
           <Stack direction="row" spacing={4} marginBottom="20px" flexDir="row-reverse">
             <Button
-              backgroundColor="gray.800"
-              _hover={{ backgroundColor: 'gray.600' }}
+              variant="primary"
               type="submit"
               isDisabled={isDisabled}
             >
               {isCreateMode ? 'Install' : 'Save'}
             </Button>
             <Button
-              backgroundColor="gray.200"
-              color="blackAlpha.700"
-              _hover={{ backgroundColor: 'gray.300' }}
               isDisabled={isDisabled}
               onClick={onReset}
             >Reset
@@ -85,15 +81,11 @@ export function ConfigureInstallationBase(
           </Stack>
           <Box
             p={8}
-            width="100%"
-            border="1px solid #EFEFEF"
-            borderRadius={8}
-            boxShadow="md"
-            textAlign={['left']}
+            borderRadius={4}
+            boxShadow="sm"
             margin="auto"
-            bgColor="white"
-            maxHeight="100%"
-            overflowY="scroll"
+            backgroundColor="white"
+            border="1px solid gray.100"
             minHeight={300}
           >
             {loading && <LoadingIcon />}

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -75,16 +75,15 @@ export function ObjectManagementNav({
       <Box
         p={8}
         maxWidth="55rem"
-        border="1px solid #EFEFEF"
-        borderRadius={6}
-        boxShadow="md"
+        borderRadius={4}
         margin="auto"
-        bgColor="whitesmoke"
         display="flex"
         gap="6"
         minHeight="100%"
-        color="gray.800"
         fontSize="md"
+        backgroundColor="#FCFCFC"
+        border="1px solid #EFEFEF"
+        boxShadow="0px 4px 8px rgba(0, 0, 0, 0.05)"
       >
         <Box width="20rem">
           <Text>{getProviderName(provider)} integration</Text>

--- a/src/components/NoAuth/NoAuthFlow/LandingContent.tsx
+++ b/src/components/NoAuth/NoAuthFlow/LandingContent.tsx
@@ -24,6 +24,7 @@ export function LandingContent({
         <NoAuthErrorAlert error={error} />
         <br />
         <Button
+          variant="primary"
           isDisabled={isButtonDisabled}
           width="100%"
           type="submit"

--- a/src/components/Oauth/NoWorkspaceEntry/ClientCredentialsContent.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/ClientCredentialsContent.tsx
@@ -94,6 +94,7 @@ export function ClientCredentialsContent({
         <br />
 
         <Button
+          variant="primary"
           isDisabled={isSubmitDisabled}
           width="100%"
           type="submit"

--- a/src/components/Oauth/NoWorkspaceEntry/LandingContent.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/LandingContent.tsx
@@ -24,6 +24,7 @@ export function LandingContent({
         <OAuthErrorAlert error={error} />
         <br />
         <Button
+          variant="primary"
           isDisabled={isButtonDisabled}
           width="100%"
           type="submit"

--- a/src/components/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
@@ -44,6 +44,7 @@ export function SalesforceSubdomainEntry({
         </Flex>
         <br />
         <Button
+          variant="primary"
           isDisabled={isButtonDisabled}
           width="100%"
           type="submit"

--- a/src/components/Oauth/WorkspaceEntry/ClientCredentialsContent.tsx
+++ b/src/components/Oauth/WorkspaceEntry/ClientCredentialsContent.tsx
@@ -104,6 +104,7 @@ export function ClientCredentialsContent({
         <br />
 
         <Button
+          variant="primary"
           isDisabled={isSubmitDisabled}
           width="100%"
           type="submit"

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceEntry.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceEntry.tsx
@@ -32,6 +32,7 @@ export function WorkspaceEntry({
         </Flex>
         <br />
         <Button
+          variant="primary"
           isDisabled={isButtonDisabled}
           width="100%"
           type="submit"

--- a/src/components/ThemeProvider/Button/buttonTheme.ts
+++ b/src/components/ThemeProvider/Button/buttonTheme.ts
@@ -1,11 +1,26 @@
 // define custom button variants
 export const buttonVariants = {
+  primary: {
+    bg: 'black', // Background color
+    color: 'white', // Text color
+    _hover: {
+      bg: 'gray.700', // Background color on hover
+      _disabled: {
+        bg: 'gray.600', // Background color for disabled state
+      },
+    },
+    _disabled: {
+      bg: 'gray.600', // Background color for disabled state
+      color: 'gray.300', // Text color for disabled state
+      cursor: 'not-allowed', // Optional: Disable the pointer
+      opacity: 1, // Ensure it is fully visible (no transparency)
+    },
+  },
   warning: {
     bg: 'red.50', // Background color
-    outlineColor: 'red.800',
-    outline: '2px solid',
+    outline: '2px solid red.100',
     outlineOffset: '0',
-    borderColor: 'red.800', // Border color
+    borderColor: 'red.100', // Border color
     color: 'red.800', // Text color
     _hover: {
       bg: 'red.100', // Background color on hover

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -1,4 +1,6 @@
-import { ChakraProvider, extendTheme, withDefaultColorScheme } from '@chakra-ui/react';
+import {
+  ChakraProvider, extendTheme, withDefaultColorScheme,
+} from '@chakra-ui/react';
 
 import { buttonVariants } from './Button';
 
@@ -10,15 +12,15 @@ const customTheme = extendTheme({
           width: '100%',
           borderRadius: '4px',
           _hover: {
-            bg: 'gray.300',
+            bg: 'gray.200',
           },
           _selected: {
             color: 'black', // Set the color of the selected tab to 'black
             fontWeight: '500', // Set the font weight of the selected tab
-            bg: 'gray.200', // Set the background color of the selected tab
+            bg: 'gray.100', // Set the background color of the selected tab
             border: 'none',
             _hover: {
-              bg: 'gray.300',
+              bg: 'gray.200',
             },
           },
         },
@@ -27,15 +29,15 @@ const customTheme = extendTheme({
           width: '100%',
           borderRadius: '4px',
           _hover: {
-            bg: 'red.200',
+            bg: 'red.100',
           },
           _selected: {
             color: 'red.800', // Set the color of the selected tab
             fontWeight: '500', // Set the font weight of the selected tab
-            bg: 'red.100', // Set the background color of the selected tab
+            bg: 'red.50', // Set the background color of the selected tab
             border: 'none',
             _hover: {
-              bg: 'red.200',
+              bg: 'red.100',
             },
           },
         },
@@ -47,13 +49,7 @@ const customTheme = extendTheme({
   },
 });
 
-const theme = extendTheme(
-  withDefaultColorScheme({
-    colorScheme: 'facebook',
-    components: ['Button'],
-  }),
-  customTheme,
-);
+const theme = extendTheme(customTheme);
 
 type ThemeProviderProps = {
   children: React.ReactNode;


### PR DESCRIPTION
### Summary
This PR attempts to update styles to better "smart defaults". 
- make colors more muted
- update button styles to be black/gray
- reduces border radius and shadows to be less pronounced.
- adds a primary button variant
- removes default chakra/fb styling

### demo
![react-style-update-defaults](https://github.com/user-attachments/assets/ce73e1eb-f0bf-42e3-bbc8-95fa218aac43)

<img width="1033" alt="Screenshot 2024-09-06 at 4 10 11 PM" src="https://github.com/user-attachments/assets/c55ab213-4f95-4693-ba31-0c9de15f10ee">
<img width="995" alt="Screenshot 2024-09-06 at 4 10 24 PM" src="https://github.com/user-attachments/assets/f2037ea3-ca3a-4631-9aed-d05ed305e47f">
<img width="907" alt="Screenshot 2024-09-06 at 4 10 53 PM" src="https://github.com/user-attachments/assets/73fa1dbb-12b9-40dd-b5fd-d6b111dab89b">



