### PR TITLE
feat: add bridge Divider component

### DIFF
--- a/src/components/Configure/content/fields/FieldHeader.tsx
+++ b/src/components/Configure/content/fields/FieldHeader.tsx
@@ -1,4 +1,6 @@
-import { Divider, Flex, Heading } from '@chakra-ui/react';
+import { Flex, Heading } from '@chakra-ui/react';
+
+import { Divider } from 'src/components/ui-base/Divider';
 
 interface FieldHeaderProps {
   string: string;
@@ -11,7 +13,7 @@ export function FieldHeader({ string }: FieldHeaderProps) {
         {string}
       </Heading>
       <Flex flex="1" justifyContent="flex-end" alignItems="center">
-        <Divider marginLeft={2} />
+        <Divider style={{ marginLeft: '1rem' }} />
       </Flex>
     </Flex>
   );

--- a/src/components/Configure/nav/ObjectManagementNav/OtherTab.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/OtherTab.tsx
@@ -1,4 +1,4 @@
-import { Divider } from '@chakra-ui/react';
+import { Divider } from 'components/ui-base/Divider';
 
 import { OTHER_CONST } from './constant';
 import { NavObjectItem } from './NavObjectItem';
@@ -12,7 +12,7 @@ type OtherTabProps = {
 export function OtherTab({ pending, completed, displayName }: OtherTabProps) {
   return (
     <>
-      <Divider marginY={3} />
+      <Divider style={{ margin: '1rem 0' }} />
       <NavObjectItem
         key="other-write"
         objectName={OTHER_CONST}

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -2,9 +2,12 @@ import {
   createContext, useContext, useState,
 } from 'react';
 import {
-  Box, Container, Divider, Tabs, Text,
+  Tabs, Text,
 } from '@chakra-ui/react';
 
+import { Box } from 'components/ui-base/Box/Box';
+import { Container } from 'components/ui-base/Container/Container';
+import { Divider } from 'components/ui-base/Divider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { AmpersandFooter } from 'src/layout/AuthCardLayout/AmpersandFooter';
@@ -47,6 +50,9 @@ function getSelectedObject(navObjects: NavObject[], tabIndex: number): NavObject
   return { name: UNINSTALL_INSTALLATION_CONST, completed: false };
 }
 
+const backgroundColor = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-background-secondary').trim() || '#FCFCFC';
+
 // note: when the object key exists in the config; the user has already completed the object before
 export function ObjectManagementNav({
   children,
@@ -73,20 +79,16 @@ export function ObjectManagementNav({
 
   return (
     <SelectedObjectNameContext.Provider value={selectedObject?.name}>
-      <Container maxWidth="55rem">
+      <Container style={{ maxWidth: '55rem' }}>
         <Box
-          p={8}
-          borderRadius={4}
-          margin="auto"
-          display="flex"
-          gap="6"
-          minHeight="100%"
-          fontSize="md"
-          backgroundColor="#FCFCFC"
-          border="1px solid #EFEFEF"
-          boxShadow="0px 4px 8px rgba(0, 0, 0, 0.05)"
+          style={{
+            display: 'flex',
+            gap: '4rem',
+            padding: '3rem',
+            backgroundColor,
+          }}
         >
-          <Box width="20rem">
+          <div style={{ width: '20rem' }}>
             <Text>{getProviderName(provider)} integration</Text>
             <Text marginBottom="20px" fontSize="1.125rem" fontWeight="500">{appName}</Text>
             {isNavObjectsReady && (
@@ -120,17 +122,16 @@ export function ObjectManagementNav({
               {/* Uninstall tab */}
               {installation && (
                 <>
-                  <Divider marginTop={10} marginBottom={3} />
+                  <Divider style={{ margin: '3rem 0 1rem 0' }} />
                   <UninstallInstallation
                     key="uninstall-installation"
                     text="Uninstall"
                   />
                 </>
-
               )}
             </Tabs>
             )}
-          </Box>
+          </div>
           {children}
         </Box>
         <AmpersandFooter />

--- a/src/components/ui-base/Divider/divider.module.css
+++ b/src/components/ui-base/Divider/divider.module.css
@@ -1,0 +1,3 @@
+.divider {
+    border-color: var(--amp-colors-border);
+}

--- a/src/components/ui-base/Divider/index.tsx
+++ b/src/components/ui-base/Divider/index.tsx
@@ -1,0 +1,21 @@
+import { Divider as ChakraDivider } from '@chakra-ui/react';
+
+import { isChakraRemoved } from '../constant';
+
+import classes from './divider.module.css';
+
+export function Divider({ className, style }:
+{ className?: string, style?: React.CSSProperties }) {
+  if (isChakraRemoved) {
+    return (
+      <hr
+        className={className ? `${classes.divider} ${className}` : classes.divider}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <ChakraDivider className={className} style={style} />
+  );
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -24,6 +24,9 @@
     --amp-colors-error-text: #991B1B;
     --amp-colors-accent-primary: var(--amp-colors-neutral-700);
     --amp-colors-accent-secondary: var(--amp-colors-neutral-500);
+    --amp-colors-background: var(--amp-colors-neutral-50);
+    --amp-colors-background-secondary: #FCFCFC;
+    
 
     /* misc */
     --amp-default-border-radius: 4px;


### PR DESCRIPTION
### Summary
add bridge Divider component
- creates a bridge Divider component with custom css
- swaps all existing Divider components with the new bridge Divider component
- swaps out Box and Container in ObjectManagmentNav component

### with Chakra
<img width="888" alt="Screenshot 2024-09-18 at 3 46 58 PM" src="https://github.com/user-attachments/assets/a00ce349-b766-4f04-a2cc-87ba582e780d">

### no Chakra (with css import)
<img width="913" alt="Screenshot 2024-09-18 at 3 46 23 PM" src="https://github.com/user-attachments/assets/9e4b2796-10e8-4061-81ed-c22450ef5759">



