### PR TITLE
feat: Rename other tab to write

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -6,7 +6,7 @@ import { Box } from 'components/ui-base/Box/Box';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { Button } from 'src/components/ui-base/Button';
 
-import { OTHER_CONST, UNINSTALL_INSTALLATION_CONST } from '../nav/ObjectManagementNav/constant';
+import { UNINSTALL_INSTALLATION_CONST, WRITE_CONST } from '../nav/ObjectManagementNav/constant';
 import { useHydratedRevision } from '../state/HydratedRevisionContext';
 import { getReadObject } from '../utils';
 
@@ -45,7 +45,7 @@ export function ConfigureInstallationBase(
   const isModified = isReadModified || isWriteModified;
 
   // if the read object is not completed, it is a new state
-  const isSelectedReadObjectComplete = (selectedObjectName !== OTHER_CONST && !isSelectedReadConfigComplete);
+  const isSelectedReadObjectComplete = (selectedObjectName !== WRITE_CONST && !isSelectedReadConfigComplete);
   // is this a new state (modified or creating a new state)
   const isStateNew = isModified || isCreateMode || isSelectedReadObjectComplete;
 
@@ -54,7 +54,7 @@ export function ConfigureInstallationBase(
    || !isStateNew;
 
   // is other selected?
-  const isNonConfigurableWrite = selectedObjectName === OTHER_CONST;
+  const isNonConfigurableWrite = selectedObjectName === WRITE_CONST;
 
   // is the form in the uninstall case?
   const isUninstall = selectedObjectName === UNINSTALL_INSTALLATION_CONST;

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -53,7 +53,7 @@ export function ConfigureInstallationBase(
   const isDisabled = loading || isLoading || !configureState || !selectedObjectName
    || !isStateNew;
 
-  // is other selected?
+  // is write selected?
   const isNonConfigurableWrite = selectedObjectName === WRITE_CONST;
 
   // is the form in the uninstall case?

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -34,8 +34,7 @@ export function CreateInstallation() {
   } = useMutateInstallation();
   const [isLoading, setLoadingState] = useState<boolean>(false);
 
-  // is other selected?
-  const isOtherSelected = selectedObjectName === WRITE_CONST;
+  const isWriteSelected = selectedObjectName === WRITE_CONST;
 
   const errorMsg = getMutateInstallationError(selectedObjectName);
 
@@ -134,7 +133,7 @@ export function CreateInstallation() {
 
   const onSave = (e: FormEvent) => {
     e.preventDefault();
-    if (!isOtherSelected) {
+    if (!isWriteSelected) {
       onSaveRead();
     } else {
       onSaveWrite();

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -11,7 +11,7 @@ import {
 
 import { onSaveReadCreateInstallation } from '../actions/read/onSaveReadCreateInstallation';
 import { onSaveWriteCreateInstallation } from '../actions/write/onSaveWriteCreateInstallation';
-import { OTHER_CONST } from '../nav/ObjectManagementNav/constant';
+import { WRITE_CONST } from '../nav/ObjectManagementNav/constant';
 import { setHydrateConfigState } from '../state/utils';
 import { validateFieldMappings } from '../utils';
 
@@ -35,7 +35,7 @@ export function CreateInstallation() {
   const [isLoading, setLoadingState] = useState<boolean>(false);
 
   // is other selected?
-  const isOtherSelected = selectedObjectName === OTHER_CONST;
+  const isOtherSelected = selectedObjectName === WRITE_CONST;
 
   const errorMsg = getMutateInstallationError(selectedObjectName);
 

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -7,7 +7,7 @@ import { Installation, Integration } from 'services/api';
 
 import { onSaveReadUpdateInstallation } from '../actions/read/onSaveReadUpdateInstallation';
 import { onSaveWriteUpdateInstallation } from '../actions/write/onSaveWriteUpdateInstallation';
-import { OTHER_CONST } from '../nav/ObjectManagementNav/constant';
+import { WRITE_CONST } from '../nav/ObjectManagementNav/constant';
 import { setHydrateConfigState } from '../state/utils';
 import { validateFieldMappings } from '../utils';
 
@@ -33,7 +33,7 @@ export function UpdateInstallation(
 
   const [isLoading, setLoadingState] = useState<boolean>(false);
   // is other selected?
-  const isOtherSelected = selectedObjectName === OTHER_CONST;
+  const isOtherSelected = selectedObjectName === WRITE_CONST;
 
   const errorMsg = getMutateInstallationError(selectedObjectName);
 

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -32,8 +32,7 @@ export function UpdateInstallation(
   } = useMutateInstallation();
 
   const [isLoading, setLoadingState] = useState<boolean>(false);
-  // is other selected?
-  const isOtherSelected = selectedObjectName === WRITE_CONST;
+  const isWriteSelected = selectedObjectName === WRITE_CONST;
 
   const errorMsg = getMutateInstallationError(selectedObjectName);
 
@@ -138,7 +137,7 @@ export function UpdateInstallation(
   const onSave = (e: FormEvent) => {
     e.preventDefault();
 
-    if (!isOtherSelected) {
+    if (!isWriteSelected) {
       onSaveRead();
     } else {
       onSaveWrite();

--- a/src/components/Configure/nav/ObjectManagementNav/constant.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/constant.tsx
@@ -1,2 +1,4 @@
-export const OTHER_CONST = 'other';
+// WRITE_CONST is used for the "Write" tab, its value is "other" for legacy reasons.
+export const WRITE_CONST = 'other';
+// UNINSTALL_INSTALLATION_CONST is used for the tab for uninstalling an installation.
 export const UNINSTALL_INSTALLATION_CONST = 'uninstall-installation';

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -6,7 +6,7 @@ import { TrashIcon } from 'assets/TrashIcon';
 import { NavObject, ObjectConfigurationsState } from 'src/components/Configure/types';
 import { Divider } from 'src/components/ui-base/Divider';
 
-import { OTHER_CONST, UNINSTALL_INSTALLATION_CONST } from '../../constant';
+import { UNINSTALL_INSTALLATION_CONST, WRITE_CONST } from '../../constant';
 
 import styles from './tabs.module.css';
 
@@ -36,21 +36,21 @@ function NavObjectTab({
   );
 }
 
-type OtherTabProps = {
+type WriteTabProps = {
   completed: boolean;
   pending: boolean;
   displayName: string;
 };
 
-function OtherTab({
+function WriteTab({
   completed, pending, displayName,
-}: OtherTabProps) {
+}: WriteTabProps) {
   return (
     <>
       <Divider style={{ margin: '1rem 0' }} />
       <NavObjectTab
         key="other-write"
-        objectName={OTHER_CONST}
+        objectName={WRITE_CONST}
         completed={completed}
         pending={pending}
         displayName={displayName}
@@ -81,7 +81,7 @@ function UninstallTab() {
 
 type VerticalTabsProps = {
   readNavObjects: NavObject[];
-  otherNavObject?: NavObject; // write tab
+  writeNavObject?: NavObject;
   value: string;
   onValueChange: (value: string) => void;
   objectConfigurationsState?: ObjectConfigurationsState;
@@ -90,7 +90,7 @@ type VerticalTabsProps = {
 
 export function VerticalTabs({
   value, readNavObjects, onValueChange, objectConfigurationsState,
-  otherNavObject, showUninstallButton,
+  writeNavObject: otherNavObject, showUninstallButton,
 }: VerticalTabsProps) {
   return (
     <Tabs.Root value={value} className={styles.tabsRoot} onValueChange={onValueChange}>
@@ -108,7 +108,7 @@ export function VerticalTabs({
         ))}
         {/* Other / Write Tab */}
         {otherNavObject && (
-          <OtherTab
+          <WriteTab
             completed={otherNavObject.completed}
             pending={objectConfigurationsState?.other?.write?.isWriteModified || false}
             displayName="Write"

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -90,7 +90,7 @@ type VerticalTabsProps = {
 
 export function VerticalTabs({
   value, readNavObjects, onValueChange, objectConfigurationsState,
-  writeNavObject: otherNavObject, showUninstallButton,
+  writeNavObject, showUninstallButton,
 }: VerticalTabsProps) {
   return (
     <Tabs.Root value={value} className={styles.tabsRoot} onValueChange={onValueChange}>
@@ -107,9 +107,9 @@ export function VerticalTabs({
           />
         ))}
         {/* Other / Write Tab */}
-        {otherNavObject && (
+        {writeNavObject && (
           <WriteTab
-            completed={otherNavObject.completed}
+            completed={writeNavObject.completed}
             pending={objectConfigurationsState?.other?.write?.isWriteModified || false}
             displayName="Write"
           />

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -111,8 +111,7 @@ export function VerticalTabs({
           <OtherTab
             completed={otherNavObject.completed}
             pending={objectConfigurationsState?.other?.write?.isWriteModified || false}
-             // if read tab exists, display 'other' else 'write' when write tab is the only tab
-            displayName={readNavObjects.length ? 'Other' : 'Write'}
+            displayName="Write"
           />
         )}
 

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -101,7 +101,7 @@ export function ObjectManagementNavV2({
                 readNavObjects={readNavObjects}
                 onValueChange={(value: string) => setTabvalue(value)}
                 objectConfigurationsState={objectConfigurationsState}
-                otherNavObject={otherNavObject}
+                writeNavObject={otherNavObject}
                 showUninstallButton={!!installation}
               />
               )}

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -13,7 +13,7 @@ import { getProviderName } from 'src/utils';
 
 import { useObjectsConfigureState } from '../../../state/ConfigurationStateProvider';
 import { useHydratedRevision } from '../../../state/HydratedRevisionContext';
-import { generateOtherNavObject, generateReadNavObjects } from '../../../utils';
+import { generatewriteNavObject, generateReadNavObjects } from '../../../utils';
 import { UNINSTALL_INSTALLATION_CONST } from '../constant';
 import { NextTabIndexContext, SelectedObjectNameContext } from '../ObjectManagementNavContext';
 
@@ -49,13 +49,13 @@ export function ObjectManagementNavV2({
   const isNavObjectsReady = readNavObjects !== null; // null = hydratedRevision/config is not ready
 
   const isWriteSupported = !!hydratedRevision?.content?.write;
-  const otherNavObject = isWriteSupported ? generateOtherNavObject(config) : undefined;
+  const writeNavObject = isWriteSupported ? generatewriteNavObject(config) : undefined;
 
   const allNavObjects = useMemo(() => {
     const navObjects = [...(readNavObjects || [])];
-    if (otherNavObject && isWriteSupported) { navObjects.push(otherNavObject); }
+    if (writeNavObject && isWriteSupported) { navObjects.push(writeNavObject); }
     return navObjects;
-  }, [readNavObjects, otherNavObject, isWriteSupported]);
+  }, [readNavObjects, writeNavObject, isWriteSupported]);
 
   const selectedObject = getSelectedObject(allNavObjects, tabValue);
 
@@ -101,7 +101,7 @@ export function ObjectManagementNavV2({
                 readNavObjects={readNavObjects}
                 onValueChange={(value: string) => setTabvalue(value)}
                 objectConfigurationsState={objectConfigurationsState}
-                writeNavObject={otherNavObject}
+                writeNavObject={writeNavObject}
                 showUninstallButton={!!installation}
               />
               )}

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -13,7 +13,7 @@ import { getProviderName } from 'src/utils';
 
 import { useObjectsConfigureState } from '../../../state/ConfigurationStateProvider';
 import { useHydratedRevision } from '../../../state/HydratedRevisionContext';
-import { generateReadNavObjects, generatewriteNavObject } from '../../../utils';
+import { generateReadNavObjects, generateWriteNavObject } from '../../../utils';
 import { UNINSTALL_INSTALLATION_CONST } from '../constant';
 import { NextTabIndexContext, SelectedObjectNameContext } from '../ObjectManagementNavContext';
 
@@ -49,7 +49,7 @@ export function ObjectManagementNavV2({
   const isNavObjectsReady = readNavObjects !== null; // null = hydratedRevision/config is not ready
 
   const isWriteSupported = !!hydratedRevision?.content?.write;
-  const writeNavObject = isWriteSupported ? generatewriteNavObject(config) : undefined;
+  const writeNavObject = isWriteSupported ? generateWriteNavObject(config) : undefined;
 
   const allNavObjects = useMemo(() => {
     const navObjects = [...(readNavObjects || [])];

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -13,7 +13,7 @@ import { getProviderName } from 'src/utils';
 
 import { useObjectsConfigureState } from '../../../state/ConfigurationStateProvider';
 import { useHydratedRevision } from '../../../state/HydratedRevisionContext';
-import { generatewriteNavObject, generateReadNavObjects } from '../../../utils';
+import { generateReadNavObjects, generatewriteNavObject } from '../../../utils';
 import { UNINSTALL_INSTALLATION_CONST } from '../constant';
 import { NextTabIndexContext, SelectedObjectNameContext } from '../ObjectManagementNavContext';
 

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -5,7 +5,7 @@ import { Draft, produce } from 'immer';
 
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 
-import { OTHER_CONST } from '../nav/ObjectManagementNav/constant';
+import { WRITE_CONST } from '../nav/ObjectManagementNav/constant';
 import { ConfigureState, ObjectConfigurationsState } from '../types';
 
 import { useHydratedRevision } from './HydratedRevisionContext';
@@ -121,7 +121,7 @@ export function ConfigurationProvider(
     objectName: string,
   ) => {
     // write case
-    if (objectName === OTHER_CONST) {
+    if (objectName === WRITE_CONST) {
       resetWritePendingConfigurationState();
     } else {
       // read case

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -101,7 +101,7 @@ export const generateReadNavObjects = (config: Config | undefined, hydratedRevis
   return navObjects;
 };
 
-export const generateOtherNavObject = (
+export const generateWriteNavObject = (
   config: Config | undefined,
 ) => {
   const navObject: NavObject = {
@@ -118,8 +118,8 @@ export function generateAllNavObjects(
 ) {
   const navObjects: NavObject[] = generateReadNavObjects(config, hydratedRevision);
   const isWriteSupported = !!hydratedRevision?.content?.write;
-  const otherNavObject = isWriteSupported ? generateOtherNavObject(config) : undefined;
-  if (otherNavObject) { navObjects.push(otherNavObject); }
+  const writeNavObject = isWriteSupported ? generateWriteNavObject(config) : undefined;
+  if (writeNavObject) { navObjects.push(writeNavObject); }
   return navObjects;
 }
 

--- a/src/components/Configure/utils.ts
+++ b/src/components/Configure/utils.ts
@@ -11,7 +11,7 @@ import {
 } from 'services/api';
 import { capitalize } from 'src/utils';
 
-import { OTHER_CONST } from './nav/ObjectManagementNav/constant';
+import { WRITE_CONST } from './nav/ObjectManagementNav/constant';
 import {
   NavObject,
   SelectMappingFields,
@@ -105,7 +105,7 @@ export const generateOtherNavObject = (
   config: Config | undefined,
 ) => {
   const navObject: NavObject = {
-    name: OTHER_CONST,
+    name: WRITE_CONST,
     completed: config ? !!config?.content?.write : false,
   };
   return navObject;

--- a/src/components/auth/Oauth/AuthorizationCode/fetchOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/fetchOAuthPopupURL.ts
@@ -19,7 +19,8 @@ export const fetchOAuthPopupURL = async (
   }
 
   if (provInfo.authType === 'oauth2') {
-    if (provInfo.oauth2Opts?.grantType === 'authorizationCode' || provInfo.oauth2Opts?.grantType === 'authorizationCodePKCE') {
+    if (provInfo.oauth2Opts?.grantType === 'authorizationCode'
+      || provInfo.oauth2Opts?.grantType === 'authorizationCodePKCE') {
       const providerApps = await api().providerAppApi.listProviderApps({ projectIdOrName: projectId }, {
         headers: { 'X-Api-Key': apiKey ?? '' },
       });


### PR DESCRIPTION
Users have found the "Other" tab to be confusingly named. 

<img width="1920" alt="Screenshot 2024-12-06 at 1 27 55 PM (2)" src="https://github.com/user-attachments/assets/f060cacb-e1e3-4801-b6a7-247ee53ebeb3">
