### PR TITLE
[ENG-1532] feat: add onUninstallSuccess in InstallIntegration

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -20,11 +20,13 @@ interface InstallIntegrationProps {
   groupName?: string,
   onInstallSuccess?: (installationId: string, config: Config) => void,
   onUpdateSuccess?: (installationId: string, config: Config) => void,
+  onUninstallSuccess?: (installationId: string) => void,
 }
 
 export function InstallIntegration(
   {
     integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
+    onUninstallSuccess,
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();
@@ -43,6 +45,7 @@ export function InstallIntegration(
       groupName={groupName}
       onInstallSuccess={onInstallSuccess}
       onUpdateSuccess={onUpdateSuccess}
+      onUninstallSuccess={onUninstallSuccess}
     >
       <ConnectionsProvider groupRef={groupRef}>
         <ProtectedConnectionLayout

--- a/src/components/Configure/content/UninstallContent.tsx
+++ b/src/components/Configure/content/UninstallContent.tsx
@@ -10,7 +10,7 @@ export function UninstallContent() {
   const apiKey = useApiKey();
   const { projectId, appName } = useProject();
   const {
-    integrationId, installation, resetInstallations, setIntegrationDeleted,
+    integrationId, installation, resetInstallations, setIntegrationDeleted, onUninstallSuccess,
   } = useInstallIntegrationProps();
   const [loading, setLoading] = useState<boolean>(false);
   const isDisabled = !projectId || !integrationId || !installation?.id || loading;
@@ -33,9 +33,10 @@ export function UninstallContent() {
           },
         );
 
+        console.warn('successfully uninstalled installation: ', installation.id);
+        onUninstallSuccess?.(installation?.id); // callback
         resetInstallations();
         setIntegrationDeleted();
-        console.warn('successfully uninstalled installation: ', installation.id);
       } catch (e) {
         console.error('error uninstalling installation', e);
       } finally {

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -31,6 +31,7 @@ interface InstallIntegrationContextValue {
   resetInstallations: () => void;
   onInstallSuccess?: (installationId: string, config: Config) => void;
   onUpdateSuccess?: (installationId: string, config: Config) => void;
+  onUninstallSuccess?: (installationId: string) => void;
   isIntegrationDeleted: boolean;
   setIntegrationDeleted: () => void;
 }
@@ -48,6 +49,7 @@ export const InstallIntegrationContext = createContext<InstallIntegrationContext
   resetInstallations: () => { },
   onInstallSuccess: undefined,
   onUpdateSuccess: undefined,
+  onUninstallSuccess: undefined,
   isIntegrationDeleted: false,
   setIntegrationDeleted: () => { },
 });
@@ -70,11 +72,13 @@ interface InstallIntegrationProviderProps {
   children: React.ReactNode,
   onInstallSuccess?: (installationId: string, config: Config) => void,
   onUpdateSuccess?: (installationId: string, config: Config) => void,
+  onUninstallSuccess?: (installationId: string) => void,
 }
 
 // Wrap your parent component with the context provider
 export function InstallIntegrationProvider({
-  children, integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
+  children, integration, consumerRef, consumerName, groupRef, groupName,
+  onInstallSuccess, onUpdateSuccess, onUninstallSuccess,
 }: InstallIntegrationProviderProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
@@ -152,10 +156,12 @@ export function InstallIntegrationProvider({
     resetInstallations,
     onInstallSuccess,
     onUpdateSuccess,
+    onUninstallSuccess,
     isIntegrationDeleted,
     setIntegrationDeleted,
   }), [integrationObj, consumerRef, consumerName, groupRef, groupName,
-    installation, setInstallation, resetInstallations, onInstallSuccess, onUpdateSuccess,
+    installation, setInstallation, resetInstallations,
+    onInstallSuccess, onUpdateSuccess, onUninstallSuccess,
     isIntegrationDeleted, setIntegrationDeleted]);
 
   if (integrationObj !== null) {


### PR DESCRIPTION
### Summary
the `onUninstallSuccess` prop will enable builders to pass in a callback from their application (i.e. page navigation or cleaning up their connections)
- supports uninstall installation callback as a prop

#### tbd 
add in documentation

#### tested in mailmonkey 

```js
 <InstallIntegration
      integration={integration}
      consumerName={userName}
      consumerRef={userId}
      groupRef={groupId}
      groupName={groupName}
      onInstallSuccess= {(installationId: string, configObject: any) => {
        console.log(`Successfully installed ${installationId} with configuration ${JSON.stringify(configObject, null, 2)}`)}                              
      }
      onUpdateSuccess = {(installationId: string, configObject: any) =>{
        console.log(`Successfully updated ${installationId} with configuration ${JSON.stringify(configObject, null, 2)}`)}
      }
      onUninstallSuccess={(installationId: string) =>
        console.log(`Successfully uninstalled ${installationId}`)
      }              
    />
```


