### PR TITLE
style: add dark theme support

### DIFF
--- a/src/assets/TrashIcon.tsx
+++ b/src/assets/TrashIcon.tsx
@@ -2,17 +2,17 @@
 export function TrashIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M2.25 4.5H3.75H15.75" stroke="#991B1B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2.25 4.5H3.75H15.75" stroke="#E73D3D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
       <path
         // eslint-disable-next-line max-len
         d="M14.25 4.5V15C14.25 15.3978 14.092 15.7794 13.8107 16.0607C13.5294 16.342 13.1478 16.5 12.75 16.5H5.25C4.85218 16.5 4.47064 16.342 4.18934 16.0607C3.90804 15.7794 3.75 15.3978 3.75 15V4.5M6 4.5V3C6 2.60218 6.15804 2.22064 6.43934 1.93934C6.72064 1.65804 7.10218 1.5 7.5 1.5H10.5C10.8978 1.5 11.2794 1.65804 11.5607 1.93934C11.842 2.22064 12 2.60218 12 3V4.5"
-        stroke="#991B1B"
+        stroke="#E73D3D"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="M7.5 8.25V12.75" stroke="#991B1B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M10.5 8.25V12.75" stroke="#991B1B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M7.5 8.25V12.75" stroke="#E73D3D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M10.5 8.25V12.75" stroke="#E73D3D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -5,21 +5,48 @@
     --amp-font-family: 'DM Sans', Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 
     /* COLOR TOKENS */
-    --amp-colors-white: #ffffff;
-    --amp-colors-black: #111111;
-    --amp-colors-primary: #000000;
+    color-scheme: light dark;
+    --amp-colors-white: light-dark(#ffffff, #1D1D1D);
+    --amp-colors-black: light-dark(#111111, #FDFCFD);
+    --amp-colors-primary: light-dark(#000000, #FFF);
 
-    --amp-colors-neutral-25: #FEFEFE;
-    --amp-colors-neutral-50: #FDFCFD;
-    --amp-colors-neutral-100: #FAFAFC;
-    --amp-colors-neutral-200: #F6F5F9;
-    --amp-colors-neutral-300: #F1EFF5;
-    --amp-colors-neutral-400: #EDEAF2;
-    --amp-colors-neutral-500: #E8E5EF;
-    --amp-colors-neutral-600: #918E95;
-    --amp-colors-neutral-700: #646266;
-    --amp-colors-neutral-800: #363638;
-    --amp-colors-neutral-900: #1D1D1D;
+    /* Light color pallete */
+    --amp-colors-neutral-25-light: #FEFEFE;
+    --amp-colors-neutral-50-light: #FDFCFD;
+    --amp-colors-neutral-100-light: #FAFAFC;
+    --amp-colors-neutral-200-light: #F6F5F9;
+    --amp-colors-neutral-300-light: #F1EFF5;
+    --amp-colors-neutral-400-light: #EDEAF2;
+    --amp-colors-neutral-500-light: #E8E5EF;
+    --amp-colors-neutral-600-light: #918E95;
+    --amp-colors-neutral-700-light: #646266;
+    --amp-colors-neutral-800-light: #363638;
+    --amp-colors-neutral-900-light: #1D1D1D;
+
+    /* Dark color pallete */
+    --amp-colors-neutral-25-dark: #1D1D1D; /* Background variations */
+    --amp-colors-neutral-50-dark: #292929;
+    --amp-colors-neutral-100-dark: #363636;
+    --amp-colors-neutral-200-dark: #484848;
+    --amp-colors-neutral-300-dark: #606060;
+    --amp-colors-neutral-400-dark: #757575;
+    --amp-colors-neutral-500-dark: #8D8D8D;
+    --amp-colors-neutral-600-dark: #A8A8A8;
+    --amp-colors-neutral-700-dark: #C4C4C4;
+    --amp-colors-neutral-800-dark: #DFDFDF;
+    --amp-colors-neutral-900-dark: #F3F3F3;
+
+    --amp-colors-neutral-25: light-dark(var(--amp-colors-neutral-25-light), var(--amp-colors-neutral-25-dark));
+    --amp-colors-neutral-50: light-dark(var(--amp-colors-neutral-50-light), var(--amp-colors-neutral-50-dark));
+    --amp-colors-neutral-100: light-dark(var(--amp-colors-neutral-100-light), var(--amp-colors-neutral-100-dark));
+    --amp-colors-neutral-200: light-dark(var(--amp-colors-neutral-200-light), var(--amp-colors-neutral-200-dark));
+    --amp-colors-neutral-300: light-dark(var(--amp-colors-neutral-300-light), var(--amp-colors-neutral-300-dark));
+    --amp-colors-neutral-400: light-dark(var(--amp-colors-neutral-400-light), var(--amp-colors-neutral-400-dark));
+    --amp-colors-neutral-500: light-dark(var(--amp-colors-neutral-500-light), var(--amp-colors-neutral-500-dark));
+    --amp-colors-neutral-600: light-dark(var(--amp-colors-neutral-600-light), var(--amp-colors-neutral-600-dark));
+    --amp-colors-neutral-700: light-dark(var(--amp-colors-neutral-700-light), var(--amp-colors-neutral-700-dark));
+    --amp-colors-neutral-800: light-dark(var(--amp-colors-neutral-800-light), var(--amp-colors-neutral-800-dark));
+    --amp-colors-neutral-900: light-dark(var(--amp-colors-neutral-900-light), var(--amp-colors-neutral-900-dark));
     
     /* SEMANTIC COLORS */
 
@@ -38,9 +65,9 @@
     --amp-default-border-radius: 6px;
 
     /* status */
-    --amp-colors-status-critical-dark: #702525;
-    --amp-colors-status-critical: #E73D3D;
-    --amp-colors-status-critical-muted: #FFD9D9;
+    --amp-colors-status-critical-dark: light-dark(#702525, #FFD9D9);
+    --amp-colors-status-critical:#E73D3D;
+    --amp-colors-status-critical-muted: light-dark(#FFD9D9, #702525);
      
     /* links */
     --amp-colors-link-text: var(--amp-colors-text-muted);


### PR DESCRIPTION
### Summary 
Our library was not built to support dark mode when system's change. To support we add a dark palette placeholder.
- change trash icon color to match the critical color so no super dark or light in either theme
- adds a dark color palatte
- remove some hard coded white values. 

note: we can turn off mode in the builder's custom css override file by using 
```.css
// App.css
:root {
 color-scheme: light; 
}
```

#### Problem
<img width="1133" alt="Screenshot 2024-11-26 at 4 55 21 PM" src="https://github.com/user-attachments/assets/edb9f56a-d995-4b93-bc32-9c79def38602">

#### Demo 
<img width="597" alt="Screenshot 2024-11-26 at 4 48 24 PM" src="https://github.com/user-attachments/assets/d5c48abb-f310-4c7f-a44d-1801e52c1984">
<img width="596" alt="Screenshot 2024-11-26 at 4 48 16 PM" src="https://github.com/user-attachments/assets/8dc2071a-2868-42c7-ad25-988e24466d73">
<img width="795" alt="Screenshot 2024-11-26 at 4 48 08 PM" src="https://github.com/user-attachments/assets/b84ac903-daf5-4948-8269-4d12171cce34">
<img width="802" alt="Screenshot 2024-11-26 at 4 47 58 PM" src="https://github.com/user-attachments/assets/fc0c0358-0fdd-415c-85d0-a1fb7d3b286c">
