### PR TITLE
fix: field mappings for required fields

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -36,24 +36,24 @@ export function RequiredFieldMappings() {
   };
 
   const integrationFieldMappings = useMemo(() => {
-    if (!selectedObjectName) return []; // No object selected, return empty array
+    // 1. Extract required map fields from configureState
+    const requiredFieldMappings = configureState?.read?.requiredMapFields || [];
 
-    // Extract dynamic field mappings for the selected object name from the fieldMapping object if it exists
-    const dynamicFieldMappings = fieldMapping
+    // 2. Extract dynamic field mappings for the selected object name from the fieldMapping object if it exists
+    const dynamicFieldMappings = selectedObjectName && fieldMapping
       ? Object.values(fieldMapping[selectedObjectName] || {}).flat()
       : [];
 
-    // Combine dynamic field mappings with the required map fields from configureState
-    const combinedFieldMappings = (configureState?.read?.requiredMapFields || [])
-      .concat(dynamicFieldMappings)
-      // Remove duplicates based on mapToName and keep the latest item
+    // 3. Combine dynamic field mappings with the required map fields from configureState
+    const combinedFieldMappings = requiredFieldMappings.concat(dynamicFieldMappings)
+      // 4. Remove duplicates based on mapToName and keep the latest item
       .reduce((acc, item) => {
         const existingItem = acc.find((i) => i.mapToName === item.mapToName);
         if (existingItem) return acc.map((i) => (i.mapToName === item.mapToName ? item : i));
         return acc.concat(item);
       }, new Array<IntegrationFieldMapping>());
 
-    // Filter out any items that are not instances of IntegrationFieldMapping
+    // 5. Filter out any items that are not instances of IntegrationFieldMapping
     return combinedFieldMappings.filter(isIntegrationFieldMapping);
   }, [configureState, fieldMapping, selectedObjectName]);
 

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -36,11 +36,13 @@ export function RequiredFieldMappings() {
   };
 
   const integrationFieldMappings = useMemo(() => {
-    if (!selectedObjectName || !fieldMapping) return [];
-    // Extract dynamic field mappings for the selected object name from the fieldMapping object
+    if (!selectedObjectName) return []; // No object selected, return empty array
+
+    // Extract dynamic field mappings for the selected object name from the fieldMapping object if it exists
     const dynamicFieldMappings = fieldMapping
       ? Object.values(fieldMapping[selectedObjectName] || {}).flat()
       : [];
+
     // Combine dynamic field mappings with the required map fields from configureState
     const combinedFieldMappings = (configureState?.read?.requiredMapFields || [])
       .concat(dynamicFieldMappings)
@@ -50,11 +52,12 @@ export function RequiredFieldMappings() {
         if (existingItem) return acc.map((i) => (i.mapToName === item.mapToName ? item : i));
         return acc.concat(item);
       }, new Array<IntegrationFieldMapping>());
+
     // Filter out any items that are not instances of IntegrationFieldMapping
     return combinedFieldMappings.filter(isIntegrationFieldMapping);
   }, [configureState, fieldMapping, selectedObjectName]);
 
-  return integrationFieldMappings.length ? (
+  return integrationFieldMappings?.length ? (
     <>
       <FieldHeader string="Map the following fields (required)" />
       <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>


### PR DESCRIPTION
### Summary
Required field mappings was returning an empty array if fieldMappings didn't exists. We update the code to remove this line (fix), and to separate extracting required map fields and dynamic field mappings to be easier to read and maintain. 

#### only required fields
<img width="870" alt="Screenshot 2024-11-06 at 11 41 46 AM" src="https://github.com/user-attachments/assets/015f4889-0043-41ac-8c58-048cb8ee57ad">


#### with required fields and dynamic field
<img width="888" alt="Screenshot 2024-11-06 at 11 42 23 AM" src="https://github.com/user-attachments/assets/9c01a907-4821-438e-8814-e50aa13d75f9">
