### PR TITLE
[ENG-1657] style: update css default styles, simplify css variables

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -28,10 +28,10 @@ interface ConfigureInstallationBaseProps {
 
 // fallback during migration away from chakra-ui, when variable is not defined
 const borderColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-neutral-100').trim() || '#f5f5f5';
+  .getPropertyValue('--amp-colors-border').trim() || '#e5e5e5';
 
-const boxShadow = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-shadows-sm').trim() || '0 1px 2px 0 rgba(0, 0, 0, 0.05)';
+const backgroundColor = getComputedStyle(document.documentElement)
+  .getPropertyValue('--amp-colors-background').trim() || 'white';
 
 // Installation UI Base
 export function ConfigureInstallationBase(
@@ -88,7 +88,7 @@ export function ConfigureInstallationBase(
       : (
         <form style={{ width: '34rem' }} onSubmit={onSave}>
           <div style={{
-            display: 'flex', flexDirection: 'row-reverse', gap: '1rem', marginBottom: '2rem',
+            display: 'flex', flexDirection: 'row-reverse', gap: '.8rem', marginBottom: '2rem',
           }}
           >
             {ButtonBridgeSubmit}
@@ -96,11 +96,10 @@ export function ConfigureInstallationBase(
           </div>
           <Box
             style={{
-              padding: '2rem',
+              padding: '1rem 2rem',
               minHeight: '300px',
-              backgroundColor: 'white',
+              backgroundColor,
               borderColor,
-              boxShadow,
             }}
           >
             {errorMsg && (

--- a/src/components/Configure/content/fields/FieldHeader.tsx
+++ b/src/components/Configure/content/fields/FieldHeader.tsx
@@ -11,7 +11,7 @@ const color = getComputedStyle(document.documentElement)
 export function FieldHeader({ string }: FieldHeaderProps) {
   return (
     <div style={{
-      display: 'flex', position: 'relative', paddingTop: '2rem', paddingBottom: '1rem',
+      display: 'flex', position: 'relative', paddingTop: '1rem', paddingBottom: '.5rem',
     }}
     >
       <h3 style={{ color, fontSize: '1rem', fontWeight: '500' }}>{string}</h3>

--- a/src/components/Configure/content/fields/OptionalFields/optionalFields.module.css
+++ b/src/components/Configure/content/fields/OptionalFields/optionalFields.module.css
@@ -37,7 +37,7 @@
 }
 
 .checkbox:hover {
-    background-color: var(--amp-accessibility-color); 
+    background-color: var(--amp-colors-input-hover); 
 }
   
 .checkbox:focus {

--- a/src/components/Configure/content/fields/RequiredFields.tsx
+++ b/src/components/Configure/content/fields/RequiredFields.tsx
@@ -13,7 +13,7 @@ export function RequiredFields() {
   return (
     <>
       <FieldHeader string={`${appName} reads the following ${selectedObjectName} fields`} />
-      <div style={{ display: 'flex', gap: '.5rem', marginBottom: '2rem' }}>
+      <div style={{ display: 'flex', gap: '.5rem', marginBottom: '.5rem' }}>
         {configureState?.read?.requiredFields?.length
           ? (configureState.read?.requiredFields.map((field) => {
             if (!isIntegrationFieldMapping(field)) {

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -40,7 +40,7 @@ function getSelectedObject(navObjects: NavObject[], tabIndex: number): NavObject
 }
 
 const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-background-secondary').trim() || '#FCFCFC';
+  .getPropertyValue('--amp-colors-background').trim() || 'white';
 
 /**
  * @deprecated remove this component when the chakra migration is done

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
@@ -18,17 +18,18 @@
   margin-bottom: 5px;
 }
 
+.tabTrigger:hover {
+  background-color: var(--amp-colors-tabs-background-hover);
+}
+
 .tabTrigger[data-state="active"] {
   background-color: var(--amp-colors-tabs-background-active); 
 }
 
 .danger {
   color: var(--amp-colors-error-text);
-  background-color: var(--amp-colors-error-background);
+  /* background-color: var(--amp-colors-error-background); */
   border-color: var(--amp-colors-error-border);
 }
 
-.danger[data-state="active"] {
-  background-color: var(--amp-colors-error-background-hover);
-}
 

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -32,7 +32,7 @@ function getSelectedObject(navObjects: NavObject[], tabValue: string): NavObject
   };
 
 const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-background-secondary').trim() || '#FCFCFC';
+  .getPropertyValue('--amp-colors-background').trim() || 'white';
 
 // note: when the object key exists in the config; the user has already completed the object before
 export function ObjectManagementNavV2({

--- a/src/components/SuccessTextBox/SuccessTextBox.tsx
+++ b/src/components/SuccessTextBox/SuccessTextBox.tsx
@@ -16,8 +16,6 @@ export function SuccessTextBox({ text, children }: ConnectedSuccessBoxProps) {
         alignItems: 'center',
         padding: '3rem',
         gap: '3rem',
-        // todo: box shadow is --amp-shadows-md (convert to module.css after removing chakra)
-        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
       }}
       >
         <SuccessCheckmarkIcon />

--- a/src/components/form/FormControl/formControl.module.css
+++ b/src/components/form/FormControl/formControl.module.css
@@ -1,5 +1,5 @@
 .formControl {
-    margin-bottom: 1rem;
+    margin-bottom: .25rem;
 }
   
 .formLabel {

--- a/src/components/ui-base/Box/box.module.css
+++ b/src/components/ui-base/Box/box.module.css
@@ -1,6 +1,5 @@
 .box {
     border-radius: var(--amp-default-border-radius);
     background-color: var(--amp-colors-white);
-    box-shadow: var(--amp-shadows-sm);
     border: 1px solid var(--amp-colors-border);
 }

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -34,7 +34,7 @@
 
 /* Additional styling to support screen readers */
 button[aria-expanded="true"] {
-    background-color: var(--amp-accessibility-color);  /* Can visually indicate button state */
+    background-color: var(--amp-colors-input-hover);  /* Can visually indicate button state */
 }
 
 .danger {

--- a/src/components/ui-base/Checkbox/checkbox.module.css
+++ b/src/components/ui-base/Checkbox/checkbox.module.css
@@ -1,6 +1,6 @@
 .checkboxGroupContainer {
     margin-bottom: 10px;
-    border: 2px solid var(--amp-colors-border);
+    border: 1px solid var(--amp-colors-border);
     border-radius: var(--amp-default-border-radius);
 }
 .stack {
@@ -10,13 +10,13 @@
   
 .selectAllContainer {
     background-color: var(--amp-colors-neutral-100);
-    padding: 8px 16px;
+    padding: 8px 10px;
     display: flex;
     align-items: center;
 }
   
 .fieldContainer {
-    padding: 8px 16px;
+    padding: 8px 10px;
     border-bottom: 1px solid var(--amp-colors-border);
     display: flex;
     align-items: center;
@@ -25,20 +25,19 @@
 .checkbox {
     margin-right: 10px;
     background-color: white;
-    width: 25px;
-    height: 25px;
+    width: 20px;
+    height: 20px;
     border-radius: 4px;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
     border: 1px solid var(--amp-colors-border);
     cursor: pointer;
     flex: none;
 }
 
 .checkbox:hover {
-    background-color: var(--amp-accessibility-color); 
+    background-color: var(--amp-colors-input-hover); 
 }
   
 .checkbox:focus {

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -48,7 +48,7 @@
 
 .menuItem:hover,
 .highlighted {
-  background-color: var(--amp-colors-menu-hover);
+  background-color: var(--amp-colors-input-hover);
 }
 
 .selected {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -15,21 +15,8 @@
     --amp-colors-neutral-900: #171717;
     --amp-colors-neutral-950: #0a0a0a;
 
-    /* based of chakra colors */
-    --amp-colors-gray-50: #F7FAFC;
-    --amp-colors-gray-100: #EDF2F7;
-    --amp-colors-gray-200: #E2E8F0;
-    --amp-colors-gray-300: #CBD5E0;
-    --amp-colors-gray-400: #A0AEC0;
-    --amp-colors-gray-500: #718096;
-    --amp-colors-gray-600: #4A5568;
-    --amp-colors-gray-700: #2D3748;
-    --amp-colors-gray-800: #1A202C;
-    --amp-colors-gray-900: #171923;
 
     /* semantic colors  */
-    --amp-shadows-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --amp-shadows-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
     --amp-colors-border: var(--amp-colors-neutral-200);
 
     --amp-colors-error-background: #FEF2F2;
@@ -37,34 +24,33 @@
     --amp-colors-error-border: #FECACA;
     --amp-colors-error-text: #991B1B;
 
-    --amp-colors-accent-primary: var(--amp-colors-neutral-700);
-    --amp-colors-accent-secondary: var(--amp-colors-neutral-500);
-    --amp-colors-background: var(--amp-colors-neutral-50);
-    --amp-colors-background-secondary: #FCFCFC;
-    --amp-colors-text-secondary: var(--amp-colors-neutral-500);
+    /* accent primary and secondary accent used in loading*/
+    --amp-colors-accent-primary: var(--amp-colors-neutral-700); 
+    --amp-colors-accent-secondary: var(--amp-colors-neutral-500); 
+     
+    /* background boxes */
+    --amp-colors-background: var(--amp-colors-white);
+    --amp-colors-text-secondary: var(--amp-colors-neutral-700);
 
-    --amp-colors-badge: var(--amp-colors-neutral-200);
+    --amp-colors-badge: var(--amp-colors-neutral-100);
     --amp-colors-badge-text: var(--amp-colors-neutral-700);
 
-    --amp-colors-link-base: var(--amp-colors-neutral-500);
-    --amp-colors-link-text: var(--amp-colors-link-base);
-    --amp-colors-link-hover: calc(var(--amp-colors-link-base) + 10%);
-    --amp-colors-link-focus: calc(var(--amp-colors-link-base) + 15%);
-    --amp-colors-link-active: calc(var(--amp-colors-link-base) - 20%);
+    --amp-colors-link-text: var(--amp-colors-neutral-700);
+    --amp-colors-link-focus: var(--amp-colors-neutral-800);
+    --amp-colors-link-active: var(--amp-colors-neutral-600);
 
     --amp-colors-button-primary: var(--amp-colors-accent-primary);
     --amp-colors-button-primary-hover: var(--amp-colors-neutral-600);
     --amp-colors-button-text: var(--amp-colors-neutral-200);
-    --amp-button-hover-shadow: var(--amp-shadows-sm);
 
-    --amp-colors-menu-hover:  var(--amp-colors-gray-100);
+    --amp-colors-input-hover: var(--amp-colors-neutral-100);
     --amp-colors-focus-border: var(--amp-colors-neutral-800);
 
-    --amp-colors-tabs-background: #f1f5f9;
-    --amp-colors-tabs-background-active: #e0e9f5;
-    --amp-colors-tabs-text: #1a202c;
+    --amp-colors-tabs-background: transparent;
+    --amp-colors-tabs-background-active: var(--amp-colors-neutral-100);
+    --amp-colors-tabs-background-hover: var(--amp-colors-neutral-100);
+    --amp-colors-tabs-text: var(--amp-colors-neutral-900);
         
     /* misc */
     --amp-default-border-radius: 4px;
-    --amp-accessibility-color: var(--amp-colors-gray-200);
 }


### PR DESCRIPTION
### Summary
This PR updates the styles for the native migrated components. 
- update spacing, borders in boxes, headers, and inputs
- rm box shadows
- update tab styles
- adjust checkbox sizing and spacing
- change background to white

**clean up variable.css**
- remove secondary background color
- remove unused colors

#### Screenshots
<img width="749" alt="Screenshot 2024-11-06 at 2 21 50 PM" src="https://github.com/user-attachments/assets/28257ec1-2e9d-4a79-bbcf-bbc467d55ec9">

<img width="745" alt="Screenshot 2024-11-06 at 2 22 15 PM" src="https://github.com/user-attachments/assets/c4e830fd-6978-460a-8375-702b7c55a7f2">

<img width="348" alt="Screenshot 2024-11-06 at 2 31 43 PM" src="https://github.com/user-attachments/assets/7e5855f5-97b0-4b9a-81d6-37c5cf01803b">

<img width="414" alt="Screenshot 2024-11-06 at 2 31 38 PM" src="https://github.com/user-attachments/assets/b9ca2a3d-8dec-4002-8133-bce94d06d999">


