### PR TITLE
[ENG-1564] refactor: componentize the checkbox component

### DIFF
--- a/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
+++ b/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
@@ -1,15 +1,12 @@
-import * as Checkbox from '@radix-ui/react-checkbox';
-import { CheckIcon, DividerHorizontalIcon } from '@radix-ui/react-icons';
+import {
+  CheckboxField, CheckboxFieldsContainer, CheckboxGroup, SelectAllCheckbox,
+} from 'components/ui-base/Checkbox';
 
 import { isIntegrationFieldMapping } from '../../../utils';
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 import { FieldHeader } from '../FieldHeader';
 
 import { setOptionalField } from './setOptionalField';
-
-import styles from './optionalFields.module.css'; // CSS module for styling
-
-const selectAllID = 'selectAll';
 
 export function OptionalFieldsV2() {
   const {
@@ -47,47 +44,33 @@ export function OptionalFieldsV2() {
     shouldRender && (
       <>
         <FieldHeader string={`${appName} reads the following optional fields`} />
-        <div className={styles.checkboxGroupContainer}>
+        <CheckboxGroup>
           {(readOptionalFields?.length || 0) >= 2 && (
-          <div className={styles.selectAllContainer}>
-            <Checkbox.Root
-              className={styles.checkbox}
-              id={selectAllID}
+            <SelectAllCheckbox
+              id="select-all-fields"
+              isChecked={isAllChecked}
+              label="Select all"
               onCheckedChange={onSelectAllCheckboxChange}
-            >
-              <Checkbox.Indicator id={selectAllID}>
-                {isIndeterminate && <DividerHorizontalIcon />}
-                {isAllChecked === true && <CheckIcon />}
-              </Checkbox.Indicator>
-            </Checkbox.Root>
-            {/* fix eslint issue with custom checkbox label */}
-            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-            <label htmlFor={selectAllID}>Select all</label>
-          </div>
+              isIndeterminate={isIndeterminate}
+            />
           )}
-          <div className={styles.stack}>
+          <CheckboxFieldsContainer>
             {readOptionalFields.map((field) => {
               if (!isIntegrationFieldMapping(field)) {
                 return (
-                  <div key={field.fieldName} className={styles.fieldContainer}>
-                    <Checkbox.Root
-                      className={styles.checkbox}
-                      id={field.fieldName}
-                      checked={!!selectedOptionalFields?.[field?.fieldName]}
-                      onCheckedChange={(checked) => onCheckboxChange(checked, field.fieldName)}
-                    >
-                      <Checkbox.Indicator>
-                        <CheckIcon />
-                      </Checkbox.Indicator>
-                    </Checkbox.Root>
-                    <label htmlFor={field.fieldName}>{field.displayName}</label>
-                  </div>
+                  <CheckboxField
+                    key={field.fieldName}
+                    id={field.fieldName}
+                    isChecked={!!selectedOptionalFields?.[field?.fieldName]}
+                    label={field.displayName}
+                    onCheckedChange={(checked) => onCheckboxChange(checked, field.fieldName)}
+                  />
                 );
               }
               return null;
             })}
-          </div>
-        </div>
+          </CheckboxFieldsContainer>
+        </CheckboxGroup>
       </>
     )
   );

--- a/src/components/ui-base/Checkbox/checkbox.module.css
+++ b/src/components/ui-base/Checkbox/checkbox.module.css
@@ -43,4 +43,4 @@
 .checkbox:focus {
     box-shadow: 0 0 0 2px var(--amp-colors-focus-border);
 }
-  
+ 

--- a/src/components/ui-base/Checkbox/checkbox.module.css
+++ b/src/components/ui-base/Checkbox/checkbox.module.css
@@ -1,0 +1,46 @@
+.checkboxGroupContainer {
+    margin-bottom: 10px;
+    border: 2px solid var(--amp-colors-border);
+    border-radius: var(--amp-default-border-radius);
+}
+.stack {
+    overflow-y: scroll;
+    max-height: 300px;
+}
+  
+.selectAllContainer {
+    background-color: var(--amp-colors-neutral-100);
+    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+}
+  
+.fieldContainer {
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--amp-colors-border);
+    display: flex;
+    align-items: center;
+}
+  
+.checkbox {
+    margin-right: 10px;
+    background-color: white;
+    width: 25px;
+    height: 25px;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
+    border: 1px solid var(--amp-colors-border);
+    cursor: pointer;
+}
+
+.checkbox:hover {
+    background-color: var(--amp-accessibility-color); 
+}
+  
+.checkbox:focus {
+    box-shadow: 0 0 0 2px var(--amp-colors-focus-border);
+}
+  

--- a/src/components/ui-base/Checkbox/index.tsx
+++ b/src/components/ui-base/Checkbox/index.tsx
@@ -1,0 +1,96 @@
+import * as Checkbox from '@radix-ui/react-checkbox';
+import { CheckIcon, DividerHorizontalIcon } from '@radix-ui/react-icons';
+
+import styles from './checkbox.module.css'; // CSS module for styling
+
+type CheckboxFieldProps = {
+  id: string;
+  isChecked?: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+};
+
+export function CheckboxField({
+  id, isChecked, label, onCheckedChange,
+}: CheckboxFieldProps) {
+  return (
+    <div className={styles.fieldContainer}>
+      <Checkbox.Root
+        className={styles.checkbox}
+        id={id}
+        onCheckedChange={onCheckedChange}
+        checked={isChecked}
+      >
+        <Checkbox.Indicator>
+          <CheckIcon />
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      <label htmlFor={id}>{label}</label>
+    </div>
+  );
+}
+
+type SelectAllCheckboxProps = {
+  id: string;
+  isChecked?: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void;
+  isIndeterminate: boolean;
+};
+
+export function SelectAllCheckbox({
+  id, isChecked, label, onCheckedChange, isIndeterminate,
+}: SelectAllCheckboxProps) {
+  return (
+    <div className={styles.selectAllContainer}>
+      <Checkbox.Root
+        className={styles.checkbox}
+        id={id}
+        onCheckedChange={onCheckedChange}
+      >
+        <Checkbox.Indicator>
+          {isIndeterminate && <DividerHorizontalIcon />}
+          {isChecked === true && <CheckIcon />}
+        </Checkbox.Indicator>
+      </Checkbox.Root>
+      <label htmlFor={id}>{label}</label>
+    </div>
+  );
+}
+
+/**
+ * Container for all checkbox fields and select all checkbox
+ * @param param0
+ * @returns
+ */
+export function CheckboxGroup({ children }: { children: React.ReactNode }) {
+  return <div className={styles.checkboxGroupContainer}>{children}</div>;
+}
+
+/**
+ * Container for all checkbox fields
+ * @param param0
+ * @returns
+ */
+export function CheckboxFieldsContainer({ children }: { children: React.ReactNode }) {
+  return <div className={styles.stack}>{children}</div>;
+}
+
+//  Example layout for CheckboxGroup, CheckboxFieldsContainer, CheckboxField, and SelectAllCheckbox
+/**
+ *
+
+```tsx
+const fields = [
+    { fieldDisplayName: 'Field 1', fieldName: 'field1' },
+    { fieldDisplayName: 'Field 2', fieldName: 'field2' },
+];
+<CheckboxGroup>
+  <SelectAllCheckbox />
+  <CheckboxFieldsContainer>
+    {fields.map((field) => {<CheckboxField />}
+    </CheckboxFieldsContainer>
+</CheckboxGroup>
+```
+
+*/


### PR DESCRIPTION
### Summary 
Makes checkboxes into it's own component to be used outside of OptionalFields
- move the checkbox component to ui-base
- shared styles

followup to: https://github.com/amp-labs/react/pull/600


### Demo

![checkbox-compontize](https://github.com/user-attachments/assets/cd3c0970-f678-46ff-9b98-81330be18277)
