### PR TITLE
[ENG-1689] styles: update design system variables and layout

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -23,13 +23,6 @@ interface ConfigureInstallationBaseProps {
   errorMsg?: string | boolean,
 }
 
-// fallback during migration away from chakra-ui, when variable is not defined
-const borderColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-border').trim() || '#e5e5e5';
-
-const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-background').trim() || 'white';
-
 // Installation UI Base
 export function ConfigureInstallationBase(
   {
@@ -84,8 +77,8 @@ export function ConfigureInstallationBase(
             style={{
               padding: '1rem 2rem',
               minHeight: '300px',
-              backgroundColor,
-              borderColor,
+              backgroundColor: 'var(--amp-colors-bg-primary)',
+              borderColor: 'var(--amp-colors-border)',
             }}
           >
             {errorMsg && (

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -67,7 +67,7 @@ export function ConfigureInstallationBase(
       : (
         <form style={{ width: '34rem' }} onSubmit={onSave}>
           <div style={{
-            display: 'flex', flexDirection: 'row-reverse', gap: '.8rem', marginBottom: '2rem',
+            display: 'flex', flexDirection: 'row-reverse', gap: '.8rem', marginBottom: '20px',
           }}
           >
             {ButtonBridgeSubmit}

--- a/src/components/Configure/content/fields/FieldHeader.tsx
+++ b/src/components/Configure/content/fields/FieldHeader.tsx
@@ -4,22 +4,18 @@ interface FieldHeaderProps {
   string: string;
 }
 
-// fallback during migration away from chakra-ui, when variable is not defined
-const color = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-text-secondary').trim() || '#737373';
-
 export function FieldHeader({ string }: FieldHeaderProps) {
   return (
     <div style={{
       display: 'flex', position: 'relative', paddingTop: '1rem', paddingBottom: '.5rem',
     }}
     >
-      <h3 style={{ color, fontSize: '1rem', fontWeight: '500' }}>{string}</h3>
+      <h3 style={{ color: 'var(--amp-colors-text-muted)', fontSize: '1rem', fontWeight: '400' }}>{string}</h3>
       <div style={{
         display: 'flex', flex: 1, justifyContent: 'flex-end', alignItems: 'center',
       }}
       >
-        <Divider style={{ marginLeft: '1rem' }} />
+        <Divider style={{ width: '100%', marginLeft: '1rem' }} />
       </div>
     </div>
   );

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -57,7 +57,7 @@ export function RequiredFieldMappings() {
 
   return integrationFieldMappings?.length ? (
     <>
-      <FieldHeader string="Map the following fields (required)" />
+      <FieldHeader string="Map the following fields" />
       <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
         {integrationFieldMappings.map((field) => (
           <FormControl

--- a/src/components/Configure/content/fields/OptionalFields/optionalFields.module.css
+++ b/src/components/Configure/content/fields/OptionalFields/optionalFields.module.css
@@ -9,7 +9,7 @@
 }
   
 .selectAllContainer {
-    background-color: var(--amp-colors-neutral-100);
+    background-color: var(--amp-colors-neutral-200);
     padding: 8px 16px;
     display: flex;
     align-items: center;

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
@@ -19,17 +19,15 @@
 }
 
 .tabTrigger:hover {
-  background-color: var(--amp-colors-tabs-background-hover);
+  background-color: var(--amp-colors-bg-highlight);
 }
 
 .tabTrigger[data-state="active"] {
-  background-color: var(--amp-colors-tabs-background-active); 
+  background-color: var(--amp-colors-bg-highlight); 
 }
 
 .danger {
-  color: var(--amp-colors-error-text);
-  /* background-color: var(--amp-colors-error-background); */
-  border-color: var(--amp-colors-error-border);
+  color: var(--amp-colors-status-critical-dark);
 }
 
 

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -31,9 +31,6 @@ function getSelectedObject(navObjects: NavObject[], tabValue: string): NavObject
     children?: React.ReactNode;
   };
 
-const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-background').trim() || 'white';
-
 // note: when the object key exists in the config; the user has already completed the object before
 export function ObjectManagementNavV2({
   children,
@@ -88,7 +85,7 @@ export function ObjectManagementNavV2({
               display: 'flex',
               gap: '1rem',
               padding: '3rem',
-              backgroundColor,
+              backgroundColor: 'var(--amp-colors-bg-primary)',
             }}
           >
             <div style={{ width: '20rem' }}>

--- a/src/components/Configure/resetCss.module.css
+++ b/src/components/Configure/resetCss.module.css
@@ -1,5 +1,4 @@
-/* Chakra Reset Scoped with CSS Modules */
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');
+/* CSS Reset Scoped with CSS Modules */
 
 
 .resetContainer {
@@ -11,7 +10,7 @@
     }
 
     * {
-      font-family: 'DM Sans', Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+      font-family: var(--amp-font-family);
     }
   
     /* Body defaults */

--- a/src/components/Docs/DocsHelperText.tsx
+++ b/src/components/Docs/DocsHelperText.tsx
@@ -6,13 +6,9 @@ type DocsHelperTextProps = {
   credentialName: string;
 };
 
-// fallback during migration away from chakra-ui, when variable is not defined
-const color = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-text-secondary').trim() || '#737373';
-
 export function DocsHelperText({ url, providerDisplayName, credentialName }: DocsHelperTextProps) {
   return (
-    <p style={{ color }}>
+    <p style={{ color: 'var(--amp-colors-text-muted)' }}>
       <AccessibleLink href={url} newTab>
         <span style={{ textDecoration: 'underline' }}>Learn more</span>
       </AccessibleLink> about where to find your {providerDisplayName} {credentialName}.

--- a/src/components/ErrorTextBox/errorTextBox.module.css
+++ b/src/components/ErrorTextBox/errorTextBox.module.css
@@ -13,10 +13,10 @@
     align-items: center;
     padding: 1em 2rem;
     border-radius: var(--amp-default-border-radius);
-    background-color: var(--amp-colors-error-background);
-    border: 1px solid var(--amp-colors-error-border);
+    background-color: var(--amp-colors-status-critical-muted);
+    border: 1px solid var(--amp-colors-status-critical-muted);
 }
 
 .errorText {
-    color: var(--amp-colors-error-text);
+    color: var(--amp-colors-status-critical-dark);
 }

--- a/src/components/FormCalloutBox.tsx
+++ b/src/components/FormCalloutBox.tsx
@@ -1,12 +1,8 @@
 import { Box } from 'src/components/ui-base/Box/Box';
 
-// fallback during migration away from chakra-ui, when variable is not defined
-const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-callout-background').trim() || '#f5f5f5';
-
 const defaultStyle = {
-  backgroundColor,
-  border: 'none',
+  backgroundColor: 'var(--amp-colors-bg-highlight)',
+  borderColor: 'var(--amp-colors-bg-highlight)',
   padding: '.5rem 1rem',
 };
 

--- a/src/components/FormErrorBox.tsx
+++ b/src/components/FormErrorBox.tsx
@@ -1,19 +1,9 @@
 import { Box } from 'src/components/ui-base/Box/Box';
 
-// fallback during migration away from chakra-ui, when variable is not defined
-const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-error-background').trim() || '#FEF2F2';
-
-const borderColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-error-border').trim() || '#FECACA';
-
-const color = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-error-text').trim() || '#991B1B';
-
 const defaultStyle = {
-  backgroundColor,
-  borderColor,
-  color,
+  backgroundColor: 'var(--amp-colors-status-critical-muted)',
+  borderColor: 'var(--amp-colors-status-critical-muted)',
+  color: 'var(--amp-colors-status-critical-dark)',
   padding: '.5rem 1rem',
 };
 

--- a/src/components/Loading/style.module.css
+++ b/src/components/Loading/style.module.css
@@ -14,14 +14,14 @@
 }
 .loader:before {
     animation: ball1 1s infinite;
-    background-color: var(--amp-colors-accent-primary);
-    box-shadow: 30px 0 0 var(--amp-colors-accent-secondary);
+    background-color: var(--amp-colors-primary);
+    box-shadow: 30px 0 0 var(--amp-colors-neutral-700);
     margin-bottom: 10px;
 }
 .loader:after {
     animation: ball2 1s infinite;
-    background-color: var(--amp-colors-accent-secondary);
-    box-shadow: 30px 0 0 var(--amp-colors-accent-primary);
+    background-color: var(--amp-colors-neutral-700);
+    box-shadow: 30px 0 0 var(--amp-colors-primary);
 }
 
 @keyframes rotate {
@@ -32,30 +32,30 @@
 
 @keyframes ball1 {
     0% {
-        box-shadow: 30px 0 0 var(--amp-colors-accent-secondary);
+        box-shadow: 30px 0 0 var(--amp-colors-neutral-700);
     }
     50% {
-        box-shadow: 0 0 0 var(--amp-colors-accent-secondary);;
+        box-shadow: 0 0 0 var(--amp-colors-neutral-700);
         margin-bottom: 0;
         transform: translate(15px, 15px);
     }
     100% {
-        box-shadow: 30px 0 0 var(--amp-colors-accent-secondary);
+        box-shadow: 30px 0 0 var(--amp-colors-neutral-700);
         margin-bottom: 10px;
     }
 }
 
 @keyframes ball2 {
     0% {
-        box-shadow: 30px 0 0 var(--amp-colors-accent-primary);
+        box-shadow: 30px 0 0 var(--amp-colors-primary);
     }
     50% {
-        box-shadow: 0 0 0 var(--amp-colors-accent-primary);
+        box-shadow: 0 0 0 var(--amp-colors-primary);
         margin-top: -20px;
         transform: translate(15px, 15px);
     }
     100% {
-        box-shadow: 30px 0 0 var(--amp-colors-accent-primary);
+        box-shadow: 30px 0 0 var(--amp-colors-primary);
         margin-top: 0;
     }
 }

--- a/src/components/form/FormControl/formControl.module.css
+++ b/src/components/form/FormControl/formControl.module.css
@@ -10,7 +10,7 @@
 
 .formLabelRequired::after {
     content: ' *';
-    color: var(--amp-colors-error-text);
+    color: var(--amp-colors-status-critical-dark);
 }
 
 .formInput {
@@ -18,11 +18,11 @@
 }
 
 .formInputInvalid input {
-    border-color: var(--amp-colors-error-border);
+    border-color: var(--amp-colors-status-critical);
 }
 
 .formError {
-    color: var(--amp-colors-error-text);
+    color: var(--amp-colors-status-critical-dark);
     font-size: 0.875rem;
     margin-top: 0.5rem;
 }

--- a/src/components/form/Input/input.module.css
+++ b/src/components/form/Input/input.module.css
@@ -15,11 +15,11 @@
 }
 
 .inputError {
-    border: 1px solid var(--amp-colors-error-border);
+    border: 1px solid var(--amp-colors-status-critical);
 }
 
 .input:focus:enabled {
-    border: 2px solid var(--amp-colors-accent-primary);
+    border: 2px solid var(--amp-colors-focus-border);
     outline: none;
 }
 
@@ -29,7 +29,7 @@
 }
 
 .error {
-    color: var(--amp-colors-error-border);
+    color: var(--amp-colors-status-critical);
     font-size: 0.875rem;
     font-weight: 400;
     line-height: 1.25rem; /* 142.857% */

--- a/src/components/form/Textarea/textarea.module.css
+++ b/src/components/form/Textarea/textarea.module.css
@@ -11,11 +11,11 @@
 }
 
 .textareaError {
-    border-color: var(--amp-colors-error-border);
+    border-color: var(--amp-colors-status-critical);
 }
 
 .textarea:focus:enabled {
-    border: 2px solid var(--amp-colors-accent-primary);
+    border: 2px solid var(--amp-colors-input-hover);
     outline: none;
 }
 
@@ -25,7 +25,7 @@
 }
 
 .error {
-    color: var(--amp-colors-error-text);
+    color: var(--amp-colors-status-critical-dark);
     font-size: 0.875rem;
     font-weight: 400;
     line-height: 1.25rem; /* 142.857% */

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -7,7 +7,7 @@
     border-color: inherit;
     height: 2.5rem;
     font-size: 1rem;
-    font-weight: 400;
+    font-weight: 500;
     line-height: 1.5rem; /* 150% */
     padding: 0 1rem;
     transition: all .1s ease;
@@ -19,11 +19,11 @@
 }
 
 .buttonError {
-    border: 1px solid var(--amp-colors-error-border);
+    border: 1px solid var(--amp-colors-status-critical);
 }
 
 .button:focus:enabled {
-    border: 2px solid var(--amp-colors-accent-primary);
+    border: 2px solid var(--amp-colors-input-hover);
     outline: none;
 }
 
@@ -32,22 +32,14 @@
     cursor: not-allowed;
 }
 
-/* Additional styling to support screen readers */
-button[aria-expanded="true"] {
-    background-color: var(--amp-colors-input-hover);  /* Can visually indicate button state */
-}
-
 .danger {
-    color: var(--amp-colors-error-text);
-    background-color: var(--amp-colors-error-background);
-    border-color: var(--amp-colors-error-border);
-}
-
-.danger:hover {
-    background-color: var(--amp-colors-error-background-hover);   
+    color: var(--amp-colors-status-critical-dark);
+    background-color: var(--amp-colors-status-critical-muted);
+    border-color: var(--amp-colors-status-critical-muted);
 }
 
 .ghost {
-    background-color: var(--amp-colors-neutral-100);    
-    color: var(--amp-colors-neutral-900);
+    border-color: var(--amp-colors-neutral-200);
+    background-color: var(--amp-colors-neutral-200);    
+    color: var(--amp-colors-black);
 }

--- a/src/components/ui-base/Checkbox/checkbox.module.css
+++ b/src/components/ui-base/Checkbox/checkbox.module.css
@@ -9,7 +9,7 @@
 }
   
 .selectAllContainer {
-    background-color: var(--amp-colors-neutral-100);
+    background-color: var(--amp-colors-neutral-200);
     padding: 8px 10px;
     display: flex;
     align-items: center;

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -20,11 +20,13 @@
 .input {
   padding: 0.5rem;
   width: 100%;
+  font-size: 1rem;
 }
 
 .toggleButton {
   padding: 0.5rem;
   cursor: pointer;
+  background-color: var(--amp-colors-neutral-200);
 }
 
 .menu {
@@ -39,6 +41,7 @@
   z-index: 10;
   border-radius: var(--amp-default-border-radius);
   padding: 0;
+  font-size: .8rem;
 }
 
 .menuItem {

--- a/src/components/ui-base/Tag/index.tsx
+++ b/src/components/ui-base/Tag/index.tsx
@@ -3,15 +3,9 @@ type TagProps = {
   children: React.ReactNode,
 };
 
-const backgroundColor = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-badge').trim() || '#e5e5e5';
-
-const color = getComputedStyle(document.documentElement)
-  .getPropertyValue('--amp-colors-badge-text').trim() || '#404040';
-
 const defaultStyle = {
-  color,
-  backgroundColor,
+  color: 'var(--amp-colors-text-regular)',
+  backgroundColor: 'var(--amp-colors-bg-highlight)',
   borderRadius: '4px',
   display: 'inline-block',
   fontSize: '0.75rem',

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,56 +1,52 @@
 :root {
-    /* color tokens */
+    /* COLOR TOKENS */
     --amp-colors-white: #ffffff;
-    --amp-colors-black: #000000;
+    --amp-colors-black: #111111;
+    --amp-colors-primary: #000000;
 
-    --amp-colors-neutral-50: #fafafa;
-    --amp-colors-neutral-100: #f5f5f5;
-    --amp-colors-neutral-200: #e5e5e5;
-    --amp-colors-neutral-300: #d4d4d4;
-    --amp-colors-neutral-400: #a3a3a3;
-    --amp-colors-neutral-500: #737373;
-    --amp-colors-neutral-600: #525252;
-    --amp-colors-neutral-700: #404040;
-    --amp-colors-neutral-800: #262626;
-    --amp-colors-neutral-900: #171717;
-    --amp-colors-neutral-950: #0a0a0a;
+    --amp-colors-neutral-25: #FEFEFE;
+    --amp-colors-neutral-50: #FDFCFD;
+    --amp-colors-neutral-100: #FAFAFC;
+    --amp-colors-neutral-200: #F6F5F9;
+    --amp-colors-neutral-300: #F1EFF5;
+    --amp-colors-neutral-400: #EDEAF2;
+    --amp-colors-neutral-500: #E8E5EF;
+    --amp-colors-neutral-600: #918E95;
+    --amp-colors-neutral-700: #646266;
+    --amp-colors-neutral-800: #363638;
+    --amp-colors-neutral-900: #1D1D1D;
+    
+    /* SEMANTIC COLORS */
 
-    /* semantic colors  */
-    --amp-colors-border: var(--amp-colors-neutral-200);
+    /* typography colors */
+    --amp-colors-text-standout: var(--amp-colors-black);
+    --amp-colors-text-regular: var(--amp-colors-neutral-900);
+    --amp-colors-text-muted: var(--amp-colors-neutral-700);
 
-    --amp-colors-error-background: #FEF2F2;
-    --amp-colors-error-background-hover: #FED7D7;
-    --amp-colors-error-border: #FECACA;
-    --amp-colors-error-text: #991B1B;
+    /* bg-surfaces */
+    --amp-colors-bg-primary: var(--amp-colors-white);
+    --amp-colors-bg-secondary: var(--amp-colors-neutral-50);
+    --amp-colors-bg-highlight: var(--amp-colors-neutral-200);
 
-    --amp-colors-callout-background: var(--amp-colors-neutral-100);
+    /* border */
+    --amp-colors-border: var(--amp-colors-neutral-300);
+    --amp-default-border-radius: 6px;
 
-    /* accent primary and secondary accent used in loading*/
-    --amp-colors-accent-primary: var(--amp-colors-neutral-700); 
-    --amp-colors-accent-secondary: var(--amp-colors-neutral-500); 
+    /* status */
+    --amp-colors-status-critical-dark: #702525;
+    --amp-colors-status-critical: #E73D3D;
+    --amp-colors-status-critical-muted: #FFD9D9;
      
-    /* background boxes */
-    --amp-colors-background: var(--amp-colors-white);
-    --amp-colors-text-secondary: var(--amp-colors-neutral-700);
+    /* links */
+    --amp-colors-link-text: var(--amp-colors-text-muted);
+    --amp-colors-link-focus: var(--amp-colors-text-standout);
+    --amp-colors-link-active: var(--amp-colors-text-regular);
 
-    --amp-colors-badge: var(--amp-colors-neutral-100);
-    --amp-colors-badge-text: var(--amp-colors-neutral-700);
+    /* button */
+    --amp-colors-button-primary: var(--amp-colors-primary);
+    --amp-colors-button-text: var(--amp-colors-white);
 
-    --amp-colors-link-text: var(--amp-colors-neutral-700);
-    --amp-colors-link-focus: var(--amp-colors-neutral-800);
-    --amp-colors-link-active: var(--amp-colors-neutral-600);
-
-    --amp-colors-button-primary: var(--amp-colors-accent-primary);
-    --amp-colors-button-text: var(--amp-colors-neutral-200);
-
-    --amp-colors-input-hover: var(--amp-colors-neutral-100);
+    /* input */
+    --amp-colors-input-hover: var(--amp-colors-bg-highlight);
     --amp-colors-focus-border: var(--amp-colors-neutral-800);
-
-    --amp-colors-tabs-background: transparent;
-    --amp-colors-tabs-background-active: var(--amp-colors-neutral-100);
-    --amp-colors-tabs-background-hover: var(--amp-colors-neutral-100);
-    --amp-colors-tabs-text: var(--amp-colors-neutral-900);
-        
-    /* misc */
-    --amp-default-border-radius: 4px;
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,4 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');
+
 :root {
+    /* font */
+    --amp-font-family: 'DM Sans', Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+
     /* COLOR TOKENS */
     --amp-colors-white: #ffffff;
     --amp-colors-black: #111111;


### PR DESCRIPTION
### Summary  
This PR syncs up designs closer to mocks and converts global variables to use semantic variables from our [ui pallete](https://www.figma.com/design/sBbeJCAqMVaH8vYZpXwWBC/Simple-UI-For-Ampersand?node-id=1-2&node-type=canvas&t=vNbrLHpYyUFs5Vvr-0). 

- match design system variables to UI Pallette
- remove computed doc styles (temporary bridge from migration)
- update button styles
- update neutral colors to match UI Pallette
- make combobox menu items smaller
- make combobox input same size as label
- exposes font-family as a override css variable
- addresses [ENG-1680, ENG-1682]

#### Screensthots
##### auth
<img width="696" alt="Screenshot 2024-11-20 at 2 10 15 PM" src="https://github.com/user-attachments/assets/21210eed-e3e3-4e1f-8597-ad20506ceafa">

##### disabled button
<img width="191" alt="Screenshot 2024-11-20 at 2 10 56 PM" src="https://github.com/user-attachments/assets/4f3871f8-d8cb-472c-96b0-5809a1e5da7b">

##### combobox
<img width="498" alt="Screenshot 2024-11-20 at 2 10 34 PM" src="https://github.com/user-attachments/assets/2f546a99-cbd8-4055-a840-d0622efc78f9">

##### Install Integration
<img width="934" alt="Screenshot 2024-11-20 at 3 54 45 PM" src="https://github.com/user-attachments/assets/ac3cdaf0-cbeb-4daa-9ba5-70c2d68a41de">


##### Object Field Mapping 
<img width="939" alt="Screenshot 2024-11-20 at 2 10 50 PM" src="https://github.com/user-attachments/assets/18a39016-1581-4394-b28c-8aafb4108f55">

##### Uninstall
<img width="898" alt="Screenshot 2024-11-20 at 2 11 06 PM" src="https://github.com/user-attachments/assets/de6bf8a3-ce49-4e87-b3f7-f6efdeb97322">



