### PR TITLE
[ENG-1620] fix: adds re-render state to combobox items

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -40,20 +40,16 @@ export function RequiredFieldMappings() {
       ? Object.values(fieldMapping[selectedObjectName] || {}).flat()
       : [];
     // Combine dynamic field mappings with the required map fields from configureState
-    const combinedFieldMappings = (
-      configureState?.read?.requiredMapFields || []
-    )
+    const combinedFieldMappings = (configureState?.read?.requiredMapFields || [])
       .concat(dynamicFieldMappings)
       // Remove duplicates based on mapToName and keep the latest item
       .reduce((acc, item) => {
         const existingItem = acc.find((i) => i.mapToName === item.mapToName);
-        if (existingItem) {
-          return acc.map((i) => (i.mapToName === item.mapToName ? item : i));
-        }
+        if (existingItem) return acc.map((i) => (i.mapToName === item.mapToName ? item : i));
         return acc.concat(item);
       }, new Array<IntegrationFieldMapping>());
     // Filter out any items that are not instances of IntegrationFieldMapping
-    return combinedFieldMappings.filter(isIntegrationFieldMapping) || [];
+    return combinedFieldMappings.filter(isIntegrationFieldMapping);
   }, [configureState, fieldMapping, selectedObjectName]);
 
   return integrationFieldMappings.length ? (

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useCombobox } from 'downshift';
 
 import styles from './combobox.module.css'; // CSS Modules
@@ -38,6 +38,9 @@ export function ComboBox({
   placeholder,
 }: ComboBoxProps) {
   const [filteredItems, setFilteredItems] = useState<Option[]>(items);
+
+  // Update the filtered items when the items prop changes
+  useEffect(() => setFilteredItems(items), [items]);
 
   const onInputValueChange = (_inputValue: string) => {
     setFilteredItems(items.filter(getOptionsFilter(_inputValue)));


### PR DESCRIPTION
### Summary
Not totally sure why combobox breaks only on dynamic fields. It might have to do with items being re-rendered and the internal state is not catching the re-render. This PR adds a useEffect to explicitly listen to item changes. 

#### Testing
Navigate to an object that is not completed and supports dynamic fields. (see linear ticket for setup)
![combobox-reload-items](https://github.com/user-attachments/assets/6d5ae7ed-982b-40bd-8efb-340d1bd3c1bc)

