### PR TITLE
[ENG-1561] refactor: move client credentials grant type to own dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",
+    "classnames": "^2.5.1",
     "immer": "^10.0.3",
     "lodash.isequal": "^4.5.0"
   },

--- a/src/components/auth/Oauth/ClientCredentials/NoWorkspaceClientCredentialsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/NoWorkspaceClientCredentialsContent.tsx
@@ -15,45 +15,40 @@ import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAler
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 import { convertTextareaToArray } from 'src/utils';
 
-export type WorkspaceClientCredentialsCreds = {
-  workspace: string;
+export type ClientCredentialsCreds = {
   clientId: string;
   clientSecret: string;
   scopes?: string[];
 };
 
 type LandingContentProps = {
-  handleSubmit: (creds: WorkspaceClientCredentialsCreds) => void;
+  handleSubmit: (creds: ClientCredentialsCreds) => void;
   error: string | null;
   explicitScopesRequired?: boolean;
   isButtonDisabled?: boolean;
   providerName?: string;
 };
 
-export function ClientCredentialsContent({
-  handleSubmit, error, isButtonDisabled, providerName,
-  explicitScopesRequired,
+export function NoWorkspaceClientCredentialsContent({
+  handleSubmit, error, explicitScopesRequired, isButtonDisabled, providerName,
 }: LandingContentProps) {
   const [show, setShow] = useState(false);
   const [clientSecret, setClientSecret] = useState('');
   const [clientId, setClientId] = useState('');
-  const [workspace, setWorkspace] = useState('');
   const [scopes, setScopes] = useState('');
 
   const onToggleShowHide = () => setShow(!show);
+
   const handleClientSecretChange = (event: React.FormEvent<HTMLInputElement>) => setClientSecret(event.currentTarget.value);
   const handleClientIdChange = (event: React.FormEvent<HTMLInputElement>) => setClientId(event.currentTarget.value);
-  const handleWorkspaceChange = (event: React.FormEvent<HTMLInputElement>) => setWorkspace(event.currentTarget.value);
   const handleScopesChange = (event: React.FormEvent<HTMLTextAreaElement>) => setScopes(event.currentTarget.value);
 
   const isClientSecretValid = clientSecret.length > 0;
   const isClientIdValid = clientId.length > 0;
-  const isWorkspaceValid = workspace.length > 0;
-  const isSubmitDisabled = isButtonDisabled || !isClientSecretValid || !isClientIdValid || !isWorkspaceValid;
+  const isSubmitDisabled = isButtonDisabled || !isClientSecretValid || !isClientIdValid;
 
   const onHandleSubmit = () => {
-    const req: WorkspaceClientCredentialsCreds = {
-      workspace,
+    const req: ClientCredentialsCreds = {
       clientId,
       clientSecret,
     };
@@ -75,10 +70,6 @@ export function ClientCredentialsContent({
         <br />
 
         <Stack spacing={4}>
-          <Input
-            placeholder="MyWorkspace"
-            onChange={handleWorkspaceChange}
-          />
           <Input placeholder="Client ID" onChange={handleClientIdChange} />
           <InputGroup size="md">
             <Input
@@ -100,7 +91,6 @@ export function ClientCredentialsContent({
             />
           )}
         </Stack>
-
         <br />
 
         <Button

--- a/src/components/auth/Oauth/ClientCredentials/NoWorkspaceOauthClientCredsFlow.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/NoWorkspaceOauthClientCredsFlow.tsx
@@ -5,15 +5,16 @@
 import { useState } from 'react';
 import { Connection, GenerateConnectionRequest } from '@generated/api/src';
 
-import {
-  ClientCredentialsContent,
-  WorkspaceClientCredentialsCreds,
-} from 'components/auth/Oauth/WorkspaceEntry/ClientCredentialsContent';
 import { LoadingCentered } from 'components/Loading';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
+
+import {
+  ClientCredentialsCreds,
+  NoWorkspaceClientCredentialsContent,
+} from './NoWorkspaceClientCredentialsContent';
 
 interface NoWorkspaceOauthClientCredsFlowProps {
   provider: string;
@@ -31,9 +32,8 @@ interface NoWorkspaceOauthClientCredsFlowProps {
  * NoWorkspaceOauthFlow first prompts user with a next button,
  * then launches a popup with the OAuth flow.
  */
-export function WorkspaceOauthClientCredsFlow({
-  provider, providerName,
-  consumerRef, consumerName, groupRef, groupName, explicitScopesRequired,
+export function NoWorkspaceOauthClientCredsFlow({
+  provider, consumerRef, consumerName, groupRef, groupName, explicitScopesRequired, providerName,
   selectedConnection, setSelectedConnection,
 }: NoWorkspaceOauthClientCredsFlowProps) {
   const { projectId } = useProject();
@@ -41,7 +41,7 @@ export function WorkspaceOauthClientCredsFlow({
   const [error, setError] = useState<string | null>(null);
 
   //  fetch OAuth callback URL from connection so that oath popup can be launched
-  const handleSubmit = async (creds: WorkspaceClientCredentialsCreds) => {
+  const handleSubmit = async (creds: ClientCredentialsCreds) => {
     setError(null);
     const req: GenerateConnectionRequest = {
       groupName,
@@ -49,7 +49,6 @@ export function WorkspaceOauthClientCredsFlow({
       consumerName,
       consumerRef,
       provider,
-      providerWorkspaceRef: creds.workspace,
       oauth2ClientCredentials: {
         clientId: creds.clientId,
         clientSecret: creds.clientSecret,
@@ -70,7 +69,7 @@ export function WorkspaceOauthClientCredsFlow({
 
   if (selectedConnection === null) {
     return (
-      <ClientCredentialsContent
+      <NoWorkspaceClientCredentialsContent
         providerName={providerName}
         handleSubmit={handleSubmit}
         error={error}

--- a/src/components/auth/Oauth/ClientCredentials/WorkspaceClientCredentialsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/WorkspaceClientCredentialsContent.tsx
@@ -15,40 +15,45 @@ import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAler
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 import { convertTextareaToArray } from 'src/utils';
 
-export type ClientCredentialsCreds = {
+export type WorkspaceClientCredentialsCreds = {
+  workspace: string;
   clientId: string;
   clientSecret: string;
   scopes?: string[];
 };
 
 type LandingContentProps = {
-  handleSubmit: (creds: ClientCredentialsCreds) => void;
+  handleSubmit: (creds: WorkspaceClientCredentialsCreds) => void;
   error: string | null;
   explicitScopesRequired?: boolean;
   isButtonDisabled?: boolean;
   providerName?: string;
 };
 
-export function ClientCredentialsContent({
-  handleSubmit, error, explicitScopesRequired, isButtonDisabled, providerName,
+export function WorkspaceClientCredentialsContent({
+  handleSubmit, error, isButtonDisabled, providerName,
+  explicitScopesRequired,
 }: LandingContentProps) {
   const [show, setShow] = useState(false);
   const [clientSecret, setClientSecret] = useState('');
   const [clientId, setClientId] = useState('');
+  const [workspace, setWorkspace] = useState('');
   const [scopes, setScopes] = useState('');
 
   const onToggleShowHide = () => setShow(!show);
-
   const handleClientSecretChange = (event: React.FormEvent<HTMLInputElement>) => setClientSecret(event.currentTarget.value);
   const handleClientIdChange = (event: React.FormEvent<HTMLInputElement>) => setClientId(event.currentTarget.value);
+  const handleWorkspaceChange = (event: React.FormEvent<HTMLInputElement>) => setWorkspace(event.currentTarget.value);
   const handleScopesChange = (event: React.FormEvent<HTMLTextAreaElement>) => setScopes(event.currentTarget.value);
 
   const isClientSecretValid = clientSecret.length > 0;
   const isClientIdValid = clientId.length > 0;
-  const isSubmitDisabled = isButtonDisabled || !isClientSecretValid || !isClientIdValid;
+  const isWorkspaceValid = workspace.length > 0;
+  const isSubmitDisabled = isButtonDisabled || !isClientSecretValid || !isClientIdValid || !isWorkspaceValid;
 
   const onHandleSubmit = () => {
-    const req: ClientCredentialsCreds = {
+    const req: WorkspaceClientCredentialsCreds = {
+      workspace,
       clientId,
       clientSecret,
     };
@@ -70,6 +75,10 @@ export function ClientCredentialsContent({
         <br />
 
         <Stack spacing={4}>
+          <Input
+            placeholder="MyWorkspace"
+            onChange={handleWorkspaceChange}
+          />
           <Input placeholder="Client ID" onChange={handleClientIdChange} />
           <InputGroup size="md">
             <Input
@@ -91,6 +100,7 @@ export function ClientCredentialsContent({
             />
           )}
         </Stack>
+
         <br />
 
         <Button

--- a/src/components/auth/Oauth/ClientCredentials/WorkspaceOauthClientCredsFlow.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/WorkspaceOauthClientCredsFlow.tsx
@@ -5,17 +5,18 @@
 import { useState } from 'react';
 import { Connection, GenerateConnectionRequest } from '@generated/api/src';
 
-import {
-  ClientCredentialsContent,
-  ClientCredentialsCreds,
-} from 'components/auth/Oauth/NoWorkspaceEntry/ClientCredentialsContent';
 import { LoadingCentered } from 'components/Loading';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
-interface NoWorkspaceOauthClientCredsFlowProps {
+import {
+  WorkspaceClientCredentialsContent,
+  WorkspaceClientCredentialsCreds,
+} from './WorkspaceClientCredentialsContent';
+
+interface WorkspaceOauthClientCredsFlowProps {
   provider: string;
   consumerRef: string;
   consumerName?: string;
@@ -31,16 +32,17 @@ interface NoWorkspaceOauthClientCredsFlowProps {
  * NoWorkspaceOauthFlow first prompts user with a next button,
  * then launches a popup with the OAuth flow.
  */
-export function NoWorkspaceOauthClientCredsFlow({
-  provider, consumerRef, consumerName, groupRef, groupName, explicitScopesRequired, providerName,
+export function WorkspaceOauthClientCredsFlow({
+  provider, providerName,
+  consumerRef, consumerName, groupRef, groupName, explicitScopesRequired,
   selectedConnection, setSelectedConnection,
-}: NoWorkspaceOauthClientCredsFlowProps) {
+}: WorkspaceOauthClientCredsFlowProps) {
   const { projectId } = useProject();
   const apiKey = useApiKey();
   const [error, setError] = useState<string | null>(null);
 
   //  fetch OAuth callback URL from connection so that oath popup can be launched
-  const handleSubmit = async (creds: ClientCredentialsCreds) => {
+  const handleSubmit = async (creds: WorkspaceClientCredentialsCreds) => {
     setError(null);
     const req: GenerateConnectionRequest = {
       groupName,
@@ -48,6 +50,7 @@ export function NoWorkspaceOauthClientCredsFlow({
       consumerName,
       consumerRef,
       provider,
+      providerWorkspaceRef: creds.workspace,
       oauth2ClientCredentials: {
         clientId: creds.clientId,
         clientSecret: creds.clientSecret,
@@ -68,7 +71,7 @@ export function NoWorkspaceOauthClientCredsFlow({
 
   if (selectedConnection === null) {
     return (
-      <ClientCredentialsContent
+      <WorkspaceClientCredentialsContent
         providerName={providerName}
         handleSubmit={handleSubmit}
         error={error}

--- a/src/components/auth/Oauth/NoWorkspaceEntry/LandingContent.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/LandingContent.tsx
@@ -5,14 +5,14 @@ import {
 import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAlert';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
-type LandingContentProps = {
-  handleSubmit: () => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-  providerName?: string;
-};
+import { LandingContentProps } from './LandingContentProps';
 
-export function LandingContent({
+/**
+ * @deprecated - delete file after removing chakra-ui
+ * @param param0
+ * @returns
+ */
+export function ChakraLandingContent({
   handleSubmit, error, isButtonDisabled, providerName,
 }: LandingContentProps) {
   return (

--- a/src/components/auth/Oauth/NoWorkspaceEntry/LandingContentProps.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/LandingContentProps.tsx
@@ -1,0 +1,6 @@
+export type LandingContentProps = {
+  handleSubmit: () => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+  providerName?: string;
+};

--- a/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
@@ -1,0 +1,37 @@
+import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { Button } from 'components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
+
+import { ChakraLandingContent } from './LandingContent';
+import { LandingContentProps } from './LandingContentProps';
+
+export function NoWorkspaceEntryContent({
+  handleSubmit, error, isButtonDisabled, providerName,
+}: LandingContentProps) {
+  if (!isChakraRemoved) {
+    return (
+      <ChakraLandingContent
+        handleSubmit={handleSubmit}
+        error={error}
+        isButtonDisabled={isButtonDisabled}
+        providerName={providerName}
+      />
+    );
+  }
+
+  return (
+    <AuthCardLayout>
+      <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
+      <AuthErrorAlert error={error} />
+      <Button
+        style={{ marginTop: '1em', width: '100%' }}
+        disabled={isButtonDisabled}
+        type="submit"
+        onClick={handleSubmit}
+      >
+        Next
+      </Button>
+    </AuthCardLayout>
+  );
+}

--- a/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -11,7 +11,7 @@ import { handleServerError } from 'src/utils/handleServerError';
 import { fetchOAuthPopupURL } from '../fetchOAuthPopupURL';
 import { OAuthWindow } from '../OAuthWindow/OAuthWindow';
 
-import { LandingContent } from './LandingContent';
+import { NoWorkspaceEntryContent } from './NoWorkspaceEntryContent';
 
 interface NoWorkspaceOauthFlowProps {
   provider: string;
@@ -68,7 +68,7 @@ export function NoWorkspaceOauthFlow({
       oauthUrl={oAuthPopupURL}
       onError={onError}
     >
-      <LandingContent handleSubmit={handleSubmit} error={error} providerName={providerName} />
+      <NoWorkspaceEntryContent handleSubmit={handleSubmit} error={error} providerName={providerName} />
     </OAuthWindow>
   );
 }

--- a/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
+++ b/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
@@ -1,11 +1,11 @@
 import { Connection, ProviderInfo } from 'services/api';
 import {
   NoWorkspaceOauthClientCredsFlow,
-} from 'src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthClientCredsFlow';
-import { NoWorkspaceOauthFlow } from 'src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow';
+} from 'src/components/auth/Oauth/ClientCredentials/NoWorkspaceOauthClientCredsFlow';
 import {
   WorkspaceOauthClientCredsFlow,
-} from 'src/components/auth/Oauth/WorkspaceEntry/WorkspaceOauthClientCredsFlow';
+} from 'src/components/auth/Oauth/ClientCredentials/WorkspaceOauthClientCredsFlow';
+import { NoWorkspaceOauthFlow } from 'src/components/auth/Oauth/NoWorkspaceEntry/NoWorkspaceOauthFlow';
 import { WorkspaceOauthFlow } from 'src/components/auth/Oauth/WorkspaceEntry/WorkspaceOauthFlow';
 import { getProviderName } from 'src/utils';
 

--- a/src/components/auth/Oauth/Salesforce/ChakraSalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/Salesforce/ChakraSalesforceSubdomainEntry.tsx
@@ -1,0 +1,53 @@
+import { ExternalLinkIcon } from '@chakra-ui/icons';
+import {
+  Button, FormControl,
+  FormLabel, Heading, Input,
+} from '@chakra-ui/react';
+
+import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { AccessibleLink } from 'components/ui-base/AccessibleLink';
+import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
+
+import { SALESFORCE_HELP_URL, SubdomainEntryProps } from './SubdomainEntryProps';
+
+/**
+ * @deprecated - delete file after removing chakra-ui
+ * Salesforce specific subdomain entry component, use workspace entry for other providers.
+ * @param param0
+ * @returns
+ */
+export function ChakraSalesforceSubdomainEntry({
+  handleSubmit, setWorkspace, error, isButtonDisabled,
+}: SubdomainEntryProps) {
+  return (
+    <AuthCardLayout>
+      <FormControl>
+        <FormLabel>
+          <Heading as="h4" size="md">Enter your Salesforce subdomain</Heading>
+        </FormLabel>
+        <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
+          {'What is my Salesforce subdomain? '}
+          <ExternalLinkIcon />
+        </AccessibleLink>
+        <AuthErrorAlert error={error} />
+        <div style={{ display: 'flex', marginTop: '1em' }}>
+          <Input
+            placeholder="MyDomain"
+            onChange={(event) => setWorkspace(event.currentTarget.value)}
+          />
+          <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
+        </div>
+        <br />
+        <Button
+          variant="primary"
+          isDisabled={isButtonDisabled}
+          width="100%"
+          type="submit"
+          onClick={handleSubmit}
+        >
+          Next
+        </Button>
+      </FormControl>
+    </AuthCardLayout>
+  );
+}

--- a/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
@@ -3,7 +3,7 @@ import { FormComponent } from 'components/form';
 import { AccessibleLink } from 'components/ui-base/AccessibleLink';
 import { Button } from 'components/ui-base/Button';
 import { isChakraRemoved } from 'src/components/ui-base/constant';
-import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
 import { ChakraSalesforceSubdomainEntry } from './ChakraSalesforceSubdomainEntry';
 import { SALESFORCE_HELP_URL, SubdomainEntryProps } from './SubdomainEntryProps';
@@ -20,7 +20,7 @@ export function SalesforceSubdomainEntry({
 
   return (
     <AuthCardLayout>
-      <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>Enter your Salesforce subdomain</h1>
+      <AuthTitle>Enter your Salesforce subdomain</AuthTitle>
       <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
         What is my Salesforce subdomain?
       </AccessibleLink>
@@ -35,7 +35,7 @@ export function SalesforceSubdomainEntry({
         <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
       </div>
       <Button
-        style={{ marginTop: '1em' }}
+        style={{ marginTop: '1em', width: '100%' }}
         disabled={isButtonDisabled}
         type="submit"
         onClick={handleSubmit}

--- a/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/Salesforce/SalesforceSubdomainEntry.tsx
@@ -1,59 +1,47 @@
-import { ExternalLinkIcon } from '@chakra-ui/icons';
-import {
-  Button, FormControl,
-  FormLabel, Heading, Input,
-} from '@chakra-ui/react';
-
 import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { FormComponent } from 'components/form';
 import { AccessibleLink } from 'components/ui-base/AccessibleLink';
+import { Button } from 'components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
-const SALESFORCE_HELP_URL = 'https://help.salesforce.com/s/articleView?id=sf.faq_domain_name_what.htm&type=5';
+import { ChakraSalesforceSubdomainEntry } from './ChakraSalesforceSubdomainEntry';
+import { SALESFORCE_HELP_URL, SubdomainEntryProps } from './SubdomainEntryProps';
 
-type SubdomainEntryProps = {
-  handleSubmit: () => void;
-  setWorkspace: (workspace: string) => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-};
-
-/**
- * Salesforce specific subdomain entry component, use workspace entry for other providers.
- * @param param0
- * @returns
- */
 export function SalesforceSubdomainEntry({
   handleSubmit, setWorkspace, error, isButtonDisabled,
 }: SubdomainEntryProps) {
+  const props = {
+    handleSubmit, setWorkspace, error, isButtonDisabled,
+  };
+  if (!isChakraRemoved) {
+    return <ChakraSalesforceSubdomainEntry {...props} />;
+  }
+
   return (
     <AuthCardLayout>
-      <FormControl>
-        <FormLabel>
-          <Heading as="h4" size="md">Enter your Salesforce subdomain</Heading>
-        </FormLabel>
-        <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
-          {'What is my Salesforce subdomain? '}
-          <ExternalLinkIcon />
-        </AccessibleLink>
-        <AuthErrorAlert error={error} />
-        <div style={{ display: 'flex', marginTop: '1em' }}>
-          <Input
-            placeholder="MyDomain"
-            onChange={(event) => setWorkspace(event.currentTarget.value)}
-          />
-          <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
-        </div>
-        <br />
-        <Button
-          variant="primary"
-          isDisabled={isButtonDisabled}
-          width="100%"
-          type="submit"
-          onClick={handleSubmit}
-        >
-          Next
-        </Button>
-      </FormControl>
+      <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>Enter your Salesforce subdomain</h1>
+      <AccessibleLink href={SALESFORCE_HELP_URL} newTab>
+        What is my Salesforce subdomain?
+      </AccessibleLink>
+      <AuthErrorAlert error={error} />
+      <div style={{ display: 'flex', marginTop: '1em' }}>
+        <FormComponent.Input
+          id="salesforce-subdomain"
+          type="text"
+          placeholder="MyDomain"
+          onChange={(event) => setWorkspace(event.currentTarget.value)}
+        />
+        <p style={{ lineHeight: '2.2em', marginLeft: '0.4em' }}>.my.salesforce.com</p>
+      </div>
+      <Button
+        style={{ marginTop: '1em' }}
+        disabled={isButtonDisabled}
+        type="submit"
+        onClick={handleSubmit}
+      >
+        Next
+      </Button>
     </AuthCardLayout>
   );
 }

--- a/src/components/auth/Oauth/Salesforce/SubdomainEntryProps.tsx
+++ b/src/components/auth/Oauth/Salesforce/SubdomainEntryProps.tsx
@@ -1,0 +1,8 @@
+export const SALESFORCE_HELP_URL = 'https://help.salesforce.com/s/articleView?id=sf.faq_domain_name_what.htm&type=5';
+
+export type SubdomainEntryProps = {
+  handleSubmit: () => void;
+  setWorkspace: (workspace: string) => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+};

--- a/src/components/auth/Oauth/WorkspaceEntry/ChakraWorkspaceEntry.tsx
+++ b/src/components/auth/Oauth/WorkspaceEntry/ChakraWorkspaceEntry.tsx
@@ -6,15 +6,14 @@ import {
 import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
-type WorkspaceEntryProps = {
-  handleSubmit: () => void;
-  setWorkspace: (workspace: string) => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-  providerName?: string;
-};
+import { WorkspaceEntryProps } from './WorkspaceEntryProps';
 
-export function WorkspaceEntry({
+/**
+ * @deprecated - delete file after removing chakra-ui
+ * @param param0
+ * @returns
+ */
+export function ChakraWorkspaceEntry({
   handleSubmit, setWorkspace, error, isButtonDisabled, providerName,
 }: WorkspaceEntryProps) {
   return (

--- a/src/components/auth/Oauth/WorkspaceEntry/WorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/WorkspaceEntry/WorkspaceEntryContent.tsx
@@ -1,0 +1,47 @@
+import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
+import { FormComponent } from 'components/form';
+import { Button } from 'components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
+
+import { ChakraWorkspaceEntry } from './ChakraWorkspaceEntry';
+import { WorkspaceEntryProps } from './WorkspaceEntryProps';
+
+/**
+   *
+   * @param param0
+   * @returns
+   */
+export function WorkspaceEntryContent({
+  handleSubmit, setWorkspace, error, isButtonDisabled, providerName,
+}: WorkspaceEntryProps) {
+  if (!isChakraRemoved) {
+    const props = {
+      handleSubmit, setWorkspace, error, isButtonDisabled, providerName,
+    };
+    return <ChakraWorkspaceEntry {...props} />;
+  }
+
+  return (
+    <AuthCardLayout>
+      <AuthTitle>Enter your {providerName} workspace</AuthTitle>
+      <AuthErrorAlert error={error} />
+      <br />
+      <FormComponent.Input
+        id="workspace"
+        type="text"
+        placeholder="MyWorkspace"
+        onChange={(event) => setWorkspace(event.currentTarget.value)}
+      />
+      <br />
+      <Button
+        style={{ marginTop: '1em', width: '100%' }}
+        disabled={isButtonDisabled}
+        type="submit"
+        onClick={handleSubmit}
+      >
+        Next
+      </Button>
+    </AuthCardLayout>
+  );
+}

--- a/src/components/auth/Oauth/WorkspaceEntry/WorkspaceEntryProps.tsx
+++ b/src/components/auth/Oauth/WorkspaceEntry/WorkspaceEntryProps.tsx
@@ -1,0 +1,7 @@
+export type WorkspaceEntryProps = {
+  handleSubmit: () => void;
+  setWorkspace: (workspace: string) => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+  providerName?: string;
+};

--- a/src/components/auth/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -7,7 +7,7 @@ import { fetchOAuthPopupURL } from '../fetchOAuthPopupURL';
 import { OAuthWindow } from '../OAuthWindow/OAuthWindow';
 import { SalesforceSubdomainEntry } from '../Salesforce/SalesforceSubdomainEntry';
 
-import { WorkspaceEntry } from './WorkspaceEntry';
+import { WorkspaceEntryContent } from './WorkspaceEntryContent';
 
 const PROVIDER_SALESFORCE = 'salesforce';
 
@@ -77,7 +77,7 @@ export function WorkspaceOauthFlow({
       />
     ) : (
   // general workspace entry component
-      <WorkspaceEntry
+      <WorkspaceEntryContent
         handleSubmit={handleSubmit}
         setWorkspace={setWorkspace}
         error={error}

--- a/src/components/form/Input/index.tsx
+++ b/src/components/form/Input/index.tsx
@@ -1,0 +1,27 @@
+import { InputHTMLAttributes } from 'react';
+import classNames from 'classnames';
+
+import classes from './input.module.css';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  type: string;
+  className?: string;
+  isError?: boolean;
+}
+
+export function Input({
+  id, type, className, isError = false, ...rest
+}: InputProps) {
+  const defaultClassName = isError
+    ? classNames(classes.inputError, classes.input) : classes.input;
+
+  return (
+    <input
+      id={id}
+      type={type}
+      className={classNames(defaultClassName, className)}
+      {...rest}
+    />
+  );
+}

--- a/src/components/form/Input/input.module.css
+++ b/src/components/form/Input/input.module.css
@@ -1,0 +1,36 @@
+.input {
+    border-radius: var(--amp-default-border-radius);
+    border: 1px solid;
+    border-color: inherit;
+    height: 2.5rem;
+    transition: all .20s ease-in;
+
+    color: var(--amp-colors-neutral-800);
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5rem; /* 150% */
+    padding: 0 1rem;
+    width: 100%;
+    transition: all .1s ease;
+}
+
+.inputError {
+    border: 1px solid var(--amp-colors-error-border);
+}
+
+.input:focus:enabled {
+    border: 2px solid var(--amp-colors-accent-primary);
+    outline: none;
+}
+
+.input:disabled {
+    background-color: var(--amp-colors-neutral-300);
+    border: 1px solid var(--amp-colors-neutral-400);
+}
+
+.error {
+    color: var(--color-red-600, #DC2626);
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.25rem; /* 142.857% */
+}

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,5 @@
+import { Input } from './Input';
+
+export const FormComponent = {
+  Input,
+};

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -6,7 +6,6 @@
     border: 1px solid;
     border-color: inherit;
     height: 2.5rem;
-    width: 100%;
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.5rem; /* 150% */

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -1,0 +1,34 @@
+.button {
+    color: var(--amp-colors-button-text);
+    background-color: var(--amp-colors-button-primary);
+    border-radius: var(--amp-default-border-radius);
+
+    border: 1px solid;
+    border-color: inherit;
+    height: 2.5rem;
+    width: 100%;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5rem; /* 150% */
+    padding: 0 1rem;
+    transition: all .1s ease;
+}
+
+.buttonError {
+    border: 1px solid var(--amp-colors-error-border);
+}
+
+.button:focus:enabled {
+    border: 2px solid var(--amp-colors-accent-primary);
+    outline: none;
+}
+
+.button:disabled {
+    background-color: var(--amp-colors-button-primary-disabled);
+    cursor: not-allowed;
+}
+
+/* Additional styling to support screen readers */
+button[aria-expanded="true"] {
+    background-color: #004080;  /* Can visually indicate button state */
+}

--- a/src/components/ui-base/Button/index.tsx
+++ b/src/components/ui-base/Button/index.tsx
@@ -1,0 +1,26 @@
+import { ButtonHTMLAttributes } from 'react';
+
+import classes from './button.module.css';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+  type: 'button' | 'submit' | 'reset';
+}
+
+export function Button({
+  className, style, type, children, ...rest
+}: ButtonProps) {
+  return (
+    <button
+      // button type is a required pass through prop
+      // eslint-disable-next-line react/button-has-type
+      type={type}
+      className={className ? `${classes.button} ${className}` : classes.button}
+      style={style}
+      {...rest}
+    >{children}
+    </button>
+  );
+}

--- a/src/layout/AuthCardLayout/AuthCardLayout.tsx
+++ b/src/layout/AuthCardLayout/AuthCardLayout.tsx
@@ -19,3 +19,9 @@ export function AuthCardLayout({ children }: AuthCardLayoutProps) {
     </Container>
   );
 }
+
+export function AuthTitle({ children }: AuthCardLayoutProps) {
+  return (
+    <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>{children}</h1>
+  );
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -19,14 +19,17 @@
     --amp-shadows-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
     --amp-shadows-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
     --amp-colors-border: var(--amp-colors-neutral-200);
+
     --amp-colors-error-background: #FEF2F2;
     --amp-colors-error-border: #FECACA;
     --amp-colors-error-text: #991B1B;
+
     --amp-colors-accent-primary: var(--amp-colors-neutral-700);
     --amp-colors-accent-secondary: var(--amp-colors-neutral-500);
     --amp-colors-background: var(--amp-colors-neutral-50);
     --amp-colors-background-secondary: #FCFCFC;
     --amp-colors-text-secondary: var(--amp-colors-neutral-500);
+
     --amp-colors-badge: var(--amp-colors-neutral-200);
     --amp-colors-badge-text: var(--amp-colors-neutral-700);
 
@@ -35,6 +38,10 @@
     --amp-colors-link-hover: calc(var(--amp-colors-link-base) + 10%);
     --amp-colors-link-focus: calc(var(--amp-colors-link-base) + 15%);
     --amp-colors-link-active: calc(var(--amp-colors-link-base) - 20%);
+
+    --amp-colors-button-primary: var(--amp-colors-accent-primary);
+    --amp-colors-button-primary-disabled: var(--amp-colors-accent-secondary);
+    --amp-colors-button-text: var(--amp-colors-neutral-200);
     
     /* misc */
     --amp-default-border-radius: 4px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,6 +3408,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz"


### PR DESCRIPTION
### Summary
The client credential folder structure is confusing with a copy of it's own form in both workspaces and no workspaces. This PR starts simplifying the auth flows by moving `ClientCredentials` in it's own folder. This will let us deduplicate form code and start organizing auth by grant type. 

This work is needed to more easily delete copied chakra code. 

#### Future Folder Structure 
```js
Oauth
- AuthorizationCode // grant type
-- Workspace
--- SalesforceSubDomain
-- NoWorkspace
- ClientCredentials // grant type
// todo: deduplicate ClientCredentialsContent
-- Container
-- Content
- OauthFlow // choose which grant type
```

#### followup 
1. move files around to organize my grant type
2. deduplicate and simplify oauth flow logic

