### PR TITLE
refactor: removes chakra from FieldHeader and other components

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,11 +1,8 @@
-import {
-  FormEventHandler,
-} from 'react';
-import {
-  Box, Button, Stack,
-} from '@chakra-ui/react';
+import { FormEventHandler } from 'react';
+import { Button } from '@chakra-ui/react';
 
 import { LoadingCentered } from 'components/Loading';
+import { Box } from 'components/ui-base/Box/Box';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 
 import { OTHER_CONST } from '../nav/ObjectManagementNav/constant';
@@ -24,6 +21,13 @@ interface ConfigureInstallationBaseProps {
   onReset: () => void,
   isLoading: boolean,
 }
+
+// fallback during migration away from chakra-ui, when variable is not defined
+const borderColor = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-neutral-100').trim() || '#f5f5f5';
+
+const boxShadow = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-shadows-sm').trim() || '0 1px 2px 0 rgba(0, 0, 0, 0.05)';
 
 // Installation UI Base
 export function ConfigureInstallationBase(
@@ -65,7 +69,10 @@ export function ConfigureInstallationBase(
     isLoading ? <LoadingCentered />
       : (
         <form style={{ width: '100%', maxWidth: '50rem' }} onSubmit={onSave}>
-          <Stack direction="row" spacing={4} marginBottom="20px" flexDir="row-reverse">
+          <div style={{
+            display: 'flex', flexDirection: 'row-reverse', gap: '1rem', marginBottom: '2rem',
+          }}
+          >
             <Button
               variant="primary"
               type="submit"
@@ -78,15 +85,15 @@ export function ConfigureInstallationBase(
               onClick={onReset}
             >Reset
             </Button>
-          </Stack>
+          </div>
           <Box
-            p={8}
-            borderRadius={4}
-            boxShadow="sm"
-            margin="auto"
-            backgroundColor="white"
-            border="1px solid gray.100"
-            minHeight={300}
+            style={{
+              padding: '2rem',
+              minHeight: '300px',
+              backgroundColor: 'white',
+              borderColor,
+              boxShadow,
+            }}
           >
             {loading && <LoadingCentered />}
             {hydratedRevision && !isUninstall && !isNonConfigurableWrite && <ReadFields />}

--- a/src/components/Configure/content/fields/FieldHeader.tsx
+++ b/src/components/Configure/content/fields/FieldHeader.tsx
@@ -1,20 +1,26 @@
-import { Flex, Heading } from '@chakra-ui/react';
-
 import { Divider } from 'src/components/ui-base/Divider';
 
 interface FieldHeaderProps {
   string: string;
 }
 
+// fallback during migration away from chakra-ui, when variable is not defined
+const color = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-text-secondary').trim() || '#737373';
+
 export function FieldHeader({ string }: FieldHeaderProps) {
   return (
-    <Flex position="relative" paddingTop={8} paddingBottom={4}>
-      <Heading color="gray.500" as="h3" fontSize={16} fontWeight="500">
-        {string}
-      </Heading>
-      <Flex flex="1" justifyContent="flex-end" alignItems="center">
+    <div style={{
+      display: 'flex', position: 'relative', paddingTop: '2rem', paddingBottom: '1rem',
+    }}
+    >
+      <h3 style={{ color, fontSize: '1rem', fontWeight: '500' }}>{string}</h3>
+      <div style={{
+        display: 'flex', flex: 1, justifyContent: 'flex-end', alignItems: 'center',
+      }}
+      >
         <Divider style={{ marginLeft: '1rem' }} />
-      </Flex>
-    </Flex>
+      </div>
+    </div>
   );
 }

--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  Select, Stack, Text,
-} from '@chakra-ui/react';
+import { Select, Stack, Text } from '@chakra-ui/react';
 
 import { HydratedIntegrationFieldExistent, IntegrationFieldMapping } from 'services/api';
 

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -1,11 +1,7 @@
 import { useMemo } from 'react';
-import {
-  Box, FormControl, FormErrorMessage, Stack,
-} from '@chakra-ui/react';
+import { FormControl, FormErrorMessage } from '@chakra-ui/react';
 
-import {
-  ErrorBoundary, useErrorState,
-} from 'context/ErrorContextProvider';
+import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 
 import { isIntegrationFieldMapping } from '../../../utils';
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
@@ -43,29 +39,27 @@ export function RequiredFieldMappings() {
 
   return (
     integrationFieldMappings.length ? (
-      <Box>
+      <>
         <FieldHeader string="Map the following fields (required)" />
-        <Stack>
-          {integrationFieldMappings.map((field: any) => (
-            <FormControl
-              key={field.mapToName}
-              isInvalid={
+        {integrationFieldMappings.map((field: any) => (
+          <FormControl
+            key={field.mapToName}
+            isInvalid={
               isError(
                 ErrorBoundary.MAPPING,
                 field.mapToName,
               )
             }
-            >
-              <FieldMapping
-                allFields={configureState.read?.allFields || []}
-                field={field}
-                onSelectChange={onSelectChange}
-              />
-              <FormErrorMessage> * required</FormErrorMessage>
-            </FormControl>
-          ))}
-        </Stack>
-      </Box>
+          >
+            <FieldMapping
+              allFields={configureState.read?.allFields || []}
+              field={field}
+              onSelectChange={onSelectChange}
+            />
+            <FormErrorMessage> * required</FormErrorMessage>
+          </FormControl>
+        ))}
+      </>
     )
       : null
   );

--- a/src/components/Configure/content/fields/RequiredFields.tsx
+++ b/src/components/Configure/content/fields/RequiredFields.tsx
@@ -1,4 +1,4 @@
-import { Box, Tag } from '@chakra-ui/react';
+import { Tag } from '@chakra-ui/react';
 
 import { useProject } from 'context/ProjectContextProvider';
 
@@ -14,7 +14,7 @@ export function RequiredFields() {
   return (
     <>
       <FieldHeader string={`${appName} reads the following ${selectedObjectName} fields`} />
-      <Box marginBottom="20px" display="flex" gap={1}>
+      <div style={{ display: 'flex', gap: '.5rem', marginBottom: '2rem' }}>
         {configureState?.read?.requiredFields?.length
           ? (configureState.read?.requiredFields.map((field) => {
             if (!isIntegrationFieldMapping(field)) {
@@ -23,7 +23,7 @@ export function RequiredFields() {
             return null; // fallback for customed mapped fields
           }))
           : 'There are no required fields.'}
-      </Box>
+      </div>
     </>
   );
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -26,6 +26,7 @@
     --amp-colors-accent-secondary: var(--amp-colors-neutral-500);
     --amp-colors-background: var(--amp-colors-neutral-50);
     --amp-colors-background-secondary: #FCFCFC;
+    --amp-colors-text-secondary: var(--amp-colors-neutral-500);
     
 
     /* misc */


### PR DESCRIPTION
### Summary
Removes more chakra layout components and simplify html structure by removing unnecessary divs, flex boxes, and stacks. 
- remove chakra-ui box, flex from components: ConfigureInstallationBase.tsx, RequiredFieldMappings.tsx, RequiredFields.tsx
- update some imports
- adds dynamic css fallback for css variables that may not exists during migration 
```js 
// example dynamics css
const boxShadow = getComputedStyle(document.documentElement)
  .getPropertyValue('--amp-shadows-sm').trim() || '0 1px 2px 0 rgba(0, 0, 0, 0.05)';
```

#### visual screenshot
no css files were added, inline style serves as an alternative styling solution
<img width="898" alt="Screenshot 2024-09-18 at 5 07 18 PM" src="https://github.com/user-attachments/assets/2d204174-7da8-4897-a1ad-26157bbe81b9">

