### PR TITLE
fix: rename warning to danger variant

### DIFF
--- a/src/components/ThemeProvider/Button/buttonTheme.ts
+++ b/src/components/ThemeProvider/Button/buttonTheme.ts
@@ -16,7 +16,7 @@ export const buttonVariants = {
       opacity: 1, // Ensure it is fully visible (no transparency)
     },
   },
-  warning: {
+  danger: {
     bg: 'red.50', // Background color
     outline: '2px solid red.100',
     outlineOffset: '0',


### PR DESCRIPTION
### Summary
fix uninstall button by renaming to be danger variant.
 
![Screenshot 2024-11-13 at 4 04 58 PM](https://github.com/user-attachments/assets/a805d1ea-6598-4640-8a9b-228edd8b7ddd)
