### PR TITLE
[ENG-1561] feat/refactor: no workspace entry

### DIFF
--- a/src/components/auth/Oauth/NoWorkspaceEntry/LandingContent.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/LandingContent.tsx
@@ -5,14 +5,14 @@ import {
 import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAlert';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
-type LandingContentProps = {
-  handleSubmit: () => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-  providerName?: string;
-};
+import { LandingContentProps } from './LandingContentProps';
 
-export function LandingContent({
+/**
+ * @deprecated - delete file after removing chakra-ui
+ * @param param0
+ * @returns
+ */
+export function ChakraLandingContent({
   handleSubmit, error, isButtonDisabled, providerName,
 }: LandingContentProps) {
   return (

--- a/src/components/auth/Oauth/NoWorkspaceEntry/LandingContentProps.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/LandingContentProps.tsx
@@ -1,0 +1,6 @@
+export type LandingContentProps = {
+  handleSubmit: () => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+  providerName?: string;
+};

--- a/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
@@ -1,0 +1,37 @@
+import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { Button } from 'components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
+
+import { ChakraLandingContent } from './LandingContent';
+import { LandingContentProps } from './LandingContentProps';
+
+export function NoWorkspaceEntryContent({
+  handleSubmit, error, isButtonDisabled, providerName,
+}: LandingContentProps) {
+  if (!isChakraRemoved) {
+    return (
+      <ChakraLandingContent
+        handleSubmit={handleSubmit}
+        error={error}
+        isButtonDisabled={isButtonDisabled}
+        providerName={providerName}
+      />
+    );
+  }
+
+  return (
+    <AuthCardLayout>
+      <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
+      <AuthErrorAlert error={error} />
+      <Button
+        style={{ marginTop: '1em', width: '100%' }}
+        disabled={isButtonDisabled}
+        type="submit"
+        onClick={handleSubmit}
+      >
+        Next
+      </Button>
+    </AuthCardLayout>
+  );
+}

--- a/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -11,7 +11,7 @@ import { handleServerError } from 'src/utils/handleServerError';
 import { fetchOAuthPopupURL } from '../fetchOAuthPopupURL';
 import { OAuthWindow } from '../OAuthWindow/OAuthWindow';
 
-import { LandingContent } from './LandingContent';
+import { NoWorkspaceEntryContent } from './NoWorkspaceEntryContent';
 
 interface NoWorkspaceOauthFlowProps {
   provider: string;
@@ -68,7 +68,7 @@ export function NoWorkspaceOauthFlow({
       oauthUrl={oAuthPopupURL}
       onError={onError}
     >
-      <LandingContent handleSubmit={handleSubmit} error={error} providerName={providerName} />
+      <NoWorkspaceEntryContent handleSubmit={handleSubmit} error={error} providerName={providerName} />
     </OAuthWindow>
   );
 }

--- a/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
@@ -3,7 +3,7 @@ import { FormComponent } from 'components/form';
 import { AccessibleLink } from 'components/ui-base/AccessibleLink';
 import { Button } from 'components/ui-base/Button';
 import { isChakraRemoved } from 'src/components/ui-base/constant';
-import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
 import { ChakraSalesforceSubdomainEntry } from './ChakraSalesforceSubdomainEntry';
 import { SALESFORCE_HELP_URL, SubdomainEntryProps } from './SubdomainEntryProps';
@@ -20,7 +20,7 @@ export function SalesforceSubdomainEntry({
 
   return (
     <AuthCardLayout>
-      <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>Enter your Salesforce subdomain</h1>
+      <AuthTitle>Enter your Salesforce subdomain</AuthTitle>
       <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
         What is my Salesforce subdomain?
       </AccessibleLink>
@@ -35,7 +35,7 @@ export function SalesforceSubdomainEntry({
         <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
       </div>
       <Button
-        style={{ marginTop: '1em' }}
+        style={{ marginTop: '1em', width: '100%' }}
         disabled={isButtonDisabled}
         type="submit"
         onClick={handleSubmit}

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -6,7 +6,6 @@
     border: 1px solid;
     border-color: inherit;
     height: 2.5rem;
-    width: 100%;
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.5rem; /* 150% */

--- a/src/layout/AuthCardLayout/AuthCardLayout.tsx
+++ b/src/layout/AuthCardLayout/AuthCardLayout.tsx
@@ -19,3 +19,9 @@ export function AuthCardLayout({ children }: AuthCardLayoutProps) {
     </Container>
   );
 }
+
+export function AuthTitle({ children }: AuthCardLayoutProps) {
+  return (
+    <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>{children}</h1>
+  );
+}


### PR DESCRIPTION
### Summary
refactors no workspace entry form
- add NoWorkspaceEntryContent component to replace LandingContent
- deprecate LandingContent (chakra-ui)

#### before
<img width="663" alt="Screenshot 2024-09-26 at 3 00 33 PM" src="https://github.com/user-attachments/assets/e0add2e8-24c8-4d19-bc27-ccfc43acd16b">


#### after
<img width="681" alt="Screenshot 2024-09-26 at 3 01 00 PM" src="https://github.com/user-attachments/assets/c2abaa0c-bae4-4ecc-aade-a8151d936d96">
