### PR TITLE
[ENG-1576] refactor: rm chakra from docs helper text

### DIFF
--- a/src/components/Docs/DocsHelperText.tsx
+++ b/src/components/Docs/DocsHelperText.tsx
@@ -1,4 +1,4 @@
-import { Link, Text } from '@chakra-ui/react';
+import { AccessibleLink } from '../ui-base/AccessibleLink';
 
 type DocsHelperTextProps = {
   url: string;
@@ -6,18 +6,16 @@ type DocsHelperTextProps = {
   credentialName: string;
 };
 
+// fallback during migration away from chakra-ui, when variable is not defined
+const color = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-text-secondary').trim() || '#737373';
+
 export function DocsHelperText({ url, providerDisplayName, credentialName }: DocsHelperTextProps) {
   return (
-    <Text align="left" color="darkgray">
-      <Link
-        href={url}
-        target="_blank"
-        rel="noreferrer"
-        color="blackAlpha.600"
-        isExternal
-      >
+    <p style={{ color }}>
+      <AccessibleLink href={url} newTab>
         <span style={{ textDecoration: 'underline' }}>Learn more</span>
-      </Link> about where to find your {providerDisplayName} {credentialName}.
-    </Text>
+      </AccessibleLink> about where to find your {providerDisplayName} {credentialName}.
+    </p>
   );
 }


### PR DESCRIPTION
### Summary
remove chakra-ui from docs helper text in auth flows.

#### without chakra
<img width="657" alt="Screenshot 2024-10-02 at 12 16 53 PM" src="https://github.com/user-attachments/assets/821f116f-e7a6-4205-9817-5c9427485e18">

#### with chakra
<img width="611" alt="Screenshot 2024-10-02 at 12 17 35 PM" src="https://github.com/user-attachments/assets/d2578587-6235-454a-a55e-46de5a8cc030">
