### PR TITLE
style: add dark mode to footer

### DIFF
--- a/src/layout/AuthCardLayout/AmpersandFooter.tsx
+++ b/src/layout/AuthCardLayout/AmpersandFooter.tsx
@@ -6,7 +6,7 @@ export function AmpersandFooter() {
   return (
     <footer
       style={{
-        backgroundColor: '#EFEFEF',
+        backgroundColor: 'light-dark(#EFEFEF, #646266)',
         padding: '1em',
         fontSize: '0.8em',
         color: 'gray',
@@ -17,7 +17,7 @@ export function AmpersandFooter() {
         gap: '0.4em',
       }}
     >
-      <p>Secured by</p>
+      <p style={{ color: 'light-dark(gray, #EFEFEF)' }}>Secured by</p>
       <a
         href="https://www.withampersand.com/"
         target="_blank"


### PR DESCRIPTION
### Summary
add dark mode to footer.

#### demo
<img width="784" alt="Screenshot 2024-12-04 at 3 09 08 PM" src="https://github.com/user-attachments/assets/6a1bf101-8ce3-430d-babb-2a5e6561c163">

<img width="824" alt="Screenshot 2024-12-04 at 12 26 21 PM" src="https://github.com/user-attachments/assets/db59895a-bdc4-49a1-9bab-9139e7eeabde">
