### PR TITLE
[ENG-1631] feat: add tooltip to field mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "classnames": "^2.5.1",
     "downshift": "^9.0.8",
     "immer": "^10.0.3",
-    "lodash.isequal": "^4.5.0"
+    "lodash.isequal": "^4.5.0",
+    "react-tooltip": "^5.28.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/assets/TooltipIcon.tsx
+++ b/src/assets/TooltipIcon.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable max-len */
+export function TooltipIcon() {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="17" viewBox="0 0 16 17" fill="none">
+      <g clipPath="url(#clip0_2896_16290)">
+        <path d="M8.00032 11.167L8.00032 7.83366M8.00032 1.83366C4.33366 1.83366 1.33366 4.83366 1.33366 8.50033C1.33366 12.167 4.33366 15.167 8.00033 15.167C11.667 15.167 14.667 12.167 14.667 8.50033C14.667 4.83366 11.667 1.83366 8.00032 1.83366Z" stroke="#6B7280" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M8.00293 5.83301L7.99768 5.83301" stroke="#6B7280" strokeLinecap="round" strokeLinejoin="round" />
+      </g>
+      <defs>
+        <clipPath id="clip0_2896_16290">
+          <rect width="16" height="16" fill="white" transform="translate(16 16.5) rotate(180)" />
+        </clipPath>
+      </defs>
+    </svg>
+  );
+}

--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -4,6 +4,7 @@ import { Select as ChakraSelect } from '@chakra-ui/react';
 import { HydratedIntegrationFieldExistent, IntegrationFieldMapping } from 'services/api';
 import { ComboBox } from 'src/components/ui-base/ComboBox/ComboBox';
 import { isChakraRemoved } from 'src/components/ui-base/constant';
+import { LabelTooltip } from 'src/components/ui-base/Tooltip';
 
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 
@@ -74,8 +75,15 @@ export function FieldMapping(
 
   return (
     <div key={field.mapToName} style={{ display: 'flex', flexDirection: 'column' }}>
-      <h3 style={{ fontWeight: 500 }}>{field.mapToDisplayName}</h3>
-      <p style={{ paddingBottom: '1rem' }}>{field?.prompt}</p>
+      <div style={{
+        display: 'flex', flexDirection: 'row', gap: '.25rem', marginBottom: '.25rem',
+      }}
+      >
+        <span style={{ fontWeight: 500 }}>{field.mapToDisplayName}</span>
+        <span>
+          {field?.prompt && <LabelTooltip id={`tooltip-id-${field?.prompt}`} tooltipText={field?.prompt} />}
+        </span>
+      </div>
       {SelectComponent}
     </div>
   );

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -55,7 +55,7 @@ export function RequiredFieldMappings() {
   return integrationFieldMappings.length ? (
     <>
       <FieldHeader string="Map the following fields (required)" />
-      <div style={{ display: 'flex', gap: '2rem', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
         {integrationFieldMappings.map((field: any) => (
           <FormControl
             key={field.mapToName}

--- a/src/components/ui-base/Tooltip/index.tsx
+++ b/src/components/ui-base/Tooltip/index.tsx
@@ -1,0 +1,19 @@
+import { Tooltip } from 'react-tooltip';
+
+import { TooltipIcon } from 'src/assets/TooltipIcon';
+
+interface LabelTooltipProps {
+  id: string;
+  tooltipText: string;
+}
+
+export function LabelTooltip({ id, tooltipText }: LabelTooltipProps) {
+  return (
+    <>
+      <span data-tooltip-id={id} style={{ maxWidth: '20rem' }}>
+        {TooltipIcon()}
+      </span>
+      <Tooltip id={id} place="top" content={tooltipText} style={{ maxWidth: '30rem' }} />
+    </>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,6 +1349,26 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.8.tgz#aa43561be075815879305965020f492cdb43da12"
+  integrity sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/dom@^1.6.1":
+  version "1.6.11"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.11.tgz#8631857838d34ee5712339eb7cbdfb8ad34da723"
+  integrity sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.8"
+
+"@floating-ui/utils@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz"
@@ -2870,7 +2890,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
 
-classnames@^2.5.1:
+classnames@^2.3.0, classnames@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
@@ -5814,6 +5834,14 @@ react-test-renderer@^18.2.0:
     react-is "^18.3.1"
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.2"
+
+react-tooltip@^5.28.0:
+  version "5.28.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-5.28.0.tgz#c7b5343ab2d740a428494a3d8315515af1f26f46"
+  integrity sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==
+  dependencies:
+    "@floating-ui/dom" "^1.6.1"
+    classnames "^2.3.0"
 
 readable-stream@^3.4.0:
   version "3.6.2"


### PR DESCRIPTION
### Summary
Makes Field Mappings more condensed. Currently field prompts take a lot of screen real estate, we move into tool tip. Less space and padding is preferred since consumers expect to have 20+ mappings. 
- adds react-tooltip dependency
- modifies field mapping padding
- adds tooltip component

#### before 
<img width="748" alt="Screenshot 2024-10-28 at 4 45 39 PM" src="https://github.com/user-attachments/assets/d53a7d15-c9d0-4f1b-a31d-c21ff37d1f74">

#### with chakra
<img width="755" alt="Screenshot 2024-10-28 at 4 39 03 PM" src="https://github.com/user-attachments/assets/076f73fe-2593-4b9f-8b14-5326fd86be3d">

#### tootltip
<img width="732" alt="Screenshot 2024-10-28 at 4 38 59 PM" src="https://github.com/user-attachments/assets/f1da2fc2-ca2a-4c9d-8519-78c21d16ff13">

#### without chakra
<img width="751" alt="Screenshot 2024-10-28 at 4 40 20 PM" src="https://github.com/user-attachments/assets/2d0c49cd-8bb5-4eaa-9bb5-978a9777700d">
