### PR TITLE
[ENG-1601] feat: add on next tab ux to ObjectManagementNav

### DIFF
--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -30,6 +30,7 @@ export function CreateInstallation() {
     setMutateInstallationError, getMutateInstallationError, resetMutateInstallationErrorState,
     resetConfigureState, objectConfigurationsState, resetPendingConfigurationState, configureState,
     onInstallSuccess,
+    onNextIncompleteTab,
   } = useMutateInstallation();
   const [isLoading, setLoadingState] = useState<boolean>(false);
 
@@ -93,6 +94,7 @@ export function CreateInstallation() {
       res.finally(() => {
         setLoadingState(false);
         resetPendingConfigurationState(selectedObjectName);
+        onNextIncompleteTab();
       });
     } else {
       console.error('CreateInstallallation - onSaveReadCreate: missing required props');
@@ -123,6 +125,7 @@ export function CreateInstallation() {
       res.finally(() => {
         setLoadingState(false);
         resetPendingConfigurationState(selectedObjectName);// reset write pending/isModified state
+        onNextIncompleteTab();
       });
     } else {
       console.error('CreateInstallallation - onSaveWriteCreate: missing required props');

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -28,6 +28,7 @@ export function UpdateInstallation(
     loading, selectedObjectName, apiKey, projectId,
     resetBoundary, setErrors, setMutateInstallationError, getMutateInstallationError,
     resetConfigureState, resetPendingConfigurationState, configureState, onUpdateSuccess,
+    onNextIncompleteTab,
   } = useMutateInstallation();
 
   const [isLoading, setLoadingState] = useState<boolean>(false);
@@ -102,6 +103,7 @@ export function UpdateInstallation(
       res.finally(() => {
         setLoadingState(false);
         resetPendingConfigurationState(selectedObjectName);
+        onNextIncompleteTab();
       });
     } else {
       console.error('UpdateInstallation - onSaveUpdate missing required props');
@@ -126,6 +128,7 @@ export function UpdateInstallation(
       res.finally(() => {
         setLoadingState(false);
         resetPendingConfigurationState(selectedObjectName);
+        onNextIncompleteTab();
       });
     } else {
       console.error('UpdateInstallation - onSaveUpdate missing required props');

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 
-import { useSelectedObjectName } from '../nav/ObjectManagementNav';
+import { useNextIncompleteTabIndex, useSelectedObjectName } from '../nav/ObjectManagementNav/ObjectManagementNavContext';
 import { useObjectsConfigureState } from '../state/ConfigurationStateProvider';
 import { useHydratedRevision } from '../state/HydratedRevisionContext';
 import { getConfigureState } from '../state/utils';
@@ -30,7 +30,7 @@ export const useMutateInstallation = () => {
     resetConfigureState, objectConfigurationsState, resetPendingConfigurationState,
   } = useObjectsConfigureState();
   const configureState = getConfigureState(selectedObjectName || '', objectConfigurationsState);
-
+  const { onNextIncompleteTab } = useNextIncompleteTabIndex();
   /**
    * Error handling for installation mutation
    *
@@ -89,5 +89,6 @@ export const useMutateInstallation = () => {
     configureState,
     onInstallSuccess,
     onUpdateSuccess,
+    onNextIncompleteTab,
   };
 };

--- a/src/components/Configure/content/useSelectedConfigureState.tsx
+++ b/src/components/Configure/content/useSelectedConfigureState.tsx
@@ -1,6 +1,6 @@
 import { useProject } from 'context/ProjectContextProvider';
 
-import { useSelectedObjectName } from '../nav/ObjectManagementNav';
+import { useSelectedObjectName } from '../nav/ObjectManagementNav/ObjectManagementNavContext';
 import { useObjectsConfigureState } from '../state/ConfigurationStateProvider';
 import { getConfigureState } from '../state/utils';
 

--- a/src/components/Configure/nav/ObjectManagementNav/ObjectManagementNavContext.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/ObjectManagementNavContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react';
+
+// Create a context for the selected navObject's name
+
+export const SelectedObjectNameContext = createContext<string | null | undefined>(null);
+// Custom hook to access the selected navObject's name
+
+export function useSelectedObjectName() {
+  const selectedNavObjectName = useContext(SelectedObjectNameContext);
+  if (selectedNavObjectName === null) {
+    throw new Error(
+      'useSelectedNavObjectName must be used within a SelectedNavObjectNameProvider',
+    );
+  }
+  return { selectedObjectName: selectedNavObjectName }; // Return as an object
+}
+// create context for setNextTabIndex function
+
+export const NextTabIndexContext = createContext<() => void>(() => { });
+// Custom hook to access the setNextTabIndex function
+
+export function useNextIncompleteTabIndex() {
+  const onNextIncompleteTab = useContext(NextTabIndexContext);
+  if (!onNextIncompleteTab) {
+    throw new Error('useSetNextTabIndex must be used within a NextTabIndexProvider');
+  }
+  return { onNextIncompleteTab };
+}


### PR DESCRIPTION
### Summary 
There is currently no onboarding flow in the InstallIntegration component. When the user installs their integration with the first object, we do not show the user what to do next. This feature will navigate the user to the first uncompleted tab.

#### Demo
![onNextSave](https://github.com/user-attachments/assets/0d3f44cd-d60d-4040-a952-ec141a63adfa)

#### Out of Order
Picks first uncompleted tab
![onSave2](https://github.com/user-attachments/assets/ff9bd521-9a31-4492-af91-966f1e2f1ac4)



