### PR TITLE
feat/refactor: update to new loading component

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -5,7 +5,7 @@ import {
   Box, Button, Stack,
 } from '@chakra-ui/react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
+import { LoadingCentered } from 'components/Loading';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 
 import { OTHER_CONST } from '../nav/ObjectManagementNav/constant';
@@ -62,7 +62,7 @@ export function ConfigureInstallationBase(
   const isUninstall = selectedObjectName === UNINSTALL_INSTALLATION_CONST;
 
   return (
-    isLoading ? <LoadingIcon />
+    isLoading ? <LoadingCentered />
       : (
         <form style={{ width: '100%', maxWidth: '50rem' }} onSubmit={onSave}>
           <Stack direction="row" spacing={4} marginBottom="20px" flexDir="row-reverse">
@@ -88,7 +88,7 @@ export function ConfigureInstallationBase(
             border="1px solid gray.100"
             minHeight={300}
           >
-            {loading && <LoadingIcon />}
+            {loading && <LoadingCentered />}
             {hydratedRevision && !isUninstall && !isNonConfigurableWrite && <ReadFields />}
             {hydratedRevision && !isUninstall && isNonConfigurableWrite && <WriteFields />}
             {!loading && isUninstall && <UninstallContent />}

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
+import { LoadingCentered } from 'components/Loading';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
@@ -70,7 +70,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
     integrationObj?.id, groupRef, consumerRef, setInstallation, isLoading, onInstallSuccess]);
 
   if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
-  if (isLoading) return <LoadingIcon />;
+  if (isLoading) return <LoadingCentered />;
   if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;
   if (isIntegrationDeleted) return <SuccessTextBox text="Integration successfully uninstalled." />;
 

--- a/src/components/Loading/LoadingIcon.tsx
+++ b/src/components/Loading/LoadingIcon.tsx
@@ -1,12 +1,12 @@
 import {
-  Box, Spinner, Stack, Text,
+  Box, Spinner, Stack,
 } from '@chakra-ui/react';
 
-interface LoadingIconProps {
-  message?: string;
-}
-
-export function LoadingIcon({ message }: LoadingIconProps) {
+/**
+ * @deprecated - removing this component with Chakra
+ * @returns
+ */
+export function LoadingIcon() {
   return (
     <Box
       className="loading-icon"
@@ -29,7 +29,6 @@ export function LoadingIcon({ message }: LoadingIconProps) {
           size="xl"
           margin="20px"
         />
-        {message && <Text fontSize="40px" color="#4299e1">{message}</Text>}
       </Stack>
     </Box>
   );

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,39 @@
+import { isChakraRemoved } from '../ui-base/constant';
+
+import { LoadingIcon } from './LoadingIcon';
+
+import classes from './style.module.css';
+
+/**
+ * supported after removing chakra-ui
+ * @returns
+ */
+function Loading() {
+  return (
+    <span className={classes.loader} />
+  );
+}
+
+/**
+ * replaces LoadingIcon with a simple spinner centered in div
+ * @returns
+ */
+export function LoadingCentered() {
+  if (isChakraRemoved) {
+    return (
+      <div style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        justifyContent: 'center',
+        marginTop: '20%',
+        marginBottom: '20%',
+      }}
+      >
+        <Loading />
+      </div>
+    );
+  }
+
+  return <LoadingIcon />;
+}

--- a/src/components/Loading/style.module.css
+++ b/src/components/Loading/style.module.css
@@ -1,0 +1,61 @@
+.loader {
+    animation: rotate 1s infinite;
+    height: 50px;
+    width: 50px;
+}
+
+.loader:before,
+.loader:after {
+    border-radius: 50%;
+    content: "";
+    display: block;
+    height: 20px;
+    width: 20px;
+}
+.loader:before {
+    animation: ball1 1s infinite;
+    background-color: var(--amp-colors-accent-primary);
+    box-shadow: 30px 0 0 var(--amp-colors-accent-secondary);
+    margin-bottom: 10px;
+}
+.loader:after {
+    animation: ball2 1s infinite;
+    background-color: var(--amp-colors-accent-secondary);
+    box-shadow: 30px 0 0 var(--amp-colors-accent-primary);
+}
+
+@keyframes rotate {
+    0% { transform: rotate(0deg) scale(0.8) }
+    50% { transform: rotate(360deg) scale(1.2) }
+    100% { transform: rotate(720deg) scale(0.8) }
+}
+
+@keyframes ball1 {
+    0% {
+        box-shadow: 30px 0 0 var(--amp-colors-accent-secondary);
+    }
+    50% {
+        box-shadow: 0 0 0 var(--amp-colors-accent-secondary);;
+        margin-bottom: 0;
+        transform: translate(15px, 15px);
+    }
+    100% {
+        box-shadow: 30px 0 0 var(--amp-colors-accent-secondary);
+        margin-bottom: 10px;
+    }
+}
+
+@keyframes ball2 {
+    0% {
+        box-shadow: 30px 0 0 var(--amp-colors-accent-primary);
+    }
+    50% {
+        box-shadow: 0 0 0 var(--amp-colors-accent-primary);
+        margin-top: -20px;
+        transform: translate(15px, 15px);
+    }
+    100% {
+        box-shadow: 30px 0 0 var(--amp-colors-accent-primary);
+        margin-top: 0;
+    }
+}

--- a/src/components/RedirectHandler/RedirectHandler.tsx
+++ b/src/components/RedirectHandler/RedirectHandler.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Box } from '@chakra-ui/react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
+import { LoadingCentered } from 'components/Loading';
 
 type RedirectHandlerProps = {
   redirectURL?: string;
@@ -29,7 +29,8 @@ export function RedirectHandler({ redirectURL, children } : RedirectHandlerProps
   if (redirectURL) {
     return (
       <Box display="flex" alignItems="center" justifyContent="center">
-        <LoadingIcon message="Redirecting..." />
+        <LoadingCentered />
+        <p>Redirecting</p>
       </Box>
     );
   }

--- a/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthClientCredsFlow.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthClientCredsFlow.tsx
@@ -9,10 +9,10 @@ import {
   ClientCredentialsContent,
   ClientCredentialsCreds,
 } from 'components/auth/Oauth/NoWorkspaceEntry/ClientCredentialsContent';
+import { LoadingCentered } from 'components/Loading';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
-import { LoadingIcon } from 'src/assets/LoadingIcon';
 
 interface NoWorkspaceOauthClientCredsFlowProps {
   provider: string;
@@ -75,5 +75,5 @@ export function NoWorkspaceOauthClientCredsFlow({
     );
   }
 
-  return <LoadingIcon />;
+  return <LoadingCentered />;
 }

--- a/src/components/auth/Oauth/WorkspaceEntry/WorkspaceOauthClientCredsFlow.tsx
+++ b/src/components/auth/Oauth/WorkspaceEntry/WorkspaceOauthClientCredsFlow.tsx
@@ -9,10 +9,10 @@ import {
   ClientCredentialsContent,
   WorkspaceClientCredentialsCreds,
 } from 'components/auth/Oauth/WorkspaceEntry/ClientCredentialsContent';
+import { LoadingCentered } from 'components/Loading';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
-import { LoadingIcon } from 'src/assets/LoadingIcon';
 
 interface NoWorkspaceOauthClientCredsFlowProps {
   provider: string;
@@ -77,5 +77,5 @@ export function WorkspaceOauthClientCredsFlow({
     );
   }
 
-  return <LoadingIcon />;
+  return <LoadingCentered />;
 }

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -3,9 +3,9 @@ import {
   useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Connection } from 'services/api';
+import { LoadingCentered } from 'src/components/Loading';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import {
@@ -93,7 +93,7 @@ export function ConnectionsProvider({
       ? <ErrorTextBox message="Error retrieving existing connections" />
       : (
         <ConnectionsContext.Provider value={contextValue}>
-          {isLoading ? <LoadingIcon /> : children}
+          {isLoading ? <LoadingCentered /> : children}
         </ConnectionsContext.Provider>
       )
   );

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -3,11 +3,11 @@ import {
   useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import {
   api, Config, Installation, Integration,
 } from 'services/api';
+import { LoadingCentered } from 'src/components/Loading';
 import { findIntegrationFromList } from 'src/utils';
 
 import { useIsInstallationDeleted } from '../hooks/useIsInstallationDeleted';
@@ -172,7 +172,7 @@ export function InstallIntegrationProvider({
       isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey))
       ? <ErrorTextBox message={errorMessage} /> : (
         <InstallIntegrationContext.Provider value={props}>
-          {isLoading ? <LoadingIcon /> : children}
+          {isLoading ? <LoadingCentered /> : children}
         </InstallIntegrationContext.Provider>
       );
   }

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -3,9 +3,9 @@ import {
   useMemo, useState,
 } from 'react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Integration } from 'services/api';
+import { LoadingCentered } from 'src/components/Loading';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
@@ -65,7 +65,7 @@ export function IntegrationListProvider(
       ? <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />
       : (
         <IntegrationListContext.Provider value={contextValue}>
-          {isLoading ? <LoadingIcon /> : children}
+          {isLoading ? <LoadingCentered /> : children}
         </IntegrationListContext.Provider>
       )
   );

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -2,9 +2,9 @@ import {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { LoadingIcon } from 'assets/LoadingIcon';
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Project } from 'services/api';
+import { LoadingCentered } from 'src/components/Loading';
 
 import { useApiKey } from './ApiKeyContextProvider';
 import {
@@ -72,7 +72,7 @@ export function ProjectProvider(
       ? <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
       : (
         <ProjectContext.Provider value={contextValue}>
-          {isLoading ? <LoadingIcon /> : children}
+          {isLoading ? <LoadingCentered /> : children}
         </ProjectContext.Provider>
       )
   );

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -22,6 +22,8 @@
     --amp-colors-error-background: #FEF2F2;
     --amp-colors-error-border: #FECACA;
     --amp-colors-error-text: #991B1B;
+    --amp-colors-accent-primary: var(--amp-colors-neutral-700);
+    --amp-colors-accent-secondary: var(--amp-colors-neutral-500);
 
     /* misc */
     --amp-default-border-radius: 4px;


### PR DESCRIPTION
### Summary
adds bridge component for loader. 
- swap chakra for css loader that matches client loader
- move to components/loading

### before 

<img width="762" alt="Screenshot 2024-09-17 at 4 48 20 PM" src="https://github.com/user-attachments/assets/1000d563-fd7e-4b1f-a1b1-1d22969ff580">

### after 

![loading-css-modules](https://github.com/user-attachments/assets/8b451e54-a2a2-41ae-9c25-bb47080b807b)




