### PR TITLE
[ENG-1561] refactor: add client credentials flow

### DIFF
--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentials.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentials.tsx
@@ -1,0 +1,23 @@
+import { Connection } from '@generated/api/src';
+
+import { NoWorkspaceOauthClientCredsFlow } from './NoWorkspaceOauthClientCredsFlow';
+import { WorkspaceOauthClientCredsFlow } from './WorkspaceOauthClientCredsFlow';
+
+interface ClientCredsFlowProps {
+  provider: string;
+  consumerRef: string;
+  consumerName?: string;
+  groupRef: string;
+  groupName?: string;
+  providerName?: string;
+  explicitScopesRequired?: boolean;
+  explicitWorkspaceRequired?: boolean;
+  selectedConnection: Connection | null;
+  setSelectedConnection: (connection: Connection | null) => void;
+}
+export function ClientCredentials({ ...props }: ClientCredsFlowProps) {
+  if (props.explicitWorkspaceRequired) {
+    return (<WorkspaceOauthClientCredsFlow {...props} />);
+  }
+  return (<NoWorkspaceOauthClientCredsFlow {...props} />);
+}

--- a/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
+++ b/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
@@ -3,8 +3,7 @@ import { getProviderName } from 'src/utils';
 
 import { NoWorkspaceOauthFlow } from '../AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow';
 import { WorkspaceOauthFlow } from '../AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow';
-import { NoWorkspaceOauthClientCredsFlow } from '../ClientCredentials/NoWorkspaceOauthClientCredsFlow';
-import { WorkspaceOauthClientCredsFlow } from '../ClientCredentials/WorkspaceOauthClientCredsFlow';
+import { ClientCredentials } from '../ClientCredentials/ClientCredentials';
 
 const AUTHORIZATION_CODE = 'authorizationCode';
 const CLIENT_CREDENTIALS = 'clientCredentials';
@@ -30,62 +29,32 @@ export function OauthFlow({
   const { grantType, explicitScopesRequired, explicitWorkspaceRequired } = providerInfo.oauth2Opts;
   const providerName = getProviderName(provider, providerInfo);
 
+  const sharedProps = {
+    provider,
+    consumerRef,
+    consumerName,
+    groupRef,
+    groupName,
+    providerName,
+  };
+
   if (grantType === AUTHORIZATION_CODE) {
     // required workspace
     if (explicitWorkspaceRequired) {
-      return (
-        <WorkspaceOauthFlow
-          provider={provider}
-          consumerRef={consumerRef}
-          consumerName={consumerName}
-          groupRef={groupRef}
-          groupName={groupName}
-          providerName={providerName}
-        />
-      );
+      return <WorkspaceOauthFlow {...sharedProps} />;
     }
 
     // no workspace required
-    return (
-      <NoWorkspaceOauthFlow
-        provider={provider}
-        consumerRef={consumerRef}
-        consumerName={consumerName}
-        groupRef={groupRef}
-        groupName={groupName}
-        providerName={providerName}
-      />
-    );
+    return <NoWorkspaceOauthFlow {...sharedProps} />;
   }
 
   if (grantType === CLIENT_CREDENTIALS) {
-    if (explicitWorkspaceRequired) {
-      return (
-        <WorkspaceOauthClientCredsFlow
-          provider={provider}
-          consumerRef={consumerRef}
-          consumerName={consumerName}
-          groupRef={groupRef}
-          groupName={groupName}
-          explicitScopesRequired={explicitScopesRequired}
-          setSelectedConnection={setSelectedConnection}
-          selectedConnection={selectedConnection}
-          providerName={providerName}
-        />
-      );
-    }
-
     return (
-      <NoWorkspaceOauthClientCredsFlow
-        provider={provider}
-        consumerRef={consumerRef}
-        consumerName={consumerName}
-        groupRef={groupRef}
-        groupName={groupName}
+      <ClientCredentials
+        {...sharedProps}
         explicitScopesRequired={explicitScopesRequired}
-        setSelectedConnection={setSelectedConnection}
         selectedConnection={selectedConnection}
-        providerName={providerName}
+        setSelectedConnection={setSelectedConnection}
       />
     );
   }


### PR DESCRIPTION
### Summary 
Now that client credentials is it's own folder, we'll move logic to pick which client crediential form to show into it's own folder and simplify the top level oauth flow file. 
- simplify shared props across oauth flows
- add client credentials flow to prep Chakra swap

Follow up to: https://github.com/amp-labs/react/pull/557

#### No visual changes in Client Credential flow
![Screenshot 2024-09-27 at 10 22 11 AM](https://github.com/user-attachments/assets/3accee76-a481-4b43-936b-0b364d2d65e9)
