### PR TITLE
change signature of onConnectSuccess and onDisconnectSuccess

### DIFF
--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -8,7 +8,7 @@ import { useConnectionHandler } from 'components/Connect/useConnectionHandler';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
-import { api, ProviderInfo } from 'services/api';
+import { api, Connection, ProviderInfo } from 'services/api';
 import { capitalize } from 'src/utils';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -18,9 +18,9 @@ interface ProtectedConnectionLayoutProps {
   consumerName?: string,
   groupRef: string,
   groupName?: string,
-  onSuccess?: (connectionID: string) => void;
+  onSuccess?: (connection: Connection) => void;
   children: JSX.Element,
-  onDisconnectSuccess?: (connectionID: string) => void,
+  onDisconnectSuccess?: (connection: Connection) => void,
 }
 
 export const getProviderInfo = async (

--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
-import { Connection } from '@generated/api/src';
 
 import { ProtectedConnectionLayout } from 'components/Configure/layout/ProtectedConnectionLayout';
 import { RedirectHandler } from 'components/RedirectHandler';
 import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
 import { useForceUpdate } from 'src/hooks/useForceUpdate';
+import { Connection } from 'src/services/api';
 import resetStyles from 'src/styles/resetCss.module.css';
 
 import { ConnectedSuccessBox } from './ConnectedSuccessBox';

--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -1,3 +1,6 @@
+import { useCallback } from 'react';
+import { Connection } from '@generated/api/src';
+
 import { ProtectedConnectionLayout } from 'components/Configure/layout/ProtectedConnectionLayout';
 import { RedirectHandler } from 'components/RedirectHandler';
 import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
@@ -20,14 +23,14 @@ interface ConnectProviderProps {
   onSuccess?: (connectionID: string) => void;
   /**
    * Callback function to be executed when a connection is successfully established.
-   * @param connectionID - The ID of the newly established connection.
+   * @param connection - Information about the newly established connection.
    */
-  onConnectSuccess?: (connectionID: string) => void;
+  onConnectSuccess?: (connection: Connection) => void;
   /**
    * Callback function to be executed when a connection is successfully disconnected.
-   * @param connectionID - The ID of the disconnected connection.
+   * @param connection - TInformation about the disconnected connection.
    */
-  onDisconnectSuccess?: (connectionID: string) => void;
+  onDisconnectSuccess?: (connection: Connection) => void;
 }
 
 export function ConnectProvider({
@@ -43,7 +46,14 @@ export function ConnectProvider({
 }: ConnectProviderProps) {
   const { seed, reset } = useForceUpdate(); // resets the component when the seed changes
 
-  const onSuccessFx = onConnectSuccess || onSuccess;
+  const onSuccessFx = useCallback((connection: Connection) => {
+    if (onSuccess) {
+      onSuccess(connection.id);
+    } else if (onConnectSuccess) {
+      onConnectSuccess(connection);
+    }
+  }, [onSuccess, onConnectSuccess]);
+
   return (
     <div className={resetStyles.resetContainer} key={seed}>
       <ConnectionsProvider provider={provider} groupRef={groupRef}>

--- a/src/components/Connect/ConnectedSuccessBox.tsx
+++ b/src/components/Connect/ConnectedSuccessBox.tsx
@@ -1,3 +1,5 @@
+import { Connection } from '@generated/api/src';
+
 import { useProject } from 'context/ProjectContextProvider';
 import { getProviderName } from 'src/utils';
 
@@ -8,7 +10,7 @@ import { RemoveConnectionButton } from './RemoveConnectionButton';
 interface ConnectedSuccessBoxProps {
   resetComponent: () => void; // reset the ConnectProvider component
   provider: string;
-  onDisconnectSuccess?: (connectionID: string) => void;
+  onDisconnectSuccess?: (connection: Connection) => void;
 }
 export function ConnectedSuccessBox({ provider, onDisconnectSuccess, resetComponent }: ConnectedSuccessBoxProps) {
   const { appName } = useProject();

--- a/src/components/Connect/ConnectedSuccessBox.tsx
+++ b/src/components/Connect/ConnectedSuccessBox.tsx
@@ -1,6 +1,5 @@
-import { Connection } from '@generated/api/src';
-
 import { useProject } from 'context/ProjectContextProvider';
+import { Connection } from 'src/services/api';
 import { getProviderName } from 'src/utils';
 
 import { SuccessTextBox } from '../SuccessTextBox/SuccessTextBox';

--- a/src/components/Connect/RemoveConnectionButton.tsx
+++ b/src/components/Connect/RemoveConnectionButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
-import { api } from 'services/api';
+import { api, Connection } from 'services/api';
 import { Button } from 'src/components/ui-base/Button';
 import { useConnections } from 'src/context/ConnectionsContextProvider';
 import { handleServerError } from 'src/utils/handleServerError';
@@ -12,7 +12,7 @@ interface RemoveConnectionButtonProps {
   buttonText: string;
   buttonVariant?: string;
   buttonStyle?: React.CSSProperties;
-  onDisconnectSuccess?: (connectionID: string) => void;
+  onDisconnectSuccess?: (connection: Connection) => void;
 }
 
 export function RemoveConnectionButton({
@@ -50,7 +50,8 @@ export function RemoveConnectionButton({
           'successfully deleted connection:',
           selectedConnection?.id,
         );
-        onDisconnectSuccess?.(selectedConnection?.id); // callback
+        // Trigger builder-provided callback if it exists
+        onDisconnectSuccess?.(selectedConnection);
         // Reset connections
         api()
           .connectionApi.listConnections(

--- a/src/components/Connect/useConnectionHandler.tsx
+++ b/src/components/Connect/useConnectionHandler.tsx
@@ -1,20 +1,21 @@
 import { useEffect } from 'react';
+import { Connection } from '@generated/api/src';
 
 import { useConnections } from 'context/ConnectionsContextProvider';
 
-function useOnSuccessHandler(onSuccess?: (connectionID: string) => void) {
+function useOnSuccessHandler(onSuccess?: (connection: Connection) => void) {
   const { selectedConnection } = useConnections();
   useEffect(() => {
     // Check if a onSuccess callback is present
     if (onSuccess && selectedConnection) {
       // call callback when connection is selected
-      onSuccess(selectedConnection.id);
+      onSuccess(selectedConnection);
     }
   }, [onSuccess, selectedConnection]);
 }
 
 type ConnectionHandlerPropsProps = {
-  onSuccess?: (connectionID: string) => void;
+  onSuccess?: (connection: Connection) => void;
   // onError?: (error: string) => void; // not supported yet
 };
 

--- a/src/components/Connect/useConnectionHandler.tsx
+++ b/src/components/Connect/useConnectionHandler.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
-import { Connection } from '@generated/api/src';
 
 import { useConnections } from 'context/ConnectionsContextProvider';
+import { Connection } from 'src/services/api';
 
 function useOnSuccessHandler(onSuccess?: (connection: Connection) => void) {
   const { selectedConnection } = useConnections();

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -5,4 +5,8 @@ export * from '../context/AmpersandContextProvider';
 export * from '../components/Configure';
 export * from '../components/Connect/ConnectProvider';
 export * from '../hooks/useIsIntegrationInstalled';
+
+// Exported types which are helpful for builders
 export { FieldMapping } from 'src/components/Configure/content/fields/FieldMappings';
+export { Connection } from 'src/services/api'; // For callbacks in ConnectProvider
+export { Config } from 'src/services/api'; // For callbacks in InstallIntegration

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -1,3 +1,5 @@
+import { Config, Connection } from 'src/services/api';
+
 /**
  * Contains all the features to be exported out of the library
  */
@@ -8,5 +10,7 @@ export * from '../hooks/useIsIntegrationInstalled';
 
 // Exported types which are helpful for builders
 export { FieldMapping } from 'src/components/Configure/content/fields/FieldMappings';
-export { Connection } from 'src/services/api'; // For callbacks in ConnectProvider
-export { Config } from 'src/services/api'; // For callbacks in InstallIntegration
+export type {
+  Connection,
+  Config,
+};

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -8,9 +8,13 @@ export * from '../components/Configure';
 export * from '../components/Connect/ConnectProvider';
 export * from '../hooks/useIsIntegrationInstalled';
 
-// Exported types which are helpful for builders
+/**
+ *  Exported types which are helpful for builders
+ */
+
+// For defining dynamic mappings
 export { FieldMapping } from 'src/components/Configure/content/fields/FieldMappings';
 export type {
-  Connection,
-  Config,
+  Connection, // For ConnectProvider callbacks
+  Config, // For InstallIntegration callbacks
 };


### PR DESCRIPTION
I realized that only triggering the onConnectSuccess and onDisconnectSuccess callbacks with the Connection ID is not particularly useful. (For example, a customer wants to be able to customer data cleanup in the onDisconnectSuccess callback, so they'll need to know things like groupRef).

Since these 2 callbacks have not been released yet, it's a good time to change their signature. This video shows the new callbacks working, and that the legacy `onSuccess` callback still works:

https://www.loom.com/share/5438ea6be29d4ef69d5c6971f7c69a11?sid=6adf1832-0e77-496e-9cdb-7a28697d4058

Here's a dump of the Connection that the callback receives, it's the version of the Connection that does not have any sensitive info (no tokens). 
```
{
  "id": "965126de-05b5-419d-b9a0-4391c77cf03b",
  "projectId": "20c23d64-99b6-495a-8ac7-c7ae11bd91fe",
  "providerApp": {
    "id": "8540e800-2b35-40a2-b250-db546e46ab4c",
    "projectId": "20c23d64-99b6-495a-8ac7-c7ae11bd91fe",
    "externalRef": "",
    "provider": "hubspot",
    "clientId": "f49c98fd-02ce-4fea-bf88-a2425a2897d5",
    "scopes": [
      "crm.lists.read",
      "crm.lists.write",
      "crm.objects.companies.read",
      "crm.objects.companies.write",
      "crm.objects.contacts.read",
      "crm.objects.contacts.write",
      "crm.objects.deals.read",
      "crm.objects.deals.write",
      "crm.objects.leads.read",
      "crm.objects.leads.write",
      "oauth"
    ],
    "createTime": "2024-02-20T19:43:14.894Z",
    "updateTime": "2024-11-19T00:56:39.671Z"
  },
  "group": {
    "groupRef": "connect-group-2",
    "groupName": "demo-group-name-2",
    "projectId": "20c23d64-99b6-495a-8ac7-c7ae11bd91fe",
    "createTime": "2024-12-06T18:52:35.353Z",
    "updateTime": "2024-12-07T00:08:55.767Z"
  },
  "consumer": {
    "consumerRef": "demo-user-id",
    "consumerName": "demo-user-name",
    "projectId": "20c23d64-99b6-495a-8ac7-c7ae11bd91fe",
    "createTime": "0001-01-01T00:00:00.000Z",
    "updateTime": "0001-01-01T00:00:00.000Z"
  },
  "providerWorkspaceRef": "44237313",
  "createTime": "2024-12-07T00:08:55.771Z",
  "updateTime": "2024-12-07T00:08:56.306Z"
}
```