### PR TITLE
[ENG-1561] refactor: ApiKeyAuth to use native form elements

### DIFF
--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+
+import { AuthCardLayoutTemplate } from 'components/auth/AuthCardLayoutTemplate';
+import { DocsHelperText } from 'components/Docs/DocsHelperText';
+import { FormComponent } from 'src/components/form';
+import { Button } from 'src/components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
+import { getProviderName } from 'src/utils';
+
+import { ChakraLandingContent } from './ChakraLandingContent';
+import { LandingContentProps } from './LandingContentProps';
+
+function ApiKeyAuthContentForm({
+  provider, providerInfo, handleSubmit, error, isButtonDisabled,
+}: LandingContentProps) {
+  const [show, setShow] = useState(false);
+  const onToggleShowHide = () => setShow((prevShow) => !prevShow);
+  const [apiKey, setApiKey] = useState('');
+  const handlePasswordChange = (event: React.FormEvent<HTMLInputElement>) => setApiKey(event.currentTarget.value);
+
+  const isApiKeyValid = apiKey.length > 0;
+  const isSubmitDisabled = isButtonDisabled || !isApiKeyValid;
+  const providerName = getProviderName(provider, providerInfo);
+  const docsURL = providerInfo.apiKeyOpts?.docsURL;
+
+  return (
+    <AuthCardLayoutTemplate
+      providerName={providerName}
+      handleSubmit={() => { handleSubmit({ apiKey }); }}
+      error={error}
+      isButtonDisabled={isSubmitDisabled}
+    >
+      <div style={{
+        display: 'flex', gap: '1rem', flexDirection: 'column', marginTop: '1rem',
+      }}
+      >
+        {docsURL && (
+        <DocsHelperText
+          url={docsURL}
+          providerDisplayName={providerName}
+          credentialName="API key"
+        />
+        )}
+        <div style={{ display: 'flex', gap: '.5rem' }}>
+          <FormComponent.Input
+            id="password"
+            name="password"
+            type={show ? 'text' : 'password'}
+            placeholder="Password"
+            onChange={(event) => handlePasswordChange(event)}
+          />
+          <Button
+            type="button"
+            style={{ height: '2.5rem', width: '5rem' }}
+            onClick={onToggleShowHide}
+          >
+            {show ? 'Hide' : 'Show'}
+          </Button>
+        </div>
+      </div>
+    </AuthCardLayoutTemplate>
+  );
+}
+
+/**
+ * bridge for Chakra UI / native form
+ * @param param0
+ * @returns
+ */
+export function ApiKeyAuthContent({ ...props }: LandingContentProps) {
+  if (!isChakraRemoved) {
+    return <ChakraLandingContent {...props} />;
+  }
+
+  return (
+    <ApiKeyAuthContentForm {...props} />
+  );
+}

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthFlow.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthFlow.tsx
@@ -6,7 +6,8 @@ import { useProject } from 'context/ProjectContextProvider';
 import { api, Connection } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
-import { LandingContent } from './LandingContent';
+import { ApiKeyAuthContent } from './ApiKeyAuthContent';
+import { IFormType } from './LandingContentProps';
 
 type ApiKeyAuthFlowProps = {
   provider: string;
@@ -52,13 +53,13 @@ export function ApiKeyAuthFlow({
   }, [apiKey, provider, nextStep, consumerName, consumerRef, groupName, groupRef,
     project, setSelectedConnection, providerApiKey]);
 
-  const onNext = (value: string) => {
-    setProviderApiKey(value);
+  const onNext = (form: IFormType) => {
+    setProviderApiKey(form.apiKey);
     setNextStep(true);
   };
 
   if (selectedConnection === null) {
-    return <LandingContent provider={provider} providerInfo={providerInfo} handleSubmit={onNext} error={null} />;
+    return <ApiKeyAuthContent provider={provider} providerInfo={providerInfo} handleSubmit={onNext} error={null} />;
   }
 
   return children;

--- a/src/components/auth/ApiKeyAuth/ChakraLandingContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ChakraLandingContent.tsx
@@ -9,22 +9,20 @@ import {
   InputRightElement,
   Stack,
 } from '@chakra-ui/react';
-import { ProviderInfo } from '@generated/api/src';
 
 import { DocsHelperText } from 'components/Docs/DocsHelperText';
 import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAlert';
 import { AuthCardLayout } from 'src/layout/AuthCardLayout/AuthCardLayout';
 import { getProviderName } from 'src/utils';
 
-type LandingContentProps = {
-  provider: string;
-  providerInfo: ProviderInfo;
-  handleSubmit: (value: string) => void;
-  error: string | null;
-  isButtonDisabled?: boolean;
-};
+import { LandingContentProps } from './LandingContentProps';
 
-export function LandingContent({
+/**
+ * @deprecated This component is deprecated and will be removed with chakra-ui
+ * @param param0
+ * @returns
+ */
+export function ChakraLandingContent({
   provider, providerInfo, handleSubmit, error, isButtonDisabled,
 }: LandingContentProps) {
   const [show, setShow] = useState(false);
@@ -77,7 +75,7 @@ export function LandingContent({
           width="100%"
           type="submit"
           onClick={() => {
-            handleSubmit(apiKey);
+            handleSubmit({ apiKey });
           }}
         >
           Next

--- a/src/components/auth/ApiKeyAuth/LandingContentProps.tsx
+++ b/src/components/auth/ApiKeyAuth/LandingContentProps.tsx
@@ -1,0 +1,13 @@
+import { ProviderInfo } from '@generated/api/src';
+
+export type LandingContentProps = {
+  provider: string;
+  providerInfo: ProviderInfo;
+  handleSubmit: (form: IFormType) => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+};
+
+export interface IFormType {
+  apiKey: string;
+}

--- a/src/components/auth/BasicAuth/BasicAuthContent.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthContent.tsx
@@ -37,7 +37,7 @@ function BasicAuthContentForm({
   return (
     <AuthCardLayoutTemplate
       providerName={providerName}
-      handleSubmit={() => { handleSubmit({ username, password }); }}
+      handleSubmit={() => { handleSubmit({ user: username, pass: password }); }}
       error={error}
       isButtonDisabled={isSubmitDisabled}
     >

--- a/src/components/auth/BasicAuth/BasicAuthFlow.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthFlow.tsx
@@ -8,11 +8,7 @@ import { handleServerError } from 'src/utils/handleServerError';
 
 import { BasicAuthContent } from './BasicAuthContent';
 import { BasicAuthFlowProps } from './BasicAuthFlowProps';
-
-type BasicCreds = {
-  user: string;
-  pass: string;
-};
+import { BasicCreds } from './LandingContentProps';
 
 export function BasicAuthFlow({
   provider, providerInfo, consumerRef, consumerName, groupRef, groupName,
@@ -49,9 +45,9 @@ export function BasicAuthFlow({
   }, [apiKey, provider, nextStep, consumerName, consumerRef, groupName,
     groupRef, project, creds, setSelectedConnection]);
 
-  const onNext = (form: any) => {
-    const { username, password } = form;
-    setCreds({ user: username, pass: password });
+  const onNext = (form: BasicCreds) => {
+    const { user, pass } = form;
+    setCreds({ user, pass });
     setNextStep(true);
   };
 

--- a/src/components/auth/BasicAuth/LandingContentProps.tsx
+++ b/src/components/auth/BasicAuth/LandingContentProps.tsx
@@ -1,9 +1,14 @@
 import { ProviderInfo } from '@generated/api/src';
 
+export type BasicCreds = {
+  user: string;
+  pass: string;
+};
+
 export type LandingContentProps = {
   provider: string;
   providerInfo: ProviderInfo;
-  handleSubmit: (form: any) => void;
+  handleSubmit: (form: BasicCreds) => void;
   error: string | null;
   isButtonDisabled?: boolean;
 };


### PR DESCRIPTION
### Summary
Refactoring Auth forms continues. 
- deprecated ChakraLandingContent.tsx (ApiKeyAuth)
- renamed LandingContent.tsx to ChakraLandingContent.tsx (ApiKeyAuth)
- added LandingContentProps.tsx (ApiKeyAuth)
- add bridge component ApiKeyAuthContent.tsx (ApiKeyAuth)

Chakra form will still be live when feature flag is turned off. 

#### Screenshot
<img width="636" alt="Screenshot 2024-10-01 at 3 49 49 PM" src="https://github.com/user-attachments/assets/c8d5fde0-ac1f-451e-80a6-ad051042f4a5">



