### PR TITLE
refactor: rm chakra-ui tag, add custom tag component

### DIFF
--- a/src/components/Configure/content/fields/RequiredFields.tsx
+++ b/src/components/Configure/content/fields/RequiredFields.tsx
@@ -1,5 +1,4 @@
-import { Tag } from '@chakra-ui/react';
-
+import { Tag } from 'components/ui-base/Tag';
 import { useProject } from 'context/ProjectContextProvider';
 
 import { isIntegrationFieldMapping } from '../../utils';

--- a/src/components/ui-base/Tag/index.tsx
+++ b/src/components/ui-base/Tag/index.tsx
@@ -1,0 +1,31 @@
+type TagProps = {
+  style?: React.CSSProperties,
+  children: React.ReactNode,
+};
+
+const backgroundColor = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-badge').trim() || '#e5e5e5';
+
+const color = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-badge-text').trim() || '#404040';
+
+const defaultStyle = {
+  color,
+  backgroundColor,
+  borderRadius: '4px',
+  display: 'inline-block',
+  fontSize: '0.75rem',
+  fontWeight: 500,
+  lineHeight: '1.25',
+  padding: '0.25rem 0.5rem',
+};
+
+export function Tag({ children, style, ...props }: TagProps) {
+  return (
+    <span
+      style={{ ...defaultStyle, ...style }}
+      {...props}
+    >{children}
+    </span>
+  );
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -27,6 +27,8 @@
     --amp-colors-background: var(--amp-colors-neutral-50);
     --amp-colors-background-secondary: #FCFCFC;
     --amp-colors-text-secondary: var(--amp-colors-neutral-500);
+    --amp-colors-badge: var(--amp-colors-neutral-200);
+    --amp-colors-badge-text: var(--amp-colors-neutral-700);
     
 
     /* misc */


### PR DESCRIPTION
### Summary
removes the tag component, adds native Tag component with updated grayscale.

<img width="902" alt="Screenshot 2024-09-19 at 4 43 13 PM" src="https://github.com/user-attachments/assets/0f047337-8a7f-41f4-8dea-ebebd08e8f76">

<img width="441" alt="Screenshot 2024-09-19 at 4 43 09 PM" src="https://github.com/user-attachments/assets/301f363d-60c1-4460-8971-9418cdfa38f4">

