### PR TITLE
[ENG-1516] poc: css migration to remove chakra

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
       "import": "./build/amp-react.es.js",
       "require": "./build/amp-react.cjs.js",
       "types": "./build/index.d.ts"
-    }
+    },
+     "./styles": "./build/style.css"
   },
   "files": [
     "build"
@@ -60,6 +61,7 @@
     "@types/lodash.isequal": "^4.5.7",
     "@types/node": "^22.0.0",
     "@types/react": "^18.2.33",
+    "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.10.0",
     "@typescript-eslint/parser": "^7.10.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/components/Oauth/OauthCardLayout/OauthCardLayout.tsx
+++ b/src/components/Oauth/OauthCardLayout/OauthCardLayout.tsx
@@ -1,4 +1,6 @@
-import { Box, Container } from '@chakra-ui/react';
+import { Container } from '@chakra-ui/react';
+
+import { Box } from 'src/components/ui-base/Box/Box';
 
 import { AmpersandFooter } from './AmpersandFooter';
 
@@ -9,11 +11,7 @@ type OauthCardLayoutProps = {
 export function OauthCardLayout({ children }: OauthCardLayoutProps) {
   return (
     <Container>
-      <Box
-        maxWidth="600px"
-        borderWidth={1}
-        borderRadius={4}
-      >
+      <Box>
         <div style={{ padding: '3rem 2rem' }}>
           {children}
         </div>

--- a/src/components/ui-base/Box/Box.tsx
+++ b/src/components/ui-base/Box/Box.tsx
@@ -1,0 +1,32 @@
+import { Box as ChakraBox } from '@chakra-ui/react';
+
+import { isChakraRemoved } from '../constant';
+
+import classes from './box.module.css';
+
+type BoxProps = {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export function Box({ children, className, style }: BoxProps) {
+  if (!isChakraRemoved) {
+    return (
+      <ChakraBox
+        className={className}
+        style={style}
+        borderWidth={1}
+        borderRadius={4}
+      >
+        {children}
+      </ChakraBox>
+    );
+  }
+
+  return (
+    <div className={className ? `${classes.box} ${className}` : classes.box} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui-base/Box/box.module.css
+++ b/src/components/ui-base/Box/box.module.css
@@ -1,0 +1,6 @@
+.box {
+    border-radius: 4px;
+    background-color: var(--amp-colors-white);
+    box-shadow: var(--amp-shadows-sm);
+    border: 1px solid var(--amp-colors-border);
+}

--- a/src/components/ui-base/constant.ts
+++ b/src/components/ui-base/constant.ts
@@ -1,0 +1,13 @@
+/**
+ * feature flag to remove chakra-ui
+ * components should work with and without chakra-ui, and the imported styles
+ *
+ * To test with css modules, you must import the variable.css file into the parent app.
+ * In the root component of the parent app you must add the following css import; then you
+ * can turn this flag on to see the swapped component (non-chakra-ui).
+ * ```
+ * import '@amp-labs/react/styles
+ * ```
+ *
+ */
+export const isChakraRemoved = false;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+// src/global.d.ts
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
+import './styles/variables.css';
+
 export * from './public';

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,22 @@
+:root {
+    /* color tokens */
+    --amp-colors-white: #ffffff;
+    --amp-colors-black: #000000;
+
+    --amp-colors-neutral-50: #fafafa;
+    --amp-colors-neutral-100: #f5f5f5;
+    --amp-colors-neutral-200: #e5e5e5;
+    --amp-colors-neutral-300: #d4d4d4;
+    --amp-colors-neutral-400: #a3a3a3;
+    --amp-colors-neutral-500: #737373;
+    --amp-colors-neutral-600: #525252;
+    --amp-colors-neutral-700: #404040;
+    --amp-colors-neutral-800: #262626;
+    --amp-colors-neutral-900: #171717;
+    --amp-colors-neutral-950: #0a0a0a;
+
+    /* semantic colors  */
+    --amp-shadows-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    
+    --amp-colors-border: var(--amp-colors-neutral-200);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,10 +2708,17 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
-"@types/react@^18.2.33":
-  version "18.3.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.8.tgz#1672ab19993f8aca7c7dc844c07d5d9e467d5a79"
-  integrity sha512-syBUrW3/XpnW4WJ41Pft+I+aPoDVbrBVQGEnbD7NijDGlVC+8gV/XKRY+7vMDlfPpbwYt0l1vd/Sj8bJGMbs9Q==
+"@types/react-dom@^18.3.0":
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
+  integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*", "@types/react@^18.2.33":
+  version "18.3.5"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
+  integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
### Summary
Chakra UI has served as a powerful tool to get the embedded library bootstrapped. However, the advanced tooling and ease of use come at the cost of less flexibility, reliant dependencies, and issues related to [emotion](https://dev.to/srmagura/why-were-breaking-up-wiht-css-in-js-4g9b). This PR demos the migration process using the Chakra-UI `Box`. 

During the process of vetting alternative solutions, the author of Chakra-UI has indicated that two things need to be used to [replace chakra-ui](https://www.adebayosegun.com/blog/the-future-of-chakra-ui).
1. a headless library ([ark](https://ark-ui.com/), [radix](https://www.radix-ui.com/), shadcn, react-aria...)
2. a styling solution. ([panda](https://panda-css.com/), [vanilla extract](https://vanilla-extract.style/), etc...)

#### Problems
The last few weeks, I've tried very quick attempts at integration and common migration issues come up.
- styling for chakra and styling solution may have conflicting styles
- would we require the user to install both chakra and future styling solutions (would these be breaking?)

The core question wasn't about which styling or lib solution, it will be: **how will we migrate**?

#### Solution 
This PR demos a POC to start the migration process. In order to stop migrate each component piece by piece, we will use **css modules** to build native components or choose to import headless components on demand (like [radix](https://www.radix-ui.com/primitives/docs/overview/introduction), which is also compatible with module.css). The decision to choose a styling library (like Panda.css) will be deferred as the dx is not a priority yet. CSS modules will also minimize the chance of style conflicts with Chakra and other parent app external design systems.

We create a `variable.css` borrowed from Panda's suggestion to share styles between the parent app the library. The `variable.css` will include **color tokens** and **semantic colors** that will standardize the colors used across components. In the future, this might allow the parent app to modify semantic colors to customize their embedded components.

To migrate piece by piece we will slowly add bridge components, which support the local and the Chakra component. By supporting both using a `isChakraRemoved` feature flag, we can minimize breaking changes as requiring the user to add the import state for the `style.css` or `variable.css` could confuse the user as why both the imports and Chakra need to be supported. When Chakra UI components have been replicated, we can turn the feature flag on, remove the chakra dependency, and upgrade to use a break change version number. 

#### testing css components (non-chakra)
To support native css shared styles, the user must add the following import for the shared stylesheet.
```js
import {
  AmpersandProvider,
  InstallIntegration,
} from '@amp-labs/react';

// new import and breaking change
import '@amp-labs/react/styles';

// rest of app
```

then change `isChakraRemoved=true` in `src/components/ui-base/constant.ts`


#### Chakra OauthLayoutCard Box
<img width="611" alt="Screenshot 2024-09-12 at 5 03 39 PM" src="https://github.com/user-attachments/assets/ec97a413-170b-4150-83d5-985e60f6bbe0">

#### Native Box
<img width="595" alt="Screenshot 2024-09-12 at 5 04 31 PM" src="https://github.com/user-attachments/assets/238ba2d9-1161-4892-af2a-57252cb1fedb">

#### Verifying native css is successful
In the chrome dev tools, you can inspect and see that colors and css variables are present for both `chakra` and `amp-colors`. Only `chakra` colors will be present if the import stylesheet is not present. 

![Screenshot 2024-09-12 at 5 05 00 PM](https://github.com/user-attachments/assets/1905a29e-d607-4a05-adfc-6bba088bf033)

##### if borders are not present, the stylesheet was not imported and the feature flag is turned on. 
<img width="706" alt="Screenshot 2024-09-12 at 5 07 17 PM" src="https://github.com/user-attachments/assets/c6178301-7341-4b7a-a84a-134ad3a128eb">


