### PR TITLE
[ENG-1585] feat/refactor: adds uninstall tab to ObjectManagementNav v2

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler, useEffect } from 'react';
+import { FormEventHandler } from 'react';
 import { Button as ChakraButton } from '@chakra-ui/react';
 
 import { FormErrorBox } from 'components/FormErrorBox';

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,4 +1,4 @@
-import { FormEventHandler } from 'react';
+import { FormEventHandler, useEffect } from 'react';
 import { Button as ChakraButton } from '@chakra-ui/react';
 
 import { FormErrorBox } from 'components/FormErrorBox';

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@chakra-ui/react';
 
 import { Box } from 'components/ui-base/Box/Box';
-// import { isChakraRemoved } from 'components/ui-base/constant';
+import { isChakraRemoved } from 'components/ui-base/constant';
 import { Container } from 'components/ui-base/Container/Container';
 import { Divider } from 'components/ui-base/Divider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
@@ -23,7 +23,7 @@ import { NavObjectItem } from './NavObjectItem';
 import { NextTabIndexContext, SelectedObjectNameContext } from './ObjectManagementNavContext';
 import { OtherTab } from './OtherTab';
 import { UNINSTALL_INSTALLATION_CONST, UninstallInstallation } from './UninstallInstallation';
-// import { ObjectManagementNavV2 } from './v2';
+import { ObjectManagementNavV2 } from './v2';
 
 type ObjectManagementNavProps = {
   children?: React.ReactNode;
@@ -151,9 +151,9 @@ export function ChakraObjectManagementNav({
 
 export function ObjectManagementNav({ ...props }: ObjectManagementNavProps) {
   // TODO: native tabs still in progress
-  // if (isChakraRemoved) {
-  //   return <ObjectManagementNavV2 {...props} />;
-  // }
+  if (isChakraRemoved) {
+    return <ObjectManagementNavV2 {...props} />;
+  }
 
   return <ChakraObjectManagementNav {...props} />;
 }

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -1,10 +1,13 @@
 import * as Tabs from '@radix-ui/react-tabs';
+import classnames from 'classnames';
 
 import { NavIcon } from 'assets/NavIcon';
+import { TrashIcon } from 'assets/TrashIcon';
 import { NavObject, ObjectConfigurationsState } from 'src/components/Configure/types';
 import { Divider } from 'src/components/ui-base/Divider';
 
 import { OTHER_CONST } from '../../constant';
+import { UNINSTALL_INSTALLATION_CONST } from '../../UninstallInstallation';
 
 import styles from './tabs.module.css';
 
@@ -57,17 +60,38 @@ function OtherTab({
   );
 }
 
+function UninstallTab() {
+  return (
+    <>
+      <Divider style={{ margin: '3rem 0 1rem 0' }} />
+      <Tabs.Trigger
+        value={UNINSTALL_INSTALLATION_CONST}
+        className={classnames(styles.tabTrigger, styles.danger)}
+      >
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: '.5rem', marginRight: '.5rem',
+        }}
+        >
+          {TrashIcon()}
+          <span>Uninstall</span>
+        </div>
+      </Tabs.Trigger>
+    </>
+  );
+}
+
 type VerticalTabsProps = {
   readNavObjects: NavObject[];
   otherNavObject?: NavObject; // write tab
   value: string;
   onValueChange: (value: string) => void;
   objectConfigurationsState?: ObjectConfigurationsState;
+  showUninstallButton?: boolean;
 };
 
 export function VerticalTabs({
   value, readNavObjects, onValueChange, objectConfigurationsState,
-  otherNavObject,
+  otherNavObject, showUninstallButton,
 }: VerticalTabsProps) {
   return (
     <Tabs.Root value={value} className={styles.tabsRoot} onValueChange={onValueChange}>
@@ -93,7 +117,7 @@ export function VerticalTabs({
         )}
 
         {/* Uninstall Tab */}
-        {/* <Tabs.Trigger value="uninstall" className={styles.tabTrigger} style={{}}>Uninstall</Tabs.Trigger> */}
+        {showUninstallButton && <UninstallTab />}
       </Tabs.List>
 
       {/* EXAMPLE Content if children does not render content */}

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
@@ -3,24 +3,32 @@
     width: 100%;
   }
   
-  .tabsList {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-  }
-  
-  .tabTrigger {
-    all: unset;
-    padding: 10px;
-    cursor: pointer;
-    background-color: var(--amp-colors-tabs-background);
-    border-radius: var(--amp-default-border-radius);
-    margin-bottom: 5px;
-  }
-  
-  .tabTrigger[data-state="active"] {
-    background-color: var(--amp-colors-tabs-background-active); 
-    color: #1a202c;
-  }
-  
- 
+.tabsList {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.tabTrigger {
+  all: unset;
+  padding: 10px;
+  cursor: pointer;
+  background-color: var(--amp-colors-tabs-background);
+  border-radius: var(--amp-default-border-radius);
+  margin-bottom: 5px;
+}
+
+.tabTrigger[data-state="active"] {
+  background-color: var(--amp-colors-tabs-background-active); 
+}
+
+.danger {
+  color: var(--amp-colors-error-text);
+  background-color: var(--amp-colors-error-background);
+  border-color: var(--amp-colors-error-border);
+}
+
+.danger[data-state="active"] {
+  background-color: var(--amp-colors-error-background-hover);
+}
+

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -1,9 +1,3 @@
-/**
- * This page is in progress and is not yet ready for use. @dion
- * Chakra is removed from this page.
- *
- */
-
 import {
   useCallback, useEffect, useMemo, useState,
 } from 'react';
@@ -13,6 +7,7 @@ import { Container } from 'components/ui-base/Container/Container';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { VerticalTabs } from 'src/components/Configure/nav/ObjectManagementNav/v2/Tabs';
+import { NavObject } from 'src/components/Configure/types';
 import { AmpersandFooter } from 'src/layout/AuthCardLayout/AmpersandFooter';
 import { getProviderName } from 'src/utils';
 
@@ -20,6 +15,17 @@ import { useObjectsConfigureState } from '../../../state/ConfigurationStateProvi
 import { useHydratedRevision } from '../../../state/HydratedRevisionContext';
 import { generateOtherNavObject, generateReadNavObjects } from '../../../utils';
 import { NextTabIndexContext, SelectedObjectNameContext } from '../ObjectManagementNavContext';
+import { UNINSTALL_INSTALLATION_CONST } from '../UninstallInstallation';
+
+function getSelectedObject(navObjects: NavObject[], tabValue: string): NavObject | undefined {
+  if (tabValue === UNINSTALL_INSTALLATION_CONST) {
+    // uninstall tab
+    return { name: UNINSTALL_INSTALLATION_CONST, completed: false };
+  }
+
+  // read or write tabs
+  return navObjects.find((navObj) => navObj.name === tabValue);
+}
 
   type ObjectManagementNavProps = {
     children?: React.ReactNode;
@@ -54,7 +60,7 @@ export function ObjectManagementNavV2({
     return navObjects;
   }, [readNavObjects, otherNavObject, isWriteSupported]);
 
-  const selectedObject = allNavObjects.find((navObj) => navObj.name === tabValue);
+  const selectedObject = getSelectedObject(allNavObjects, tabValue);
 
   /**
    * Function to navigate to the first uncompleted tab or do nothing if all tabs are completed
@@ -96,6 +102,7 @@ export function ObjectManagementNavV2({
                 onValueChange={(value: string) => setTabvalue(value)}
                 objectConfigurationsState={objectConfigurationsState}
                 otherNavObject={otherNavObject}
+                showUninstallButton={!!installation}
               />
               )}
             </div>


### PR DESCRIPTION
### Summary
supports uninstall tab without chakra. 
- adds ObjectManagementNav v2 under feature flag
- bases styling to danger button variant. 

#### demo

![support-uninstall-tab](https://github.com/user-attachments/assets/9b567073-6afe-409c-aeee-1e652c763ded)
