### PR TITLE
feat(dx): add ability to tag a release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,10 @@ on:
       version:
         description: 'Version number for the SDK'
         required: true
+      tag:
+        description: 'Tag for the SDK version'
+        required: true
+        default: 'latest'
 
 jobs:
   publish:
@@ -39,7 +43,7 @@ jobs:
 
     - name: Publish to npm
       id: publish_to_npm
-      run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && yarn publish --non-interactive
+      run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc && yarn publish --non-interactive --tag ${{ github.event.inputs.tag }}
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
This will allow us to release non-stable versions of the react library such as `beta`, `rc-1`, `alpha` or `next`. These versions will be visible on npm  but not downloaded when someone installs the lib via `npm i @amp-labs/react` by default. 

They would have to explicitly install it via `npm i @amp-labs/react@alpha-1.0.0`

The value of the tag will be `latest` by default unless specificied, which will be the versions that show up on npm registry publicly and downloaded by default. 

Ref: https://docs.npmjs.com/cli/v10/commands/npm-dist-tag#purpose 