### PR TITLE
[ENG-1650] feat: add read object mapping callout component

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -5,7 +5,6 @@ import { FormErrorBox } from 'components/FormErrorBox';
 import { LoadingCentered } from 'components/Loading';
 import { Box } from 'components/ui-base/Box/Box';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
-// import { FormCalloutBox } from 'src/components/FormCalloutBox';
 import { Button } from 'src/components/ui-base/Button';
 import { isChakraRemoved } from 'src/components/ui-base/constant';
 
@@ -103,8 +102,6 @@ export function ConfigureInstallationBase(
               borderColor,
             }}
           >
-            {/* data comes from hydrated revision */}
-            {/* <FormCalloutBox>People in Clarify is mapped to Contacts in Hubspot</FormCalloutBox> */}
             {errorMsg && (
             <FormErrorBox>
               {(typeof (errorMsg) === 'string') ? errorMsg : 'Installation Failed.'}

--- a/src/components/Configure/content/fields/ObjectMapping.tsx
+++ b/src/components/Configure/content/fields/ObjectMapping.tsx
@@ -1,0 +1,44 @@
+import { FormCalloutBox } from 'src/components/FormCalloutBox';
+import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
+import { useProject } from 'src/context/ProjectContextProvider';
+import { capitalize, getProviderName } from 'src/utils';
+
+import { useHydratedRevision } from '../../state/HydratedRevisionContext';
+import { useSelectedConfigureState } from '../useSelectedConfigureState';
+
+/**
+ * ObjectMappingCallout component displays a callout box with the mapping information
+ * @returns
+ */
+export function ReadObjectMapping() {
+  const { project } = useProject();
+  const { hydratedRevision } = useHydratedRevision();
+  const { selectedObjectName } = useSelectedConfigureState();
+  const { provider } = useInstallIntegrationProps();
+
+  const appName = project?.appName;
+  const providerName = getProviderName(provider);
+
+  const selectedReadObject = hydratedRevision?.content?.read?.objects?.find(
+    (obj) => obj.objectName === selectedObjectName,
+  );
+
+  const objectDisplayName = selectedReadObject?.displayName
+  || (selectedObjectName && capitalize(selectedObjectName));
+
+  const mapToName = selectedReadObject?.mapToName;
+  const mapToDisplayName = selectedReadObject?.mapToDisplayName || (mapToName && capitalize(mapToName));
+
+  if (mapToDisplayName && appName && providerName) {
+    return (
+      <FormCalloutBox style={{ marginTop: '1rem' }}>
+        <p>
+          <b>{mapToDisplayName}</b> in {appName} is mapped to <b>{objectDisplayName}</b> in {providerName}.
+        </p>
+      </FormCalloutBox>
+    );
+  }
+
+  // renders no callout if there is no mapping
+  return null;
+}

--- a/src/components/Configure/content/fields/ReadFields.tsx
+++ b/src/components/Configure/content/fields/ReadFields.tsx
@@ -1,10 +1,12 @@
 import { RequiredFieldMappings } from './FieldMappings';
+import { ReadObjectMapping } from './ObjectMapping';
 import { OptionalFields } from './OptionalFields';
 import { RequiredFields } from './RequiredFields';
 
 export function ReadFields() {
   return (
     <>
+      <ReadObjectMapping />
       <RequiredFields />
       <RequiredFieldMappings />
       <OptionalFields />


### PR DESCRIPTION
### Summary
adds support for conveying when an object is mapped to builder's custom object.

#### Demo
![Screenshot 2024-11-14 at 1 21 52 PM](https://github.com/user-attachments/assets/1031e702-45cc-49bc-b9c6-b280408c5195)

#### Followup
update nav to support displayName and mapped display names https://github.com/amp-labs/react/pull/695