### PR TITLE
[auto] Update openapi dependency

### DIFF
--- a/generated-sources/api/src/models/CreateIntegrationRequest.ts
+++ b/generated-sources/api/src/models/CreateIntegrationRequest.ts
@@ -43,7 +43,7 @@ export interface CreateIntegrationRequest {
      * @type {CreateIntegrationRequestLatestRevision}
      * @memberof CreateIntegrationRequest
      */
-    latestRevision?: CreateIntegrationRequestLatestRevision;
+    latestRevision: CreateIntegrationRequestLatestRevision;
 }
 
 /**
@@ -53,6 +53,7 @@ export function instanceOfCreateIntegrationRequest(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "name" in value;
     isInstance = isInstance && "provider" in value;
+    isInstance = isInstance && "latestRevision" in value;
 
     return isInstance;
 }
@@ -69,7 +70,7 @@ export function CreateIntegrationRequestFromJSONTyped(json: any, ignoreDiscrimin
         
         'name': json['name'],
         'provider': json['provider'],
-        'latestRevision': !exists(json, 'latestRevision') ? undefined : CreateIntegrationRequestLatestRevisionFromJSON(json['latestRevision']),
+        'latestRevision': CreateIntegrationRequestLatestRevisionFromJSON(json['latestRevision']),
     };
 }
 

--- a/generated-sources/api/src/models/CreateIntegrationRequestLatestRevision.ts
+++ b/generated-sources/api/src/models/CreateIntegrationRequestLatestRevision.ts
@@ -13,24 +13,31 @@
  */
 
 import { exists, mapValues } from '../runtime';
+import type { Integration1 } from './Integration1';
+import {
+    Integration1FromJSON,
+    Integration1FromJSONTyped,
+    Integration1ToJSON,
+} from './Integration1';
+
 /**
- * If included, creating this integration will also create a new revision of the integration. For LatestRevision, one of sourceZipUrl or sourceYaml is required.
+ * 
  * @export
  * @interface CreateIntegrationRequestLatestRevision
  */
 export interface CreateIntegrationRequestLatestRevision {
     /**
-     * URL of where a zip of the source files can be downloaded (e.g. Google Cloud Storage URL).
+     * The spec version string.
      * @type {string}
      * @memberof CreateIntegrationRequestLatestRevision
      */
-    sourceZipUrl?: string;
+    specVersion: string;
     /**
-     * A YAML string that defines the integration.
-     * @type {string}
+     * 
+     * @type {Integration1}
      * @memberof CreateIntegrationRequestLatestRevision
      */
-    sourceYaml?: string;
+    content: Integration1;
 }
 
 /**
@@ -38,6 +45,8 @@ export interface CreateIntegrationRequestLatestRevision {
  */
 export function instanceOfCreateIntegrationRequestLatestRevision(value: object): boolean {
     let isInstance = true;
+    isInstance = isInstance && "specVersion" in value;
+    isInstance = isInstance && "content" in value;
 
     return isInstance;
 }
@@ -52,8 +61,8 @@ export function CreateIntegrationRequestLatestRevisionFromJSONTyped(json: any, i
     }
     return {
         
-        'sourceZipUrl': !exists(json, 'sourceZipUrl') ? undefined : json['sourceZipUrl'],
-        'sourceYaml': !exists(json, 'sourceYaml') ? undefined : json['sourceYaml'],
+        'specVersion': json['specVersion'],
+        'content': Integration1FromJSON(json['content']),
     };
 }
 
@@ -66,8 +75,8 @@ export function CreateIntegrationRequestLatestRevisionToJSON(value?: CreateInteg
     }
     return {
         
-        'sourceZipUrl': value.sourceZipUrl,
-        'sourceYaml': value.sourceYaml,
+        'specVersion': value.specVersion,
+        'content': Integration1ToJSON(value.content),
     };
 }
 

--- a/generated-sources/api/src/models/HydratedRevision.ts
+++ b/generated-sources/api/src/models/HydratedRevision.ts
@@ -33,7 +33,7 @@ export interface HydratedRevision {
      */
     id: string;
     /**
-     * The spec version string (e.g. "0.1.0").
+     * The spec version string.
      * @type {string}
      * @memberof HydratedRevision
      */

--- a/generated-sources/api/src/models/Revision.ts
+++ b/generated-sources/api/src/models/Revision.ts
@@ -33,7 +33,7 @@ export interface Revision {
      */
     id: string;
     /**
-     * The spec version string (e.g. "0.1.0").
+     * The spec version string.
      * @type {string}
      * @memberof Revision
      */


### PR DESCRIPTION
This updates the dependency to version [89cfe3f9516dafb858ef82f238628543572b4d37](https://github.com/amp-labs/openapi/commit/89cfe3f9516dafb858ef82f238628543572b4d37) from [main](https://github.com/amp-labs/openapi/tree/main)