### PR TITLE
Fix: typeguard for isIntegrationMapping

### DIFF
--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -1,3 +1,5 @@
+import { IntegrationFieldExistent } from '@generated/api/src';
+
 import { ErrorBoundary } from 'context/ErrorContextProvider';
 import {
   Config,
@@ -22,7 +24,7 @@ import {
  */
 export function isIntegrationFieldMapping(field: HydratedIntegrationField):
   field is IntegrationFieldMapping {
-  return (field as IntegrationFieldMapping).mapToName !== undefined;
+  return !(field as IntegrationFieldExistent).fieldName;
 }
 
 // 1. get object


### PR DESCRIPTION
The typeguard was checking for `mapToName`, which no longer works since IntegrationFieldExistent can also have `mapToName` now, checking for the existence of `fieldName` is more accurate. This PR also means the builders can start using builder-defined field mappings (they'll just look the same as regular required fields for now, which is fine). 

This is the test yaml file: https://github.com/amp-labs/testdata/blob/main/salesforce/amp.yaml#L9

This is what the UI library looks like:
- Billing city is a builder defined mapped field (shows up just like other required fields)
- Country is a consumer defined mapped field (shows dropdown to ask consumer to do maping)

<img width="1512" alt="Screenshot 2024-11-19 at 1 52 48 PM" src="https://github.com/user-attachments/assets/216d6be1-c38b-4312-b939-8ab50086d433">

This tab shows that if there were only consumer-field mappings, it still works:
![Uploading Screenshot 2024-11-19 at 1.53.04 PM.png…]()



