### PR TITLE
[ENG-1600] feat: support reinstall integration

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
@@ -11,6 +13,15 @@ import { ProtectedConnectionLayout } from './layout/ProtectedConnectionLayout';
 import { ObjectManagementNav } from './nav/ObjectManagementNav';
 import { ConfigurationProvider } from './state/ConfigurationStateProvider';
 import { HydratedRevisionProvider } from './state/HydratedRevisionContext';
+
+// creates a random seed to force update the component
+// pass the seed as a key to the component
+function useForceUpdate() {
+  const [seed, setSeed] = useState(1);
+  const reset = () => { setSeed(Math.random()); };
+
+  return { seed, reset };
+}
 
 interface InstallIntegrationProps {
   integration: string, // integration name
@@ -31,6 +42,7 @@ export function InstallIntegration(
 ) {
   const { projectId } = useProject();
   const { errorState } = useErrorState();
+  const { seed, reset } = useForceUpdate();
 
   if (errorState[ErrorBoundary.INTEGRATION_LIST]?.apiError) {
     return <ErrorTextBox message="Something went wrong, couldn't find integration information" />;
@@ -39,6 +51,7 @@ export function InstallIntegration(
   return (
     // install integration provider provides all props, integrationObj and installation
     <InstallIntegrationProvider
+      key={seed} // force update when seed changes
       integration={integration}
       consumerRef={consumerRef}
       consumerName={consumerName}
@@ -56,7 +69,7 @@ export function InstallIntegration(
           groupName={groupName}
         >
           <HydratedRevisionProvider projectId={projectId}>
-            <ConditionalProxyLayout>
+            <ConditionalProxyLayout resetComponent={reset}>
               <ConfigurationProvider>
                 <ObjectManagementNav>
                   <InstallationContent />

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -8,6 +8,8 @@ import { useInstallIntegrationProps } from 'context/InstallIntegrationContextPro
 import { useProject } from 'context/ProjectContextProvider';
 import { HydratedRevision } from 'services/api';
 import { SuccessTextBox } from 'src/components/SuccessTextBox/SuccessTextBox';
+import { Button } from 'src/components/ui-base/Button';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
 
 import { onCreateInstallationProxyOnly } from '../../actions/proxy/onCreateInstallationProxyOnly';
 import { useHydratedRevision } from '../../state/HydratedRevisionContext';
@@ -23,6 +25,7 @@ const getIsProxyOnly = (hydratedRevision: HydratedRevision | null) => {
 
 interface ConditionalProxyLayoutProps {
   children: React.ReactNode;
+  resetComponent: () => void; // resets installation integration component
 }
 
 /**
@@ -30,7 +33,7 @@ interface ConditionalProxyLayoutProps {
  * then it will not render the ConfigureInstallation
  * @returns
  */
-export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps) {
+export function ConditionalProxyLayout({ children, resetComponent }: ConditionalProxyLayoutProps) {
   const { projectId } = useProject();
   const apiKey = useApiKey();
   const { hydratedRevision, loading: hydratedRevisionLoading } = useHydratedRevision();
@@ -78,7 +81,22 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
   if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
   if (isLoading) return <LoadingCentered />;
   if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;
-  if (isIntegrationDeleted) return <SuccessTextBox text="Integration successfully uninstalled." />;
+  if (isIntegrationDeleted) {
+    return (
+      <SuccessTextBox
+        text="Integration successfully uninstalled."
+      >
+        {isChakraRemoved && (
+        <Button
+          type="button"
+          onClick={resetComponent}
+          style={{ width: '100%' }}
+        >Reinstall Integration
+        </Button>
+        )}
+      </SuccessTextBox>
+    );
+  }
 
   return (
     <div>

--- a/src/components/SuccessTextBox/SuccessTextBox.tsx
+++ b/src/components/SuccessTextBox/SuccessTextBox.tsx
@@ -5,8 +5,9 @@ import { Container } from '../ui-base/Container/Container';
 
 interface ConnectedSuccessBoxProps {
   text: string;
+  children?: React.ReactNode;
 }
-export function SuccessTextBox({ text }: ConnectedSuccessBoxProps) {
+export function SuccessTextBox({ text, children }: ConnectedSuccessBoxProps) {
   return (
     <Container>
       <Box style={{
@@ -21,6 +22,7 @@ export function SuccessTextBox({ text }: ConnectedSuccessBoxProps) {
       >
         <SuccessCheckmarkIcon />
         <p>{text}</p>
+        {children}
       </Box>
     </Container>
   );


### PR DESCRIPTION
### Summary 
Users are asked to delete and re-install integration when connection id or something is not set correctly. We need to support reinstallation in the UI lib.
- adds button when installation is deleted. 
- reinstall button will trigger a seed refresh and force the InstallIntegration component to re-render. 

As a side note, this logic can be forced during the onUninstallIntegration callback in the parent app. 

note: this is hidden behind feature flag so we don't have to support using a ChakraButton.

### Demo
![re-install-integration](https://github.com/user-attachments/assets/ccf089ea-d1da-473e-aa97-e92be479d722)




