### PR TITLE
[ENG-1650] feat: add displayName to object management nav

### DIFF
--- a/src/components/Configure/nav/ObjectManagementNav/OtherTab.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/OtherTab.tsx
@@ -6,7 +6,7 @@ import { NavObjectItem } from './NavObjectItem';
 type OtherTabProps = {
   pending?: boolean,
   completed: boolean,
-  displayName?: 'other' | 'write',
+  displayName?: 'Other' | 'Write',
 };
 
 /**

--- a/src/components/Configure/nav/ObjectManagementNav/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/index.tsx
@@ -110,6 +110,7 @@ export function ChakraObjectManagementNav({
                   <NavObjectItem
                     key={object.name}
                     objectName={object.name}
+                    displayName={object.displayName}
                     completed={object.completed}
                     pending={
                     objectConfigurationsState[object.name]?.read?.isOptionalFieldsModified
@@ -123,7 +124,7 @@ export function ChakraObjectManagementNav({
                 <OtherTab
                   completed={otherNavObject.completed}
                   pending={objectConfigurationsState?.other?.write?.isWriteModified}
-                  displayName={readNavObjects?.length ? 'other' : 'write'}
+                  displayName={readNavObjects?.length ? 'Other' : 'Write'}
                 />
                 ) }
 

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -101,6 +101,7 @@ export function VerticalTabs({
           <NavObjectTab
             key={object.name}
             objectName={object.name}
+            displayName={object.displayName}
             completed={object.completed}
             pending={objectConfigurationsState?.[object.name]?.read?.isOptionalFieldsModified
               || objectConfigurationsState?.[object.name]?.read?.isRequiredMapFieldsModified || false}
@@ -112,7 +113,7 @@ export function VerticalTabs({
             completed={otherNavObject.completed}
             pending={objectConfigurationsState?.other?.write?.isWriteModified || false}
              // if read tab exists, display 'other' else 'write' when write tab is the only tab
-            displayName={readNavObjects.length ? 'other' : 'write'}
+            displayName={readNavObjects.length ? 'Other' : 'Write'}
           />
         )}
 

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -59,5 +59,6 @@ export type ObjectConfigurationsState = Record<string, ConfigureState>;
 // standard object name and whether it is completed in the ObjectManagementNav
 export type NavObject = {
   name: string;
+  displayName?: string;
   completed: boolean;
 };

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -7,6 +7,7 @@ import {
   HydratedRevision,
   IntegrationFieldMapping,
 } from 'services/api';
+import { capitalize } from 'src/utils';
 
 import { OTHER_CONST } from './nav/ObjectManagementNav/constant';
 import {
@@ -86,6 +87,8 @@ export const generateReadNavObjects = (config: Config | undefined, hydratedRevis
     navObjects.push(
       {
         name: object?.objectName,
+        displayName: object?.mapToDisplayName || object?.displayName // mapToDisplayName is preferred
+         || (object?.objectName && capitalize(object?.objectName)), // fallback to objectName
         // if no config, object is not completed
         // object is completed if the key exists in the config
         completed: config ? !!getReadObject(config, object.objectName) : false,


### PR DESCRIPTION
#### Summary
followup to object mappings
- adds mapToDisplayName support in nav
- capitalize object name in nav if no displayName / mapToDisplayName is provided


#### Screenshot (with Chakra)
Account (displayName) and People (mappedToDisplay)
![Screenshot 2024-11-14 at 2 06 42 PM](https://github.com/user-attachments/assets/7f1f9364-f514-470f-9400-b4cac1748d31)

#### Screenshot (no Chakra)
![Screenshot 2024-11-14 at 2 11 06 PM](https://github.com/user-attachments/assets/b92259a7-21bd-4c5c-b859-f13f6d7c3c8a)

followup to https://github.com/amp-labs/react/pull/692


