### PR TITLE
fix: move ampersand provider errors to component level

### DIFF
--- a/src/components/Configure/ComponentContainer.tsx
+++ b/src/components/Configure/ComponentContainer.tsx
@@ -1,0 +1,12 @@
+import { Box } from '../ui-base/Box/Box';
+import { Container } from '../ui-base/Container/Container';
+
+export function ComponentContainer({ children }: { children: React.ReactNode; }) {
+  return (
+    <Container style={{ maxWidth: '55rem' }}>
+      <Box>
+        {children}
+      </Box>
+    </Container>
+  );
+}

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -66,13 +66,21 @@ export function InstallIntegration(
     onUninstallSuccess, fieldMapping,
   }: InstallIntegrationProps,
 ) {
-  const { projectId, isLoading: isProjectLoading } = useProject();
+  const { projectId, projectIdOrName, isLoading: isProjectLoading } = useProject();
   const { isLoading: isIntegrationListLoading } = useIntegrationList();
-  const { errorState } = useErrorState();
+  const { isError, errorState } = useErrorState();
   const { seed, reset } = useForceUpdate();
 
   if (isProjectLoading || isIntegrationListLoading) {
     return <LoadingCentered />;
+  }
+
+  if (isError(ErrorBoundary.PROJECT, projectIdOrName)) {
+    return <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />;
+  }
+
+  if (isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)) {
+    return <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />;
   }
 
   if (errorState[ErrorBoundary.INTEGRATION_LIST]?.apiError) {

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -17,6 +17,7 @@ import { ProtectedConnectionLayout } from './layout/ProtectedConnectionLayout';
 import { ObjectManagementNav } from './nav/ObjectManagementNav';
 import { ConfigurationProvider } from './state/ConfigurationStateProvider';
 import { HydratedRevisionProvider } from './state/HydratedRevisionContext';
+import { ComponentContainer } from './ComponentContainer';
 
 // creates a random seed to force update the component
 // pass the seed as a key to the component
@@ -72,19 +73,36 @@ export function InstallIntegration(
   const { seed, reset } = useForceUpdate();
 
   if (isProjectLoading || isIntegrationListLoading) {
-    return <LoadingCentered />;
+    return (
+      // todo refactor this into a component
+      <ComponentContainer>
+        <LoadingCentered />
+      </ComponentContainer>
+    );
   }
 
   if (isError(ErrorBoundary.PROJECT, projectIdOrName)) {
-    return <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />;
+    return (
+      <ComponentContainer>
+        <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
+      </ComponentContainer>
+    );
   }
 
   if (isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)) {
-    return <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />;
+    return (
+      <ComponentContainer>
+        <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />;
+      </ComponentContainer>
+    );
   }
 
   if (errorState[ErrorBoundary.INTEGRATION_LIST]?.apiError) {
-    return <ErrorTextBox message="Something went wrong, couldn't find integration information" />;
+    return (
+      <ComponentContainer>
+        <ErrorTextBox message="Something went wrong, couldn't find integration information" />;
+      </ComponentContainer>
+    );
   }
 
   return (

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -6,7 +6,10 @@ import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 import { InstallIntegrationProvider } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { Config, IntegrationFieldMapping } from 'services/api';
+import { useIntegrationList } from 'src/context/IntegrationListContextProvider';
 import resetStyles from 'src/styles/resetCss.module.css';
+
+import { LoadingCentered } from '../Loading';
 
 import { InstallationContent } from './content/InstallationContent';
 import { ConditionalProxyLayout } from './layout/ConditionalProxyLayout/ConditionalProxyLayout';
@@ -63,9 +66,14 @@ export function InstallIntegration(
     onUninstallSuccess, fieldMapping,
   }: InstallIntegrationProps,
 ) {
-  const { projectId } = useProject();
+  const { projectId, isLoading: isProjectLoading } = useProject();
+  const { isLoading: isIntegrationListLoading } = useIntegrationList();
   const { errorState } = useErrorState();
   const { seed, reset } = useForceUpdate();
+
+  if (isProjectLoading || isIntegrationListLoading) {
+    return <LoadingCentered />;
+  }
 
   if (errorState[ErrorBoundary.INTEGRATION_LIST]?.apiError) {
     return <ErrorTextBox message="Something went wrong, couldn't find integration information" />;

--- a/src/components/Connect/ConnectedSuccessBox.tsx
+++ b/src/components/Connect/ConnectedSuccessBox.tsx
@@ -9,7 +9,6 @@ interface ConnectedSuccessBoxProps {
 export function ConnectedSuccessBox({ provider }: ConnectedSuccessBoxProps) {
   const { appName } = useProject();
   const text = `You have successfully connected your ${getProviderName(provider)} account to ${appName}.`;
-  return (
-    <SuccessTextBox text={text} />
-  );
+
+  return <SuccessTextBox text={text} />;
 }

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -91,6 +91,7 @@ export function ConnectionsProvider({
   }), [connections, selectedConnection, setConnections, setSelectedConnection]);
 
   if (isLoading || isProjectLoading) {
+    // todo refactor this into a component
     return <LoadingCentered />;
   }
 

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -49,7 +49,7 @@ export function ConnectionsProvider({
   provider, groupRef, children,
 }: ConnectionsProviderProps) {
   const apiKey = useApiKey();
-  const { projectId } = useProject();
+  const { projectId, isLoading: isProjectLoading } = useProject();
 
   const [connections, setConnections] = useState<Connection[] | null>(null);
   const [selectedConnection, setSelectedConnection] = useState<Connection | null>(null);
@@ -90,12 +90,16 @@ export function ConnectionsProvider({
     setSelectedConnection,
   }), [connections, selectedConnection, setConnections, setSelectedConnection]);
 
+  if (isLoading || isProjectLoading) {
+    return <LoadingCentered />;
+  }
+
   return (
     isError(ErrorBoundary.CONNECTION_LIST, projectId)
       ? <ErrorTextBox message="Error retrieving existing connections" />
       : (
         <ConnectionsContext.Provider value={contextValue}>
-          {isLoading ? <LoadingCentered /> : children}
+          { children }
         </ConnectionsContext.Provider>
       )
   );

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -94,13 +94,17 @@ export function ConnectionsProvider({
     return <LoadingCentered />;
   }
 
+  if (isError(ErrorBoundary.PROJECT, projectId)) {
+    return <ErrorTextBox message={`Error loading project ${projectId}`} />;
+  }
+
+  if (isError(ErrorBoundary.CONNECTION_LIST, projectId)) {
+    return <ErrorTextBox message="Error retrieving existing connections" />;
+  }
+
   return (
-    isError(ErrorBoundary.CONNECTION_LIST, projectId)
-      ? <ErrorTextBox message="Error retrieving existing connections" />
-      : (
-        <ConnectionsContext.Provider value={contextValue}>
-          { children }
-        </ConnectionsContext.Provider>
-      )
+    <ConnectionsContext.Provider value={contextValue}>
+      { children }
+    </ConnectionsContext.Provider>
   );
 }

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -7,6 +7,7 @@ import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import {
   api, Config, Installation, Integration,
 } from 'services/api';
+import { ComponentContainer } from 'src/components/Configure/ComponentContainer';
 import { FieldMapping } from 'src/components/Configure/InstallIntegration';
 import { LoadingCentered } from 'src/components/Loading';
 import { findIntegrationFromList } from 'src/utils';
@@ -168,19 +169,36 @@ export function InstallIntegrationProvider({
     onInstallSuccess, onUpdateSuccess, onUninstallSuccess,
     isIntegrationDeleted, setIntegrationDeleted, fieldMapping]);
 
-  if (integrationObj !== null) {
-    const errorMessage = 'Error retrieving installation information for integration '
-     + `"${integrationObj?.name || 'unknown'}"`;
-
+  if (isLoading) {
     return (
-      isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey))
-      ? <ErrorTextBox message={errorMessage} /> : (
-        <InstallIntegrationContext.Provider value={props}>
-          {isLoading ? <LoadingCentered /> : children}
-        </InstallIntegrationContext.Provider>
-      );
+      <ComponentContainer>
+        <LoadingCentered />
+      </ComponentContainer>
+    );
   }
 
-  // if integration not found, return error message
-  return <ErrorTextBox message={`Integration "${integration}" not found`} />;
+  if (integrationObj === null) {
+    // if integration not found, return error message
+    return (
+      <ComponentContainer>
+        <ErrorTextBox message={`Integration "${integration}" not found`} />
+      </ComponentContainer>
+    );
+  }
+
+  if (isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey)) {
+    const errorMessage = 'Error retrieving installation information for integration '
+    + `"${integrationObj?.name || 'unknown'}"`;
+    return (
+      <ComponentContainer>
+        <ErrorTextBox message={errorMessage} />
+      </ComponentContainer>
+    );
+  }
+
+  return (
+    <InstallIntegrationContext.Provider value={props}>
+      { children }
+    </InstallIntegrationContext.Provider>
+  );
 }

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -5,7 +5,6 @@ import {
 
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Integration } from 'services/api';
-import { LoadingCentered } from 'src/components/Loading';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { useApiKey } from './ApiKeyContextProvider';
@@ -13,10 +12,12 @@ import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
 
 interface IntegrationListContextValue {
   integrations: Integration[] | null;
+  isLoading: boolean;
 }
 
 export const IntegrationListContext = createContext<IntegrationListContextValue>({
   integrations: null,
+  isLoading: false,
 });
 
 export const useIntegrationList = (): IntegrationListContextValue => {
@@ -59,15 +60,15 @@ export function IntegrationListProvider(
   }, [projectIdOrName, apiKey, setError]);
 
   const contextValue = useMemo(() => ({
-    integrations,
-  }), [integrations]);
+    integrations, isLoading,
+  }), [integrations, isLoading]);
 
   return (
     isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
       ? <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />
       : (
         <IntegrationListContext.Provider value={contextValue}>
-          {isLoading ? <LoadingCentered /> : children}
+          { children}
         </IntegrationListContext.Provider>
       )
   );

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -3,7 +3,6 @@ import {
   useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Integration } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -39,7 +38,7 @@ export function IntegrationListProvider(
   { projectIdOrName, children }: IntegrationListContextProviderProps,
 ) {
   const apiKey = useApiKey();
-  const { setError, isError } = useErrorState();
+  const { setError } = useErrorState();
   const [integrations, setIntegrations] = useState<Integration[] | null>(null);
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
@@ -64,12 +63,8 @@ export function IntegrationListProvider(
   }), [integrations, isLoading]);
 
   return (
-    isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
-      ? <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />
-      : (
-        <IntegrationListContext.Provider value={contextValue}>
-          { children}
-        </IntegrationListContext.Provider>
-      )
+    <IntegrationListContext.Provider value={contextValue}>
+      { children}
+    </IntegrationListContext.Provider>
   );
 }

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -2,7 +2,6 @@ import {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Project } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -46,7 +45,7 @@ export function ProjectProvider(
   { projectIdOrName, children }: ProjectProviderProps,
 ) {
   const apiKey = useApiKey();
-  const { isError, setError } = useErrorState();
+  const { setError } = useErrorState();
   const [project, setProject] = useState<Project | null>(null);
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
@@ -74,13 +73,5 @@ export function ProjectProvider(
     isLoading,
   }), [projectIdOrName, project, isLoading]);
 
-  return (
-    isError(ErrorBoundary.PROJECT, projectIdOrName)
-      ? <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
-      : (
-        <ProjectContext.Provider value={contextValue}>
-          {children}
-        </ProjectContext.Provider>
-      )
-  );
+  return <ProjectContext.Provider value={contextValue}>{children}</ProjectContext.Provider>;
 }

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -4,7 +4,6 @@ import {
 
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Project } from 'services/api';
-import { LoadingCentered } from 'src/components/Loading';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { useApiKey } from './ApiKeyContextProvider';
@@ -17,6 +16,7 @@ interface ProjectContextValue {
   appName: string;
   projectId: string;
   projectIdOrName: string;
+  isLoading: boolean;
 }
 
 export const ProjectContext = createContext<ProjectContextValue>({
@@ -24,6 +24,7 @@ export const ProjectContext = createContext<ProjectContextValue>({
   appName: '',
   projectId: '',
   projectIdOrName: '',
+  isLoading: false,
 });
 
 export const useProject = (): ProjectContextValue => {
@@ -66,15 +67,19 @@ export function ProjectProvider(
   }, [projectIdOrName, apiKey, setLoadingState, setError]);
 
   const contextValue = useMemo(() => ({
-    projectId: project?.id || '', projectIdOrName, project, appName: project?.appName || '',
-  }), [projectIdOrName, project]);
+    projectId: project?.id || '',
+    projectIdOrName,
+    project,
+    appName: project?.appName || '',
+    isLoading,
+  }), [projectIdOrName, project, isLoading]);
 
   return (
     isError(ErrorBoundary.PROJECT, projectIdOrName)
       ? <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
       : (
         <ProjectContext.Provider value={contextValue}>
-          {isLoading ? <LoadingCentered /> : children}
+          {children}
         </ProjectContext.Provider>
       )
   );


### PR DESCRIPTION
### Summary
This continues work on Ampersand Provider and removes error handling from the Provider Level and moves to component levels 
- moves error handling to InstallIntegration and ConnectProvider