### PR TITLE
[ENG-1561] feat/refactor: salesforce subdomain entry component

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",
+    "classnames": "^2.5.1",
     "immer": "^10.0.3",
     "lodash.isequal": "^4.5.0"
   },

--- a/src/components/auth/Oauth/Salesforce/ChakraSalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/Salesforce/ChakraSalesforceSubdomainEntry.tsx
@@ -1,0 +1,53 @@
+import { ExternalLinkIcon } from '@chakra-ui/icons';
+import {
+  Button, FormControl,
+  FormLabel, Heading, Input,
+} from '@chakra-ui/react';
+
+import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { AccessibleLink } from 'components/ui-base/AccessibleLink';
+import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
+
+import { SALESFORCE_HELP_URL, SubdomainEntryProps } from './SubdomainEntryProps';
+
+/**
+ * @deprecated - delete file after removing chakra-ui
+ * Salesforce specific subdomain entry component, use workspace entry for other providers.
+ * @param param0
+ * @returns
+ */
+export function ChakraSalesforceSubdomainEntry({
+  handleSubmit, setWorkspace, error, isButtonDisabled,
+}: SubdomainEntryProps) {
+  return (
+    <AuthCardLayout>
+      <FormControl>
+        <FormLabel>
+          <Heading as="h4" size="md">Enter your Salesforce subdomain</Heading>
+        </FormLabel>
+        <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
+          {'What is my Salesforce subdomain? '}
+          <ExternalLinkIcon />
+        </AccessibleLink>
+        <AuthErrorAlert error={error} />
+        <div style={{ display: 'flex', marginTop: '1em' }}>
+          <Input
+            placeholder="MyDomain"
+            onChange={(event) => setWorkspace(event.currentTarget.value)}
+          />
+          <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
+        </div>
+        <br />
+        <Button
+          variant="primary"
+          isDisabled={isButtonDisabled}
+          width="100%"
+          type="submit"
+          onClick={handleSubmit}
+        >
+          Next
+        </Button>
+      </FormControl>
+    </AuthCardLayout>
+  );
+}

--- a/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
@@ -1,59 +1,47 @@
-import { ExternalLinkIcon } from '@chakra-ui/icons';
-import {
-  Button, FormControl,
-  FormLabel, Heading, Input,
-} from '@chakra-ui/react';
-
 import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { FormComponent } from 'components/form';
 import { AccessibleLink } from 'components/ui-base/AccessibleLink';
+import { Button } from 'components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
-const SALESFORCE_HELP_URL = 'https://help.salesforce.com/s/articleView?id=sf.faq_domain_name_what.htm&type=5';
+import { ChakraSalesforceSubdomainEntry } from './ChakraSalesforceSubdomainEntry';
+import { SALESFORCE_HELP_URL, SubdomainEntryProps } from './SubdomainEntryProps';
 
-type SubdomainEntryProps = {
-  handleSubmit: () => void;
-  setWorkspace: (workspace: string) => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-};
-
-/**
- * Salesforce specific subdomain entry component, use workspace entry for other providers.
- * @param param0
- * @returns
- */
 export function SalesforceSubdomainEntry({
   handleSubmit, setWorkspace, error, isButtonDisabled,
 }: SubdomainEntryProps) {
+  const props = {
+    handleSubmit, setWorkspace, error, isButtonDisabled,
+  };
+  if (!isChakraRemoved) {
+    return <ChakraSalesforceSubdomainEntry {...props} />;
+  }
+
   return (
     <AuthCardLayout>
-      <FormControl>
-        <FormLabel>
-          <Heading as="h4" size="md">Enter your Salesforce subdomain</Heading>
-        </FormLabel>
-        <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
-          {'What is my Salesforce subdomain? '}
-          <ExternalLinkIcon />
-        </AccessibleLink>
-        <AuthErrorAlert error={error} />
-        <div style={{ display: 'flex', marginTop: '1em' }}>
-          <Input
-            placeholder="MyDomain"
-            onChange={(event) => setWorkspace(event.currentTarget.value)}
-          />
-          <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
-        </div>
-        <br />
-        <Button
-          variant="primary"
-          isDisabled={isButtonDisabled}
-          width="100%"
-          type="submit"
-          onClick={handleSubmit}
-        >
-          Next
-        </Button>
-      </FormControl>
+      <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>Enter your Salesforce subdomain</h1>
+      <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
+        What is my Salesforce subdomain?
+      </AccessibleLink>
+      <AuthErrorAlert error={error} />
+      <div style={{ display: 'flex', marginTop: '1em' }}>
+        <FormComponent.Input
+          id="salesforce-subdomain"
+          type="text"
+          placeholder="MyDomain"
+          onChange={(event) => setWorkspace(event.currentTarget.value)}
+        />
+        <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
+      </div>
+      <Button
+        style={{ marginTop: '1em' }}
+        disabled={isButtonDisabled}
+        type="submit"
+        onClick={handleSubmit}
+      >
+        Next
+      </Button>
     </AuthCardLayout>
   );
 }

--- a/src/components/auth/Oauth/Salesforce/SubdomainEntryProps.tsx
+++ b/src/components/auth/Oauth/Salesforce/SubdomainEntryProps.tsx
@@ -1,0 +1,8 @@
+export const SALESFORCE_HELP_URL = 'https://help.salesforce.com/s/articleView?id=sf.faq_domain_name_what.htm&type=5';
+
+export type SubdomainEntryProps = {
+  handleSubmit: () => void;
+  setWorkspace: (workspace: string) => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+};

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -1,0 +1,27 @@
+import { InputHTMLAttributes } from 'react';
+import classNames from 'classnames';
+
+import classes from './input.module.css';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  type: string;
+  className?: string;
+  isError?: boolean;
+}
+
+export function Input({
+  id, type, className, isError = false, ...rest
+}: InputProps) {
+  const defaultClassName = isError
+    ? classNames(classes.inputError, classes.input) : classes.input;
+
+  return (
+    <input
+      id={id}
+      type={type}
+      className={classNames(defaultClassName, className)}
+      {...rest}
+    />
+  );
+}

--- a/src/components/form/Input/input.module.css
+++ b/src/components/form/Input/input.module.css
@@ -1,0 +1,36 @@
+.input {
+    border-radius: var(--amp-default-border-radius);
+    border: 1px solid;
+    border-color: inherit;
+    height: 2.5rem;
+    transition: all .20s ease-in;
+
+    color: var(--amp-colors-neutral-800);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5rem; /* 150% */
+    padding: 0 1rem;
+    width: 100%;
+    transition: all .1s ease;
+}
+
+.inputError {
+    border: 1px solid var(--amp-colors-error-border);
+}
+
+.input:focus:enabled {
+    border: 2px solid var(--amp-colors-accent-primary);
+    outline: none;
+}
+
+.input:disabled {
+    background-color: var(--amp-colors-neutral-300);
+    border: 1px solid var(--amp-colors-neutral-400);
+}
+
+.error {
+    color: var(--color-red-600, #DC2626);
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.25rem; /* 142.857% */
+}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,5 @@
+import { Input } from './Input';
+
+export const FormComponent = {
+  Input,
+};

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -1,0 +1,34 @@
+.button {
+    color: var(--amp-colors-button-text);
+    background-color: var(--amp-colors-button-primary);
+    border-radius: var(--amp-default-border-radius);
+
+    border: 1px solid;
+    border-color: inherit;
+    height: 2.5rem;
+    width: 100%;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5rem; /* 150% */
+    padding: 0 1rem;
+    transition: all .1s ease;
+}
+
+.buttonError {
+    border: 1px solid var(--amp-colors-error-border);
+}
+
+.button:focus:enabled {
+    border: 2px solid var(--amp-colors-accent-primary);
+    outline: none;
+}
+
+.button:disabled {
+    background-color: var(--amp-colors-button-primary-disabled);
+    cursor: not-allowed;
+}
+
+/* Additional styling to support screen readers */
+button[aria-expanded="true"] {
+    background-color: #004080;  /* Can visually indicate button state */
+}

--- a/src/components/ui-base/Button/index.tsx
+++ b/src/components/ui-base/Button/index.tsx
@@ -1,0 +1,26 @@
+import { ButtonHTMLAttributes } from 'react';
+
+import classes from './button.module.css';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+  type: 'button' | 'submit' | 'reset';
+}
+
+export function Button({
+  className, style, type, children, ...rest
+}: ButtonProps) {
+  return (
+    <button
+      // button type is a required pass through prop
+      // eslint-disable-next-line react/button-has-type
+      type={type}
+      className={className ? `${classes.button} ${className}` : classes.button}
+      style={style}
+      {...rest}
+    >{children}
+    </button>
+  );
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -19,14 +19,17 @@
     --amp-shadows-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
     --amp-shadows-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
     --amp-colors-border: var(--amp-colors-neutral-200);
+
     --amp-colors-error-background: #FEF2F2;
     --amp-colors-error-border: #FECACA;
     --amp-colors-error-text: #991B1B;
+
     --amp-colors-accent-primary: var(--amp-colors-neutral-700);
     --amp-colors-accent-secondary: var(--amp-colors-neutral-500);
     --amp-colors-background: var(--amp-colors-neutral-50);
     --amp-colors-background-secondary: #FCFCFC;
     --amp-colors-text-secondary: var(--amp-colors-neutral-500);
+
     --amp-colors-badge: var(--amp-colors-neutral-200);
     --amp-colors-badge-text: var(--amp-colors-neutral-700);
 
@@ -35,6 +38,10 @@
     --amp-colors-link-hover: calc(var(--amp-colors-link-base) + 10%);
     --amp-colors-link-focus: calc(var(--amp-colors-link-base) + 15%);
     --amp-colors-link-active: calc(var(--amp-colors-link-base) - 20%);
+
+    --amp-colors-button-primary: var(--amp-colors-accent-primary);
+    --amp-colors-button-primary-disabled: var(--amp-colors-accent-secondary);
+    --amp-colors-button-text: var(--amp-colors-neutral-200);
     
     /* misc */
     --amp-default-border-radius: 4px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,6 +3408,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz"


### PR DESCRIPTION
### Summary
refactor SalesforceSubdomainEntry to not use Chakra. Adds bridge Component to swap out Chakra implementation.
- add native button
- add native input
- mv salesforce subdomain entry to chakra file (deprecated)

#### demo

![salesforce-domain-refactor](https://github.com/user-attachments/assets/a63f32bd-da14-4ddf-8477-653f75087698)

#### previous
<img width="611" alt="Screenshot 2024-09-26 at 2 31 02 PM" src="https://github.com/user-attachments/assets/d492e2ff-3f7a-40a7-ac85-1e628a76b3db">

#### after
<img width="638" alt="Screenshot 2024-09-26 at 2 31 26 PM" src="https://github.com/user-attachments/assets/d05d1b69-9ecf-42d1-99e5-f78fc1de9c08">


