### PR TITLE
[ENG-1677] style: update styles, reset with Chakra removed.

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -53,7 +53,7 @@ export function FieldMapping(
           } as unknown as HTMLSelectElement,
         } as unknown as React.ChangeEvent<HTMLSelectElement>);
       }}
-      placeholder={!fieldValue ? 'Please select one' : fieldValue}
+      placeholder="Please select one"
     />
   );
 

--- a/src/components/Configure/content/fields/ObjectMapping.tsx
+++ b/src/components/Configure/content/fields/ObjectMapping.tsx
@@ -32,7 +32,7 @@ export function ReadObjectMapping() {
   if (mapToDisplayName && appName && providerName) {
     return (
       <FormCalloutBox style={{ marginTop: '1rem' }}>
-        <p>
+        <p style={{ margin: '1rem 0' }}>
           <b>{mapToDisplayName}</b> in {appName} is mapped to <b>{objectDisplayName}</b> in {providerName}.
         </p>
       </FormCalloutBox>

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -92,8 +92,10 @@ export function ObjectManagementNavV2({
             }}
           >
             <div style={{ width: '20rem' }}>
-              <h1>{getProviderName(provider)} integration</h1>
-              <h3 style={{ marginBottom: '20px', fontSize: '1.125rem', fontWeight: '500' }}>{appName}</h3>
+              <h1 style={{ fontSize: 'small', fontWeight: '400' }}>{getProviderName(provider)} integration
+              </h1>
+              <h3 style={{ marginBottom: '20px', fontSize: 'large', fontWeight: '500' }}>{appName}
+              </h3>
 
               {isNavObjectsReady && (
               // dummy mock tabs with styling only

--- a/src/components/Configure/resetCss.module.css
+++ b/src/components/Configure/resetCss.module.css
@@ -19,6 +19,15 @@
       margin: 0;
       padding: 0;
     }
+
+    h1, h2, h3, h4, h5, h6, p {
+      margin: 0;
+      padding: 0;
+    }
+
+    button {
+      cursor: pointer;
+    }
    
   }
   

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/Salesforce/SalesforceSubdomainEntry.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/Salesforce/SalesforceSubdomainEntry.tsx
@@ -16,7 +16,7 @@ export function SalesforceSubdomainEntry({
         What is my Salesforce subdomain?
       </AccessibleLink>
       <AuthErrorAlert error={error} />
-      <div style={{ display: 'flex', marginTop: '1em' }}>
+      <div style={{ display: 'flex', marginTop: '1em', alignItems: 'center' }}>
         <FormComponent.Input
           id="salesforce-subdomain"
           type="text"

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -14,7 +14,7 @@
 }
 
 .button:hover {
-    background-color: var(--amp-colors-button-primary-hover);
+    opacity: .8;
     box-shadow: var(--amp-button-hover-shadow);
 }
 
@@ -48,11 +48,6 @@ button[aria-expanded="true"] {
 }
 
 .ghost {
-    background-color: white;
+    background-color: var(--amp-colors-neutral-100);    
     color: var(--amp-colors-neutral-900);
 }
-
-.ghost:hover {
-    background-color: var(--amp-button-hover-shadow);
-}
-

--- a/src/components/ui-base/Checkbox/checkbox.module.css
+++ b/src/components/ui-base/Checkbox/checkbox.module.css
@@ -29,7 +29,6 @@
     height: 20px;
     border-radius: 4px;
     display: flex;
-    align-items: center;
     justify-content: center;
     border: 1px solid var(--amp-colors-border);
     cursor: pointer;

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -70,12 +70,14 @@ export function ComboBox({
         {/* input  */}
         <div className={styles.inputContainer}>
           <input
+            style={{ border: 'none' }}
             disabled={disabled}
             placeholder={placeholder}
             className={styles.input}
             {...getInputProps()}
           />
           <button
+            style={{ border: 'none' }}
             disabled={disabled}
             aria-label="toggle menu"
             className={styles.toggleButton}

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -38,6 +38,7 @@
   border-color: var(--amp-colors-border);
   z-index: 10;
   border-radius: var(--amp-default-border-radius);
+  padding: 0;
 }
 
 .menuItem {

--- a/src/components/ui-base/Divider/divider.module.css
+++ b/src/components/ui-base/Divider/divider.module.css
@@ -1,3 +1,5 @@
 .divider {
-    border-color: var(--amp-colors-border);
+    border: none;
+    height: 1px;
+    background: var(--amp-colors-border)
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -15,7 +15,6 @@
     --amp-colors-neutral-900: #171717;
     --amp-colors-neutral-950: #0a0a0a;
 
-
     /* semantic colors  */
     --amp-colors-border: var(--amp-colors-neutral-200);
 
@@ -42,7 +41,6 @@
     --amp-colors-link-active: var(--amp-colors-neutral-600);
 
     --amp-colors-button-primary: var(--amp-colors-accent-primary);
-    --amp-colors-button-primary-hover: var(--amp-colors-neutral-600);
     --amp-colors-button-text: var(--amp-colors-neutral-200);
 
     --amp-colors-input-hover: var(--amp-colors-neutral-100);


### PR DESCRIPTION
### Summary 
With Chakra removed, many styles are broken with padding no longer consistent. We remove padding/margin in out components in our css reset. We also make changes to 
- combobox
- checkbox
- buttons 
- divider 
- Salesforce Domain Entry

#### Screenshot

<img width="934" alt="Screenshot 2024-11-15 at 4 47 24 PM" src="https://github.com/user-attachments/assets/87ac2e96-41ed-438c-85e3-b471e1ca1821">
<img width="908" alt="Screenshot 2024-11-15 at 4 47 41 PM" src="https://github.com/user-attachments/assets/557220ed-e978-4e9e-86c7-2c3eb0730452">
<img width="735" alt="Screenshot 2024-11-15 at 4 47 48 PM" src="https://github.com/user-attachments/assets/982d9683-0121-49fb-b1e5-5893d8ad8ecd">
<img width="728" alt="Screenshot 2024-11-15 at 4 47 52 PM" src="https://github.com/user-attachments/assets/3a892034-7a18-4c2a-b7de-80b99e86f080">



