### PR TITLE
[ENG-1533] feat: add a uninstalled success box

### DIFF
--- a/src/components/Configure/content/UninstallContent.tsx
+++ b/src/components/Configure/content/UninstallContent.tsx
@@ -9,7 +9,9 @@ import { api } from 'services/api';
 export function UninstallContent() {
   const apiKey = useApiKey();
   const { projectId, appName } = useProject();
-  const { integrationId, installation, resetInstallations } = useInstallIntegrationProps();
+  const {
+    integrationId, installation, resetInstallations, setIntegrationDeleted,
+  } = useInstallIntegrationProps();
   const [loading, setLoading] = useState<boolean>(false);
   const isDisabled = !projectId || !integrationId || !installation?.id || loading;
 
@@ -30,7 +32,9 @@ export function UninstallContent() {
             },
           },
         );
+
         resetInstallations();
+        setIntegrationDeleted();
         console.warn('successfully uninstalled installation: ', installation.id);
       } catch (e) {
         console.error('error uninstalling installation', e);

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -7,6 +7,7 @@ import { useConnections } from 'context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { HydratedRevision } from 'services/api';
+import { SuccessTextBox } from 'src/components/SuccessTextBox';
 
 import { onCreateInstallationProxyOnly } from '../../actions/proxy/onCreateInstallationProxyOnly';
 import { useHydratedRevision } from '../../state/HydratedRevisionContext';
@@ -35,6 +36,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
   const { hydratedRevision, loading: hydratedRevisionLoading } = useHydratedRevision();
   const {
     integrationObj, installation, groupRef, consumerRef, setInstallation, onInstallSuccess,
+    isIntegrationDeleted,
   } = useInstallIntegrationProps();
   const { selectedConnection } = useConnections();
   const [createInstallLoading, setCreateInstallLoading] = useState(false);
@@ -70,6 +72,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
   if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
   if (isLoading) return <LoadingIcon />;
   if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;
+  if (isIntegrationDeleted) return <SuccessTextBox text="Integration successfully uninstalled." />;
 
   return (
     <div>

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -10,6 +10,8 @@ import {
 } from 'services/api';
 import { findIntegrationFromList } from 'src/utils';
 
+import { useIsInstallationDeleted } from '../hooks/useIsInstallationDeleted';
+
 import { useApiKey } from './ApiKeyContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 import { useIntegrationList } from './IntegrationListContextProvider';
@@ -29,6 +31,8 @@ interface InstallIntegrationContextValue {
   resetInstallations: () => void;
   onInstallSuccess?: (installationId: string, config: Config) => void;
   onUpdateSuccess?: (installationId: string, config: Config) => void;
+  isIntegrationDeleted: boolean;
+  setIntegrationDeleted: () => void;
 }
 // Create a context to pass down the props
 export const InstallIntegrationContext = createContext<InstallIntegrationContextValue>({
@@ -44,6 +48,8 @@ export const InstallIntegrationContext = createContext<InstallIntegrationContext
   resetInstallations: () => { },
   onInstallSuccess: undefined,
   onUpdateSuccess: undefined,
+  isIntegrationDeleted: false,
+  setIntegrationDeleted: () => { },
 });
 
 // Create a custom hook to access the props
@@ -73,10 +79,11 @@ export function InstallIntegrationProvider({
   const apiKey = useApiKey();
   const { projectId } = useProject();
   const { integrations } = useIntegrationList();
+  const { setError, isError } = useErrorState();
+  const { isIntegrationDeleted, setIntegrationDeleted } = useIsInstallationDeleted();
 
   const [installations, setInstallations] = useState<Installation[]>([]);
   const [isLoading, setLoadingState] = useState<boolean>(true);
-  const { setError, isError } = useErrorState();
 
   const installation = installations?.[0] || null; // there should only be one installation for mvp
 
@@ -145,8 +152,11 @@ export function InstallIntegrationProvider({
     resetInstallations,
     onInstallSuccess,
     onUpdateSuccess,
-  }), [integrationObj, consumerRef, consumerName, groupRef,
-    groupName, installation, setInstallation, resetInstallations, onInstallSuccess, onUpdateSuccess]);
+    isIntegrationDeleted,
+    setIntegrationDeleted,
+  }), [integrationObj, consumerRef, consumerName, groupRef, groupName,
+    installation, setInstallation, resetInstallations, onInstallSuccess, onUpdateSuccess,
+    isIntegrationDeleted, setIntegrationDeleted]);
 
   if (integrationObj !== null) {
     const errorMessage = 'Error retrieving installation information for integration '

--- a/src/hooks/useIsInstallationDeleted.ts
+++ b/src/hooks/useIsInstallationDeleted.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from 'react';
+
+// custom hook to check if the integration is deleted
+// deleted integration triggers a terminal state in the InstallIntegrationApp
+export const useIsInstallationDeleted = () => {
+  const [isIntegrationDeleted, setIsIntegrationDeleted] = useState<boolean>(false);
+
+  const setIntegrationDeleted = useCallback(() => {
+    setIsIntegrationDeleted(true);
+  }, [setIsIntegrationDeleted]);
+
+  return { isIntegrationDeleted, setIntegrationDeleted };
+};


### PR DESCRIPTION
### Summary
Uninstall integration UX is a little unclear as the form still exists with an uninstall message. This replaces the component with an Uninstall Success Box. 
- adds terminal state after uninstalling an integration

context: https://ampersand-company.slack.com/archives/C06NLLVMXU7/p1725915995197509?thread_ts=1725877852.982429&cid=C06NLLVMXU7

#### demo
![uninstall-integration-success](https://github.com/user-attachments/assets/cadd6774-4ea5-4664-96e6-82fee86a0397)


