### PR TITLE
[ENG-1538] feat: adds ampersand footer to oauth card layout

### DIFF
--- a/src/components/Oauth/NoWorkspaceEntry/ClientCredentialsContent.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/ClientCredentialsContent.tsx
@@ -11,7 +11,7 @@ import {
   Textarea,
 } from '@chakra-ui/react';
 
-import { OauthCardLayout } from 'components/Oauth/OauthCardLayout';
+import { OauthCardLayout } from 'components/Oauth/OauthCardLayout/OauthCardLayout';
 import { OAuthErrorAlert } from 'components/Oauth/OAuthErrorAlert';
 import { convertTextareaToArray } from 'src/utils';
 

--- a/src/components/Oauth/NoWorkspaceEntry/LandingContent.tsx
+++ b/src/components/Oauth/NoWorkspaceEntry/LandingContent.tsx
@@ -2,7 +2,7 @@ import {
   Button, FormControl, FormLabel, Heading,
 } from '@chakra-ui/react';
 
-import { OauthCardLayout } from '../OauthCardLayout';
+import { OauthCardLayout } from '../OauthCardLayout/OauthCardLayout';
 import { OAuthErrorAlert } from '../OAuthErrorAlert';
 
 type LandingContentProps = {

--- a/src/components/Oauth/OauthCardLayout/AmpersandFooter.tsx
+++ b/src/components/Oauth/OauthCardLayout/AmpersandFooter.tsx
@@ -1,0 +1,31 @@
+/**
+ * Ampersand Logo in footer. Links to Ampersand website.
+ * @returns
+ */
+export function AmpersandFooter() {
+  return (
+    <footer
+      style={{
+        backgroundColor: '#EFEFEF',
+        padding: '1em',
+        fontSize: '0.8em',
+        color: 'gray',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        borderRadius: '0 0 4px 4px',
+        gap: '0.4em',
+      }}
+    >
+      <p>Secured by</p>
+      <a
+        href="https://www.withampersand.com/"
+        target="_blank"
+        aria-label="Go to Ampersand"
+        rel="noreferrer noopener"
+      >
+        <img style={{ height: '.8em' }} src="https://ampersand-website.vercel.app/logo-black.svg" alt="Ampersand" />
+      </a>
+    </footer>
+  );
+}

--- a/src/components/Oauth/OauthCardLayout/OauthCardLayout.tsx
+++ b/src/components/Oauth/OauthCardLayout/OauthCardLayout.tsx
@@ -1,5 +1,7 @@
 import { Box, Container } from '@chakra-ui/react';
 
+import { AmpersandFooter } from './AmpersandFooter';
+
 type OauthCardLayoutProps = {
   children: React.ReactNode;
 };
@@ -8,19 +10,14 @@ export function OauthCardLayout({ children }: OauthCardLayoutProps) {
   return (
     <Container>
       <Box
-        p={8}
         maxWidth="600px"
         borderWidth={1}
-        borderRadius={8}
-        boxShadow="lg"
-        textAlign={['left']}
-        margin="auto"
-        marginTop="40px"
-        bgColor="white"
-        color="gray.800"
-        fontSize="md"
+        borderRadius={4}
       >
-        {children}
+        <div style={{ padding: '3rem 2rem' }}>
+          {children}
+        </div>
+        <AmpersandFooter />
       </Box>
     </Container>
   );

--- a/src/components/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
@@ -4,7 +4,7 @@ import {
   FormLabel, Heading, Input, Link, Text,
 } from '@chakra-ui/react';
 
-import { OauthCardLayout } from '../OauthCardLayout';
+import { OauthCardLayout } from '../OauthCardLayout/OauthCardLayout';
 import { OAuthErrorAlert } from '../OAuthErrorAlert';
 
 const SALESFORCE_HELP_URL = 'https://help.salesforce.com/s/articleView?id=sf.faq_domain_name_what.htm&type=5';
@@ -27,7 +27,7 @@ export function SalesforceSubdomainEntry({
   return (
     <OauthCardLayout>
       <FormControl>
-        <FormLabel marginTop="16" marginBottom="0">
+        <FormLabel>
           <Heading as="h4" size="md">Enter your Salesforce subdomain</Heading>
         </FormLabel>
         <Link href={SALESFORCE_HELP_URL} color="blackAlpha.600" isExternal>

--- a/src/components/Oauth/WorkspaceEntry/ClientCredentialsContent.tsx
+++ b/src/components/Oauth/WorkspaceEntry/ClientCredentialsContent.tsx
@@ -11,7 +11,7 @@ import {
   Textarea,
 } from '@chakra-ui/react';
 
-import { OauthCardLayout } from 'components/Oauth/OauthCardLayout';
+import { OauthCardLayout } from 'components/Oauth/OauthCardLayout/OauthCardLayout';
 import { OAuthErrorAlert } from 'components/Oauth/OAuthErrorAlert';
 import { convertTextareaToArray } from 'src/utils';
 

--- a/src/components/Oauth/WorkspaceEntry/WorkspaceEntry.tsx
+++ b/src/components/Oauth/WorkspaceEntry/WorkspaceEntry.tsx
@@ -3,7 +3,7 @@ import {
   FormLabel, Heading, Input,
 } from '@chakra-ui/react';
 
-import { OauthCardLayout } from '../OauthCardLayout';
+import { OauthCardLayout } from '../OauthCardLayout/OauthCardLayout';
 import { OAuthErrorAlert } from '../OAuthErrorAlert';
 
 type WorkspaceEntryProps = {


### PR DESCRIPTION
### Summary
adds Ampersand logo to login component. Logo directs to ampersand website. 
- adds AmpersandFooter component
- moves OauthCardLayout to its own folder
- updates references to OauthCardLayout

note: css.modules are not supported yet.

![Screenshot 2024-09-10 at 3 06 07 PM](https://github.com/user-attachments/assets/71604f37-0078-4b27-a788-283bb1ccf5d3)

