### PR TITLE
[ENG-1561] refactor: NoAuthFlow to use AuthCardLayoutTemplate

### DIFF
--- a/src/components/auth/AuthCardLayoutTemplate.tsx
+++ b/src/components/auth/AuthCardLayoutTemplate.tsx
@@ -1,0 +1,43 @@
+import { Button } from 'src/components/ui-base/Button';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
+
+import { AuthErrorAlert } from './AuthErrorAlert/AuthErrorAlert';
+
+type AuthCardLayoutTemplateProps = {
+  handleSubmit: (creds: any) => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+  providerName?: string;
+  title?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * Template that assembles AuthCardLayout, AuthTitle, AuthErrorAlert, a Button
+ * with option to pass children and title
+ * @param param0
+ * @returns
+ */
+export function AuthCardLayoutTemplate({
+  handleSubmit, error, isButtonDisabled, providerName, children, title,
+}: AuthCardLayoutTemplateProps) {
+  if (!title && !providerName) {
+    throw new Error('Either title or providerName is required');
+  }
+
+  return (
+    <AuthCardLayout>
+      <AuthTitle>{title || `Set up ${providerName} integration`}</AuthTitle>
+      <AuthErrorAlert error={error} />
+      {children}
+      <Button
+        style={{ marginTop: '1em', width: '100%' }}
+        disabled={isButtonDisabled}
+        type="submit"
+        onClick={handleSubmit}
+      >
+        Next
+      </Button>
+    </AuthCardLayout>
+  );
+}

--- a/src/components/auth/NoAuth/ChakraLandingContent.tsx
+++ b/src/components/auth/NoAuth/ChakraLandingContent.tsx
@@ -5,14 +5,14 @@ import {
 import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAlert';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
-type LandingContentProps = {
-  handleSubmit: () => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-  providerName?: string;
-};
+import { LandingContentProps } from './LandingContentProps';
 
-export function LandingContent({
+/**
+ * @deprecated This component is deprecated and will be removed with chakra-ui
+ * @param param0
+ * @returns
+ */
+export function ChakraLandingContent({
   handleSubmit, error, isButtonDisabled, providerName,
 }: LandingContentProps) {
   return (

--- a/src/components/auth/NoAuth/LandingContentProps.tsx
+++ b/src/components/auth/NoAuth/LandingContentProps.tsx
@@ -1,0 +1,6 @@
+export type LandingContentProps = {
+  handleSubmit: () => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+  providerName?: string;
+};

--- a/src/components/auth/NoAuth/NoAuthContent.tsx
+++ b/src/components/auth/NoAuth/NoAuthContent.tsx
@@ -1,0 +1,13 @@
+import { AuthCardLayoutTemplate } from 'components/auth/AuthCardLayoutTemplate';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
+
+import { ChakraLandingContent } from './ChakraLandingContent';
+import { LandingContentProps } from './LandingContentProps';
+
+export function NoAuthContent({ ...props }: LandingContentProps) {
+  if (!isChakraRemoved) {
+    return <ChakraLandingContent {...props} />;
+  }
+
+  return <AuthCardLayoutTemplate {...props} />;
+}

--- a/src/components/auth/NoAuth/NoAuthContent.tsx
+++ b/src/components/auth/NoAuth/NoAuthContent.tsx
@@ -4,6 +4,11 @@ import { isChakraRemoved } from 'src/components/ui-base/constant';
 import { ChakraLandingContent } from './ChakraLandingContent';
 import { LandingContentProps } from './LandingContentProps';
 
+/**
+ * This flow is only used as for a mock provider. This flow is used for testing only.
+ * @param param0
+ * @returns
+ */
 export function NoAuthContent({ ...props }: LandingContentProps) {
   if (!isChakraRemoved) {
     return <ChakraLandingContent {...props} />;

--- a/src/components/auth/NoAuth/NoAuthFlow.tsx
+++ b/src/components/auth/NoAuth/NoAuthFlow.tsx
@@ -6,7 +6,7 @@ import { useProject } from 'context/ProjectContextProvider';
 import { api, Connection } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
-import { LandingContent } from './LandingContent';
+import { NoAuthContent } from './NoAuthContent';
 
 type NoAuthFlowProps = {
   provider: string;
@@ -54,7 +54,7 @@ export function NoAuthFlow({
   };
 
   if (selectedConnection === null) {
-    return <LandingContent handleSubmit={onNext} error={null} providerName={providerName} />;
+    return <NoAuthContent handleSubmit={onNext} error={null} providerName={providerName} />;
   }
 
   return children;

--- a/src/components/auth/NoAuth/NoAuthFlow.tsx
+++ b/src/components/auth/NoAuth/NoAuthFlow.tsx
@@ -20,6 +20,11 @@ type NoAuthFlowProps = {
   setSelectedConnection: (connection: Connection | null) => void;
 };
 
+/**
+ * This flow is only used as for a mock provider. This flow is used for testing only.
+ * @param param0
+ * @returns
+ */
 export function NoAuthFlow({
   provider, consumerRef, consumerName, groupRef, groupName,
   children, selectedConnection, setSelectedConnection, providerName,


### PR DESCRIPTION
### Summary
adds a native implementation of NoAuthFlow
- adds a template that assembles AuthCardLayout, title, buttons, and content
- renames LandingContent to ChakraLandingContent


<img width="642" alt="Screenshot 2024-09-30 at 3 49 24 PM" src="https://github.com/user-attachments/assets/92763407-bbd9-4f71-84de-df112456ffb7">
