### PR TITLE
fix: rendering issue in ConditionalProxyLayout

### DIFF
--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -78,25 +78,25 @@ export function ConditionalProxyLayout({ children, resetComponent }: Conditional
   }, [hydratedRevision, isProxyOnly, installation, selectedConnection, apiKey, projectId,
     integrationObj?.id, groupRef, consumerRef, setInstallation, isLoading, onInstallSuccess]);
 
-  if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
-  if (isLoading) return <LoadingCentered />;
-  if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;
   if (isIntegrationDeleted) {
     return (
       <SuccessTextBox
         text="Integration successfully uninstalled."
       >
         {isChakraRemoved && (
-        <Button
-          type="button"
-          onClick={resetComponent}
-          style={{ width: '100%' }}
-        >Reinstall Integration
-        </Button>
+          <Button
+            type="button"
+            onClick={resetComponent}
+            style={{ width: '100%' }}
+          >Reinstall Integration
+          </Button>
         )}
       </SuccessTextBox>
     );
   }
+  if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
+  if (isLoading) return <LoadingCentered />;
+  if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;
 
   return (
     <div>


### PR DESCRIPTION
### Summary
This PR helps debug rendering issue with uninstalling a Proxy.

The data flow is a little confusing. To debug, we'll need to look at the `InstallIntegration` component. 

```js
// InstallIntegration.tsx

 <InstallIntegrationProvider > 
      <ConnectionsProvider>
        <ProtectedConnectionLayout>
          <HydratedRevisionProvider>
            <ConditionalProxyLayout > // router to switch component to the proxy component. see layout folder.
              <ConfigurationProvider> // manages anything with the config object
                <ObjectManagementNav> // left hand nav
                  <InstallationContent /> // right side content inside nav
                </ObjectManagementNav>
              </ConfigurationProvider>
            </ConditionalProxyLayout>
          </HydratedRevisionProvider>
        </ProtectedConnectionLayout>
      </ConnectionsProvider>
    </InstallIntegrationProvider>
```

The re-render happens because `setIntegrationDeleted` will be called in the uninstall after the requests and the conditional proxy layer will interpret which component to render, the Loading and Proxy state are rendered before the IntegrationUninstalled state. 

The PR moves the IntegrationUninstalled before the loading and error state. 

```jsx
// deleted integration
  if (isIntegrationDeleted) {
    return (
      <SuccessTextBox
        text="Integration successfully uninstalled."
      >
        {isChakraRemoved && (
          <Button
            type="button"
            onClick={resetComponent}
            style={{ width: '100%' }}
          >Reinstall Integration
          </Button>
        )}
      </SuccessTextBox>
    );
  }
// error loading integration
  if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
// loading
  if (isLoading) return <LoadingCentered />;
// no configuration required
  if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;

// configuration component
  return (
    <div>
      {children}
    </div>
  );
```

note: The data flow might have been confusing since the ConditionalProxyLayout is now overloaded with rendering the Proxy Success (no object configuration) , Integration Deleted, and the normal ConfigureInstallation components. It might be time to consider renaming.

In the parent PR, the `UninstallCTA.tsx` looks like a copy of `UninstallContent`, we should consider refactoring the action call. Even without the refactor, `UninstallCTA` should be moved closer to the Proxy logic (currently sitting in layout/ConditionalProxyLayout). The content folder contains logic pertaining to InstallationContent which UninstallCTA doesn't touch.
