### PR TITLE
[ENG-1602] feat: add `fieldMapping` prop to `InstallIntegration` component

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -5,7 +5,7 @@ import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 import { InstallIntegrationProvider } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
-import { Config } from 'services/api';
+import { Config, IntegrationFieldMapping } from 'services/api';
 
 import { InstallationContent } from './content/InstallationContent';
 import { ConditionalProxyLayout } from './layout/ConditionalProxyLayout/ConditionalProxyLayout';
@@ -23,25 +23,7 @@ function useForceUpdate() {
   return { seed, reset };
 }
 
-interface Mapping {
-    /**
-     * The name of the field to map to.
-     * Example: "source"
-     */
-    mapToName: string;
-    /**
-     * The display name of the field to map to.
-     * Example: "Source"
-     */
-    mapToDisplayName?: string;
-    /**
-     * A prompt to display to the user for this field.
-     * Example: "Which field do you use to track the source of a contact?"
-     */
-    prompt?: string;
-}
-
-export type FieldMappingsType = Map<string, Array<Mapping>>
+export type FieldMappingsType = Map<string, Array<IntegrationFieldMapping>>
 
 interface InstallIntegrationProps {
   /**

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -23,7 +23,7 @@ function useForceUpdate() {
   return { seed, reset };
 }
 
-export type FieldMappingsType = Map<string, Array<IntegrationFieldMapping>>;
+export type FieldMappingsType = { [key: string]: Array<IntegrationFieldMapping> };
 
 interface InstallIntegrationProps {
   /**

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -23,7 +23,7 @@ function useForceUpdate() {
   return { seed, reset };
 }
 
-export type FieldMappingsType = Map<string, Array<IntegrationFieldMapping>>
+export type FieldMappingsType = Map<string, Array<IntegrationFieldMapping>>;
 
 interface InstallIntegrationProps {
   /**
@@ -59,7 +59,7 @@ interface InstallIntegrationProps {
 export function InstallIntegration(
   {
     integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
-    onUninstallSuccess, fieldMapping
+    onUninstallSuccess, fieldMapping,
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -23,12 +23,52 @@ function useForceUpdate() {
   return { seed, reset };
 }
 
+interface Mapping {
+    /**
+     * The name of the field to map to.
+     * Example: "source"
+     */
+    mapToName: string;
+    /**
+     * The display name of the field to map to.
+     * Example: "Source"
+     */
+    mapToDisplayName?: string;
+    /**
+     * A prompt to display to the user for this field.
+     * Example: "Which field do you use to track the source of a contact?"
+     */
+    prompt?: string;
+}
+
+export type FieldMappingsType = Map<string, Array<Mapping>>
+
 interface InstallIntegrationProps {
-  integration: string, // integration name
+  /**
+   * The name of the integration from amp.yaml
+   */
+  integration: string,
+  /**
+   *  The ID that your app uses to identify this end user.
+   */
   consumerRef: string,
+  /**
+   *  The display name that your app uses for this end user.
+   */
   consumerName?: string,
+  /**
+   *  The ID that your app uses to identify the user's company, org, or team.
+   */
   groupRef: string,
+  /**
+   *  The display name that your app uses for this company, org or team.
+   */
   groupName?: string,
+  /**
+   * Dynamic field mappings that need to be filled out by a consumer.
+   * @experimental
+   */
+  fieldMapping?: FieldMappingsType,
   onInstallSuccess?: (installationId: string, config: Config) => void,
   onUpdateSuccess?: (installationId: string, config: Config) => void,
   onUninstallSuccess?: (installationId: string) => void,
@@ -37,7 +77,7 @@ interface InstallIntegrationProps {
 export function InstallIntegration(
   {
     integration, consumerRef, consumerName, groupRef, groupName, onInstallSuccess, onUpdateSuccess,
-    onUninstallSuccess,
+    onUninstallSuccess, fieldMapping
   }: InstallIntegrationProps,
 ) {
   const { projectId } = useProject();
@@ -60,6 +100,7 @@ export function InstallIntegration(
       onInstallSuccess={onInstallSuccess}
       onUpdateSuccess={onUpdateSuccess}
       onUninstallSuccess={onUninstallSuccess}
+      fieldMapping={fieldMapping}
     >
       <ConnectionsProvider groupRef={groupRef}>
         <ProtectedConnectionLayout

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -33,52 +33,47 @@ export function RequiredFieldMappings() {
     }
   };
 
-  const integrationFieldMappings = useMemo(
-    () => {
-      if (!selectedObjectName || !fieldMapping) return [];
-      const dynamicIntegrationFieldMappings = fieldMapping ? Object.values(fieldMapping[selectedObjectName] || {}).flat() : [];
-      const combinedFieldMappings = (configureState?.read?.requiredMapFields || []).concat(dynamicIntegrationFieldMappings).reduce((acc, item) => {
+  const integrationFieldMappings = useMemo(() => {
+    if (!selectedObjectName || !fieldMapping) return [];
+    // Extract dynamic field mappings for the selected object name from the fieldMapping object
+    const dynamicFieldMappings = fieldMapping
+      ? Object.values(fieldMapping[selectedObjectName] || {}).flat()
+      : [];
+    // Combine dynamic field mappings with the required map fields from configureState
+    const combinedFieldMappings = (
+      configureState?.read?.requiredMapFields || []
+    )
+      .concat(dynamicFieldMappings)
+      // Remove duplicates based on mapToName and keep the latest item
+      .reduce((acc, item) => {
         const existingItem = acc.find((i) => i.mapToName === item.mapToName);
         if (existingItem) {
           return acc.map((i) => (i.mapToName === item.mapToName ? item : i));
         }
         return acc.concat(item);
       }, new Array<IntegrationFieldMapping>());
-      return (
-        combinedFieldMappings.filter(
-          isIntegrationFieldMapping,
-        ) || []
-      );
-    },
-    [configureState, fieldMapping, selectedObjectName],
-  );
+    // Filter out any items that are not instances of IntegrationFieldMapping
+    return combinedFieldMappings.filter(isIntegrationFieldMapping) || [];
+  }, [configureState, fieldMapping, selectedObjectName]);
 
-  return (
-    integrationFieldMappings.length ? (
-      <>
-        <FieldHeader string="Map the following fields (required)" />
-        <div style={{ display: 'flex', gap: '2rem', flexDirection: 'column' }}>
-          {integrationFieldMappings.map((field: any) => (
-            <FormControl
-              key={field.mapToName}
-              isInvalid={
-              isError(
-                ErrorBoundary.MAPPING,
-                field.mapToName,
-              )
-            }
-            >
-              <FieldMapping
-                allFields={configureState?.read?.allFields || []}
-                field={field}
-                onSelectChange={onSelectChange}
-              />
-              <FormErrorMessage> * required</FormErrorMessage>
-            </FormControl>
-          ))}
-        </div>
-      </>
-    )
-      : null
-  );
+  return integrationFieldMappings.length ? (
+    <>
+      <FieldHeader string="Map the following fields (required)" />
+      <div style={{ display: 'flex', gap: '2rem', flexDirection: 'column' }}>
+        {integrationFieldMappings.map((field: any) => (
+          <FormControl
+            key={field.mapToName}
+            isInvalid={isError(ErrorBoundary.MAPPING, field.mapToName)}
+          >
+            <FieldMapping
+              allFields={configureState?.read?.allFields || []}
+              field={field}
+              onSelectChange={onSelectChange}
+            />
+            <FormErrorMessage> * required</FormErrorMessage>
+          </FormControl>
+        ))}
+      </div>
+    </>
+  ) : null;
 }

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -30,7 +30,7 @@ export function RequiredFieldMappings() {
     }
   };
 
-  const integrationFieldMappings = useMemo(
+  const integrationFieldMappings = useMemo( // TODO: add dynamic field mappings here. 
     () => configureState?.read?.requiredMapFields?.filter(
       isIntegrationFieldMapping,
     ) || [],

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -1,17 +1,20 @@
-import { useMemo } from 'react';
-import { FormControl, FormErrorMessage } from '@chakra-ui/react';
+import { useMemo } from "react";
+import { FormControl, FormErrorMessage } from "@chakra-ui/react";
 
-import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
+import { ErrorBoundary, useErrorState } from "context/ErrorContextProvider";
 
-import { isIntegrationFieldMapping } from '../../../utils';
-import { useSelectedConfigureState } from '../../useSelectedConfigureState';
-import { FieldHeader } from '../FieldHeader';
+import { isIntegrationFieldMapping } from "../../../utils";
+import { useSelectedConfigureState } from "../../useSelectedConfigureState";
+import { FieldHeader } from "../FieldHeader";
 
-import { FieldMapping } from './FieldMapping';
-import { setFieldMapping } from './setFieldMapping';
+import { FieldMapping } from "./FieldMapping";
+import { setFieldMapping } from "./setFieldMapping";
+import { useInstallIntegrationProps } from "src/context/InstallIntegrationContextProvider";
 
 export function RequiredFieldMappings() {
-  const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
+  const { selectedObjectName, configureState, setConfigureState } =
+    useSelectedConfigureState();
+  const { fieldMapping } = useInstallIntegrationProps();
   const { isError, removeError } = useErrorState();
 
   const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -30,11 +33,17 @@ export function RequiredFieldMappings() {
     }
   };
 
-  const integrationFieldMappings = useMemo( // TODO: add dynamic field mappings here. 
-    () => configureState?.read?.requiredMapFields?.filter(
-      isIntegrationFieldMapping,
-    ) || [],
-    [configureState],
+  const integrationFieldMappings = useMemo(
+    () => {
+      const dynamicIntegrationFieldMappings = fieldMapping ? Array.from(fieldMapping.values()).flat() : [];
+      const combinedFieldMappings = dynamicIntegrationFieldMappings.concat(configureState?.read?.requiredMapFields || [])
+      return (
+        combinedFieldMappings.filter(
+          isIntegrationFieldMapping
+        ) || []
+      );
+    },
+    [configureState, fieldMapping]
   );
 
   return (

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -1,19 +1,18 @@
-import { useMemo } from "react";
-import { FormControl, FormErrorMessage } from "@chakra-ui/react";
+import { useMemo } from 'react';
+import { FormControl, FormErrorMessage } from '@chakra-ui/react';
 
-import { ErrorBoundary, useErrorState } from "context/ErrorContextProvider";
+import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
+import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
 
-import { isIntegrationFieldMapping } from "../../../utils";
-import { useSelectedConfigureState } from "../../useSelectedConfigureState";
-import { FieldHeader } from "../FieldHeader";
+import { isIntegrationFieldMapping } from '../../../utils';
+import { useSelectedConfigureState } from '../../useSelectedConfigureState';
+import { FieldHeader } from '../FieldHeader';
 
-import { FieldMapping } from "./FieldMapping";
-import { setFieldMapping } from "./setFieldMapping";
-import { useInstallIntegrationProps } from "src/context/InstallIntegrationContextProvider";
+import { FieldMapping } from './FieldMapping';
+import { setFieldMapping } from './setFieldMapping';
 
 export function RequiredFieldMappings() {
-  const { selectedObjectName, configureState, setConfigureState } =
-    useSelectedConfigureState();
+  const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
   const { fieldMapping } = useInstallIntegrationProps();
   const { isError, removeError } = useErrorState();
 
@@ -36,14 +35,14 @@ export function RequiredFieldMappings() {
   const integrationFieldMappings = useMemo(
     () => {
       const dynamicIntegrationFieldMappings = fieldMapping ? Array.from(fieldMapping.values()).flat() : [];
-      const combinedFieldMappings = dynamicIntegrationFieldMappings.concat(configureState?.read?.requiredMapFields || [])
+      const combinedFieldMappings = dynamicIntegrationFieldMappings.concat(configureState?.read?.requiredMapFields || []);
       return (
         combinedFieldMappings.filter(
-          isIntegrationFieldMapping
+          isIntegrationFieldMapping,
         ) || []
       );
     },
-    [configureState, fieldMapping]
+    [configureState, fieldMapping],
   );
 
   return (

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -16,6 +16,7 @@ import { useApiKey } from './ApiKeyContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 import { useIntegrationList } from './IntegrationListContextProvider';
 import { useProject } from './ProjectContextProvider';
+import { FieldMappingsType } from 'src/components/Configure/InstallIntegration';
 
 // Define the context value type
 interface InstallIntegrationContextValue {
@@ -34,6 +35,7 @@ interface InstallIntegrationContextValue {
   onUninstallSuccess?: (installationId: string) => void;
   isIntegrationDeleted: boolean;
   setIntegrationDeleted: () => void;
+  fieldMapping?: FieldMappingsType;
 }
 // Create a context to pass down the props
 export const InstallIntegrationContext = createContext<InstallIntegrationContextValue>({
@@ -73,12 +75,13 @@ interface InstallIntegrationProviderProps {
   onInstallSuccess?: (installationId: string, config: Config) => void,
   onUpdateSuccess?: (installationId: string, config: Config) => void,
   onUninstallSuccess?: (installationId: string) => void,
+  fieldMapping?: FieldMappingsType
 }
 
 // Wrap your parent component with the context provider
 export function InstallIntegrationProvider({
   children, integration, consumerRef, consumerName, groupRef, groupName,
-  onInstallSuccess, onUpdateSuccess, onUninstallSuccess,
+  onInstallSuccess, onUpdateSuccess, onUninstallSuccess, fieldMapping
 }: InstallIntegrationProviderProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
@@ -159,10 +162,11 @@ export function InstallIntegrationProvider({
     onUninstallSuccess,
     isIntegrationDeleted,
     setIntegrationDeleted,
+    fieldMapping
   }), [integrationObj, consumerRef, consumerName, groupRef, groupName,
     installation, setInstallation, resetInstallations,
     onInstallSuccess, onUpdateSuccess, onUninstallSuccess,
-    isIntegrationDeleted, setIntegrationDeleted]);
+    isIntegrationDeleted, setIntegrationDeleted, fieldMapping]);
 
   if (integrationObj !== null) {
     const errorMessage = 'Error retrieving installation information for integration '

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -7,6 +7,7 @@ import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import {
   api, Config, Installation, Integration,
 } from 'services/api';
+import { FieldMappingsType } from 'src/components/Configure/InstallIntegration';
 import { LoadingCentered } from 'src/components/Loading';
 import { findIntegrationFromList } from 'src/utils';
 
@@ -16,7 +17,6 @@ import { useApiKey } from './ApiKeyContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 import { useIntegrationList } from './IntegrationListContextProvider';
 import { useProject } from './ProjectContextProvider';
-import { FieldMappingsType } from 'src/components/Configure/InstallIntegration';
 
 // Define the context value type
 interface InstallIntegrationContextValue {
@@ -81,7 +81,7 @@ interface InstallIntegrationProviderProps {
 // Wrap your parent component with the context provider
 export function InstallIntegrationProvider({
   children, integration, consumerRef, consumerName, groupRef, groupName,
-  onInstallSuccess, onUpdateSuccess, onUninstallSuccess, fieldMapping
+  onInstallSuccess, onUpdateSuccess, onUninstallSuccess, fieldMapping,
 }: InstallIntegrationProviderProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
@@ -162,7 +162,7 @@ export function InstallIntegrationProvider({
     onUninstallSuccess,
     isIntegrationDeleted,
     setIntegrationDeleted,
-    fieldMapping
+    fieldMapping,
   }), [integrationObj, consumerRef, consumerName, groupRef, groupName,
     installation, setInstallation, resetInstallations,
     onInstallSuccess, onUpdateSuccess, onUninstallSuccess,


### PR DESCRIPTION
Adds dynamic fieldMapping prop to `InstallIntegration` component so builders can add dynamic field mappings per consumer. 


Tested it manually with `demo-hubspot-apollo-app`: https://github.com/amp-labs/demo-hubspot-apollo/pull/1 

How the mapping UI looks like when both static & dynamic fieldMappings are present: 

<img width="1512" alt="Screenshot 2024-10-18 at 6 28 36 PM" src="https://github.com/user-attachments/assets/fd7a292b-fd15-4d6e-8b89-6e4a85413467">

How the mapping UI looks like when both static & dynamic fieldMappings have to map the same field: 

<img width="1512" alt="Screenshot 2024-10-18 at 7 17 32 PM" src="https://github.com/user-attachments/assets/a893e792-568d-4f20-ae7b-500fa9beb899">

Tested saving the configuration as well: 

<img width="1512" alt="Screenshot 2024-10-18 at 7 22 51 PM" src="https://github.com/user-attachments/assets/14dacaaf-f662-41fe-ab7c-4afb0e626e12">
