### PR TITLE
[ENG-1580, ENG-1612] feat/refactor: add form control component

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
-import { FormControl, FormErrorMessage } from '@chakra-ui/react';
+import { FormControl as ChakraFormControl, FormErrorMessage as ChakraFormErrorMessage } from '@chakra-ui/react';
 import { IntegrationFieldMapping } from '@generated/api/src';
 
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
+import { FormControl } from 'src/components/form/FormControl';
+import { isChakraRemoved } from 'src/components/ui-base/constant';
 import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
 
 import { isIntegrationFieldMapping } from '../../../utils';
@@ -56,19 +58,39 @@ export function RequiredFieldMappings() {
     <>
       <FieldHeader string="Map the following fields (required)" />
       <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
-        {integrationFieldMappings.map((field: any) => (
-          <FormControl
-            key={field.mapToName}
-            isInvalid={isError(ErrorBoundary.MAPPING, field.mapToName)}
-          >
-            <FieldMapping
-              allFields={configureState?.read?.allFields || []}
-              field={field}
-              onSelectChange={onSelectChange}
-            />
-            <FormErrorMessage> * required</FormErrorMessage>
-          </FormControl>
-        ))}
+        {integrationFieldMappings.map((field) => {
+          if (isChakraRemoved) {
+            return (
+              <FormControl
+                id={field.mapToName}
+                key={field.mapToName}
+                isInvalid={isError(ErrorBoundary.MAPPING, field.mapToName)}
+                errorMessage="* required"
+              >
+                <FieldMapping
+                  allFields={configureState?.read?.allFields || []}
+                  field={field}
+                  onSelectChange={onSelectChange}
+                />
+              </FormControl>
+            );
+          }
+
+          // Chakra UI FormControl
+          return (
+            <ChakraFormControl
+              key={field.mapToName}
+              isInvalid={isError(ErrorBoundary.MAPPING, field.mapToName)}
+            >
+              <FieldMapping
+                allFields={configureState?.read?.allFields || []}
+                field={field}
+                onSelectChange={onSelectChange}
+              />
+              <ChakraFormErrorMessage> * required</ChakraFormErrorMessage>
+            </ChakraFormControl>
+          );
+        })}
       </div>
     </>
   ) : null;

--- a/src/components/form/FormControl/formControl.module.css
+++ b/src/components/form/FormControl/formControl.module.css
@@ -1,0 +1,33 @@
+.formControl {
+    margin-bottom: 1rem;
+}
+  
+.formLabel {
+    font-weight: bold;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.formLabelRequired::after {
+    content: ' *';
+    color: var(--amp-colors-error-text);
+}
+
+.formInput {
+    position: relative;
+}
+
+.formInputInvalid input {
+    border-color: var(--amp-colors-error-border);
+}
+
+.formError {
+    color: var(--amp-colors-error-text);
+    font-size: 0.875rem;
+    margin-top: 0.5rem;
+}
+
+.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+}

--- a/src/components/form/FormControl/index.tsx
+++ b/src/components/form/FormControl/index.tsx
@@ -1,0 +1,59 @@
+// FormControl.tsx
+import React from 'react';
+import classNames from 'classnames';
+
+import styles from './formControl.module.css';
+
+type FormControlProps = {
+  id: string;
+  label?: string;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  isInvalid?: boolean;
+  errorMessage?: string;
+  children: React.ReactNode;
+};
+
+/**
+ * mimics the FormControl component from chakra-ui
+ * renders a form control with a label and error message
+ * @param param0
+ * @returns
+ */
+export function FormControl({
+  id,
+  label,
+  isRequired = false,
+  isDisabled = false,
+  isInvalid = false,
+  errorMessage,
+  children,
+}: FormControlProps) {
+  return (
+    <div
+      className={classNames(styles.formControl, {
+        [styles.disabled]: isDisabled,
+      })}
+    >
+      {label && (
+      <label
+        htmlFor={id}
+        className={classNames(styles.formLabel, { [styles.formLabelRequired]: isRequired })}
+      >
+        {label}
+      </label>
+      )}
+      <div
+        id={id}
+        className={classNames(styles.formInput, { [styles.formInputInvalid]: isInvalid })}
+      >
+        {children}
+      </div>
+      {isInvalid && errorMessage && (
+      <div className={styles.formError} role="alert">
+        {errorMessage}
+      </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Summary
refactors RequiredFieldMappings to use native form control component
- add native form control to replace Chakra's
- adds error message to form control when not valid input is passed.

#### Screenshot
<img width="740" alt="Screenshot 2024-10-30 at 4 31 13 PM" src="https://github.com/user-attachments/assets/1e109511-d7c0-42c3-9351-667b0e9a88a1">

#### Testing
1. comment out form FieldMapping so default is not auto set.
```
//  setFieldMapping(selectedObjectName, setConfigureState, field.mapToName, field._default);
```
2. Install without selecting a RequiredFieldMapping


