### PR TITLE
refactor: move project loading to Install Integration

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -4,8 +4,11 @@ import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 import { InstallIntegrationProvider } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { Config, IntegrationFieldMapping } from 'services/api';
+import { useIntegrationList } from 'src/context/IntegrationListContextProvider';
 import { useForceUpdate } from 'src/hooks/useForceUpdate';
 import resetStyles from 'src/styles/resetCss.module.css';
+
+import { LoadingCentered } from '../Loading';
 
 import { InstallationContent } from './content/InstallationContent';
 import { ConditionalProxyLayout } from './layout/ConditionalProxyLayout/ConditionalProxyLayout';
@@ -53,9 +56,14 @@ export function InstallIntegration(
     onUninstallSuccess, fieldMapping,
   }: InstallIntegrationProps,
 ) {
-  const { projectId } = useProject();
+  const { projectId, isLoading: isProjectLoading } = useProject();
+  const { isLoading: isIntegrationListLoading } = useIntegrationList();
   const { errorState } = useErrorState();
   const { seed, reset } = useForceUpdate();
+
+  if (isProjectLoading || isIntegrationListLoading) {
+    return <LoadingCentered />;
+  }
 
   if (errorState[ErrorBoundary.INTEGRATION_LIST]?.apiError) {
     return <ErrorTextBox message="Something went wrong, couldn't find integration information" />;

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -55,7 +55,7 @@ export function ConnectionsProvider({
   children,
 }: ConnectionsProviderProps) {
   const apiKey = useApiKey();
-  const { projectId } = useProject();
+  const { projectId, isLoading: isProjectLoading } = useProject();
 
   const [connections, setConnections] = useState<Connection[] | null>(null);
   const [selectedConnection, setSelectedConnection] = useState<Connection | null>(null);
@@ -121,11 +121,17 @@ export function ConnectionsProvider({
     ],
   );
 
-  return isError(ErrorBoundary.CONNECTION_LIST, projectId) ? (
-    <ErrorTextBox message="Error retrieving existing connections" />
-  ) : (
-    <ConnectionsContext.Provider value={contextValue}>
-      {isLoading ? <LoadingCentered /> : children}
-    </ConnectionsContext.Provider>
+  if (isLoading || isProjectLoading) {
+    return <LoadingCentered />;
+  }
+
+  return (
+    isError(ErrorBoundary.CONNECTION_LIST, projectId)
+      ? <ErrorTextBox message="Error retrieving existing connections" />
+      : (
+        <ConnectionsContext.Provider value={contextValue}>
+          { children }
+        </ConnectionsContext.Provider>
+      )
   );
 }

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -5,7 +5,6 @@ import {
 
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Integration } from 'services/api';
-import { LoadingCentered } from 'src/components/Loading';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { useApiKey } from './ApiKeyContextProvider';
@@ -13,10 +12,12 @@ import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 
 interface IntegrationListContextValue {
   integrations: Integration[] | null;
+  isLoading: boolean;
 }
 
 export const IntegrationListContext = createContext<IntegrationListContextValue>({
   integrations: null,
+  isLoading: false,
 });
 
 export const useIntegrationList = (): IntegrationListContextValue => {
@@ -59,15 +60,15 @@ export function IntegrationListProvider(
   }, [projectIdOrName, apiKey, setError]);
 
   const contextValue = useMemo(() => ({
-    integrations,
-  }), [integrations]);
+    integrations, isLoading,
+  }), [integrations, isLoading]);
 
   return (
     isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
       ? <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />
       : (
         <IntegrationListContext.Provider value={contextValue}>
-          {isLoading ? <LoadingCentered /> : children}
+          { children}
         </IntegrationListContext.Provider>
       )
   );

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -17,7 +17,7 @@ interface IntegrationListContextValue {
 
 export const IntegrationListContext = createContext<IntegrationListContextValue>({
   integrations: null,
-  isLoading: false,
+  isLoading: true,
 });
 
 export const useIntegrationList = (): IntegrationListContextValue => {

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -4,7 +4,6 @@ import {
 
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Project } from 'services/api';
-import { LoadingCentered } from 'src/components/Loading';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { useApiKey } from './ApiKeyContextProvider';
@@ -17,6 +16,7 @@ interface ProjectContextValue {
   appName: string;
   projectId: string;
   projectIdOrName: string;
+  isLoading: boolean;
 }
 
 export const ProjectContext = createContext<ProjectContextValue>({
@@ -24,6 +24,7 @@ export const ProjectContext = createContext<ProjectContextValue>({
   appName: '',
   projectId: '',
   projectIdOrName: '',
+  isLoading: false,
 });
 
 export const useProject = (): ProjectContextValue => {
@@ -66,15 +67,19 @@ export function ProjectProvider(
   }, [projectIdOrName, apiKey, setLoadingState, setError]);
 
   const contextValue = useMemo(() => ({
-    projectId: project?.id || '', projectIdOrName, project, appName: project?.appName || '',
-  }), [projectIdOrName, project]);
+    projectId: project?.id || '',
+    projectIdOrName,
+    project,
+    appName: project?.appName || '',
+    isLoading,
+  }), [projectIdOrName, project, isLoading]);
 
   return (
     isError(ErrorBoundary.PROJECT, projectIdOrName)
       ? <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
       : (
         <ProjectContext.Provider value={contextValue}>
-          {isLoading ? <LoadingCentered /> : children}
+          {children}
         </ProjectContext.Provider>
       )
   );

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -24,7 +24,7 @@ export const ProjectContext = createContext<ProjectContextValue>({
   appName: '',
   projectId: '',
   projectIdOrName: '',
-  isLoading: false,
+  isLoading: true,
 });
 
 export const useProject = (): ProjectContextValue => {


### PR DESCRIPTION
### Summary
Part 1 of moving loading away from Ampersand Provider
- moved loading down from AmpersandProvider
- move project and integrationList loading to InstallIntegration
- move project loading to ConnectProvider


