### PR TITLE
[ENG-1485] feat: add error box UI to installation form 

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,6 +1,7 @@
 import { FormEventHandler } from 'react';
 import { Button } from '@chakra-ui/react';
 
+import { FormErrorBox } from 'components/FormErrorBox';
 import { LoadingCentered } from 'components/Loading';
 import { Box } from 'components/ui-base/Box/Box';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
@@ -20,6 +21,7 @@ interface ConfigureInstallationBaseProps {
   onSave: FormEventHandler,
   onReset: () => void,
   isLoading: boolean,
+  errorMsg?: string,
 }
 
 // fallback during migration away from chakra-ui, when variable is not defined
@@ -32,7 +34,7 @@ const boxShadow = getComputedStyle(document.documentElement)
 // Installation UI Base
 export function ConfigureInstallationBase(
   {
-    onSave, onReset, isLoading, isCreateMode = false,
+    onSave, onReset, isLoading, isCreateMode = false, errorMsg,
   }: ConfigureInstallationBaseProps,
 ) {
   const { installation } = useInstallIntegrationProps();
@@ -95,6 +97,7 @@ export function ConfigureInstallationBase(
               boxShadow,
             }}
           >
+            {errorMsg && <FormErrorBox>{errorMsg}</FormErrorBox>}
             {loading && <LoadingCentered />}
             {hydratedRevision && !isUninstall && !isNonConfigurableWrite && <ReadFields />}
             {hydratedRevision && !isUninstall && isNonConfigurableWrite && <WriteFields />}

--- a/src/components/FormErrorBox.tsx
+++ b/src/components/FormErrorBox.tsx
@@ -1,0 +1,29 @@
+import { Box } from 'src/components/ui-base/Box/Box';
+
+// fallback during migration away from chakra-ui, when variable is not defined
+const backgroundColor = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-error-background').trim() || '#FEF2F2';
+
+const borderColor = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-error-border').trim() || '#FECACA';
+
+const color = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-error-text').trim() || '#991B1B';
+
+const defaultStyle = {
+  backgroundColor,
+  borderColor,
+  color,
+  padding: '.5rem 1rem',
+};
+
+type FormErrorBoxProps = {
+  children: React.ReactNode,
+  style?: React.CSSProperties,
+};
+
+export function FormErrorBox({ children, style }: FormErrorBoxProps) {
+  return (
+    <Box style={{ ...defaultStyle, ...style }}>{children}</Box>
+  );
+}


### PR DESCRIPTION
### Summary 
adds native error form box component and demos in installation form
- does not include error handling logic yet


#### screenshot

<img width="510" alt="Screenshot 2024-09-20 at 4 14 39 PM" src="https://github.com/user-attachments/assets/5ce3bad7-ce83-42b3-8ab3-059465de593c">

<img width="914" alt="Screenshot 2024-09-20 at 4 14 41 PM" src="https://github.com/user-attachments/assets/92653daa-95cc-4288-876e-59bf363be442">
