### PR TITLE
[ENG-1720] fix/refactor: move error ui out of Ampersand Provider

### DIFF
--- a/src/components/Configure/ComponentContainer.tsx
+++ b/src/components/Configure/ComponentContainer.tsx
@@ -4,7 +4,7 @@ import { Box } from '../ui-base/Box/Box';
 import { Container } from '../ui-base/Container/Container';
 
 /**
- * Container (auto aligned cetner) with border to wrap some content. Usually the outer most container for
+ * Container (auto aligned center) with border to wrap some content. Usually the outer most container for
  * Ampersand public components.
  * @param param0
  * @returns

--- a/src/components/Configure/ComponentContainer.tsx
+++ b/src/components/Configure/ComponentContainer.tsx
@@ -3,6 +3,12 @@ import { LoadingCentered } from '../Loading';
 import { Box } from '../ui-base/Box/Box';
 import { Container } from '../ui-base/Container/Container';
 
+/**
+ * Container (auto aligned cetner) with border to wrap some content. Usually the outer most container for
+ * Ampersand public components.
+ * @param param0
+ * @returns
+ */
 export function ComponentContainer({ children }: { children: React.ReactNode; }) {
   return (
     <Container style={{ maxWidth: '55rem' }}>

--- a/src/components/Configure/ComponentContainer.tsx
+++ b/src/components/Configure/ComponentContainer.tsx
@@ -1,0 +1,30 @@
+import { ErrorTextBox } from '../ErrorTextBox/ErrorTextBox';
+import { LoadingCentered } from '../Loading';
+import { Box } from '../ui-base/Box/Box';
+import { Container } from '../ui-base/Container/Container';
+
+export function ComponentContainer({ children }: { children: React.ReactNode; }) {
+  return (
+    <Container style={{ maxWidth: '55rem' }}>
+      <Box>
+        {children}
+      </Box>
+    </Container>
+  );
+}
+
+export function ComponentContainerLoading() {
+  return (
+    <ComponentContainer>
+      <LoadingCentered />
+    </ComponentContainer>
+  );
+}
+
+export function ComponentContainerError({ message }: { message: string; }) {
+  return (
+    <ComponentContainer>
+      <ErrorTextBox message={message} />
+    </ComponentContainer>
+  );
+}

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -1,4 +1,3 @@
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 import { InstallIntegrationProvider } from 'context/InstallIntegrationContextProvider';
@@ -8,14 +7,13 @@ import { useIntegrationList } from 'src/context/IntegrationListContextProvider';
 import { useForceUpdate } from 'src/hooks/useForceUpdate';
 import resetStyles from 'src/styles/resetCss.module.css';
 
-import { LoadingCentered } from '../Loading';
-
 import { InstallationContent } from './content/InstallationContent';
 import { ConditionalProxyLayout } from './layout/ConditionalProxyLayout/ConditionalProxyLayout';
 import { ProtectedConnectionLayout } from './layout/ProtectedConnectionLayout';
 import { ObjectManagementNav } from './nav/ObjectManagementNav';
 import { ConfigurationProvider } from './state/ConfigurationStateProvider';
 import { HydratedRevisionProvider } from './state/HydratedRevisionContext';
+import { ComponentContainerError, ComponentContainerLoading } from './ComponentContainer';
 
 export type FieldMapping = { [key: string]: Array<IntegrationFieldMapping> };
 
@@ -56,17 +54,29 @@ export function InstallIntegration(
     onUninstallSuccess, fieldMapping,
   }: InstallIntegrationProps,
 ) {
-  const { projectId, isLoading: isProjectLoading } = useProject();
+  const { projectId, projectIdOrName, isLoading: isProjectLoading } = useProject();
   const { isLoading: isIntegrationListLoading } = useIntegrationList();
-  const { errorState } = useErrorState();
+  const { isError, errorState } = useErrorState();
   const { seed, reset } = useForceUpdate();
 
   if (isProjectLoading || isIntegrationListLoading) {
-    return <LoadingCentered />;
+    return <ComponentContainerLoading />;
+  }
+
+  if (isError(ErrorBoundary.PROJECT, projectIdOrName)) {
+    return <ComponentContainerError message={`Error loading project ${projectIdOrName}`} />;
+  }
+
+  if (isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)) {
+    return (
+      <ComponentContainerError message="Error retrieving integrations for the project, double check the API key" />
+    );
   }
 
   if (errorState[ErrorBoundary.INTEGRATION_LIST]?.apiError) {
-    return <ErrorTextBox message="Something went wrong, couldn't find integration information" />;
+    return (
+      <ComponentContainerError message="Something went wrong, couldn't find integration information" />
+    );
   }
 
   return (

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -63,10 +63,11 @@ export function InstallIntegration(
     return <ComponentContainerLoading />;
   }
 
-  if (isError(ErrorBoundary.PROJECT, projectIdOrName)) {
+  if (isError(ErrorBoundary.PROJECT, projectIdOrName)) { // set in ProjectContextProvider (AmpersandProvider)
     return <ComponentContainerError message={`Error loading project ${projectIdOrName}`} />;
   }
 
+  // set in IntegrationListContextProvider (AmpersandProvider)
   if (isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)) {
     return (
       <ComponentContainerError message="Error retrieving integrations for the project, double check the API key" />

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 
 import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
-import { LoadingCentered } from 'components/Loading';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
@@ -11,6 +10,7 @@ import { SuccessTextBox } from 'src/components/SuccessTextBox/SuccessTextBox';
 import { Button } from 'src/components/ui-base/Button';
 
 import { onCreateInstallationProxyOnly } from '../../actions/proxy/onCreateInstallationProxyOnly';
+import { ComponentContainerError, ComponentContainerLoading } from '../../ComponentContainer';
 import { useHydratedRevision } from '../../state/HydratedRevisionContext';
 
 import { InstalledSuccessBox } from './InstalledSuccessBox';
@@ -91,8 +91,8 @@ export function ConditionalProxyLayout({ children, resetComponent }: Conditional
       </SuccessTextBox>
     );
   }
-  if (!integrationObj) return <ErrorTextBox message={"We can't load the integration"} />;
-  if (isLoading) return <LoadingCentered />;
+  if (!integrationObj) return <ComponentContainerError message={"We can't load the integration"} />;
+  if (isLoading) return <ComponentContainerLoading />;
   if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;
 
   return (

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -2,7 +2,6 @@ import React, {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
 import {
@@ -11,6 +10,8 @@ import {
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { api, HydratedRevision } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
+
+import { ComponentContainerError } from '../ComponentContainer';
 
 interface HydratedRevisionContextValue {
   hydratedRevision: HydratedRevision | null;
@@ -99,15 +100,17 @@ export function HydratedRevisionProvider({
     loading,
   }), [hydratedRevision, loading]);
 
-  const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';
+  if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {
+    const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';
+    const errorMsg = `Error retrieving integration details for '${intNameOrId
+    }. This is sometimes caused by insufficient permissions with your credentials'`;
 
-  const errorMsg = `Error retrieving integration details for '${intNameOrId
-  }. This is sometimes caused by insufficient permissions with your credentials'`;
+    return <ComponentContainerError message={errorMsg} />;
+  }
 
   return (
     <HydratedRevisionContext.Provider value={contextValue}>
-      {isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)
-        ? <ErrorTextBox message={errorMsg} /> : children}
+      { children}
     </HydratedRevisionContext.Provider>
   );
 }

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -2,9 +2,8 @@ import {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Connection } from 'services/api';
-import { LoadingCentered } from 'src/components/Loading';
+import { ComponentContainerError, ComponentContainerLoading } from 'src/components/Configure/ComponentContainer';
 import { useIsInstallationDeleted } from 'src/hooks/useIsInstallationDeleted';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -117,7 +116,15 @@ export function ConnectionsProvider({
   );
 
   if (isLoading || isProjectLoading) {
-    return <LoadingCentered />;
+    return <ComponentContainerLoading />;
+  }
+
+  if (isError(ErrorBoundary.PROJECT, projectId)) {
+    return <ComponentContainerError message={`Error loading project ${projectId}`} />;
+  }
+
+  if (isError(ErrorBoundary.CONNECTION_LIST, projectId)) {
+    return <ComponentContainerError message="Error retrieving existing connections" />;
   }
 
   if (!projectId) {
@@ -127,12 +134,8 @@ export function ConnectionsProvider({
   }
 
   return (
-    isError(ErrorBoundary.CONNECTION_LIST, projectId)
-      ? <ErrorTextBox message="Error retrieving existing connections" />
-      : (
-        <ConnectionsContext.Provider value={contextValue}>
-          { children }
-        </ConnectionsContext.Provider>
-      )
+    <ConnectionsContext.Provider value={contextValue}>
+      { children }
+    </ConnectionsContext.Provider>
   );
 }

--- a/src/context/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIntegrationContextProvider.tsx
@@ -3,12 +3,11 @@ import {
   useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import {
   api, Config, Installation, Integration,
 } from 'services/api';
+import { ComponentContainerError, ComponentContainerLoading } from 'src/components/Configure/ComponentContainer';
 import { FieldMapping } from 'src/components/Configure/InstallIntegration';
-import { LoadingCentered } from 'src/components/Loading';
 import { findIntegrationFromList } from 'src/utils';
 
 import { useIsInstallationDeleted } from '../hooks/useIsInstallationDeleted';
@@ -168,19 +167,24 @@ export function InstallIntegrationProvider({
     onInstallSuccess, onUpdateSuccess, onUninstallSuccess,
     isIntegrationDeleted, setIntegrationDeleted, fieldMapping]);
 
-  if (integrationObj !== null) {
-    const errorMessage = 'Error retrieving installation information for integration '
-     + `"${integrationObj?.name || 'unknown'}"`;
-
-    return (
-      isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey))
-      ? <ErrorTextBox message={errorMessage} /> : (
-        <InstallIntegrationContext.Provider value={props}>
-          {isLoading ? <LoadingCentered /> : children}
-        </InstallIntegrationContext.Provider>
-      );
+  if (isLoading) {
+    return <ComponentContainerLoading />;
   }
 
-  // if integration not found, return error message
-  return <ErrorTextBox message={`Integration "${integration}" not found`} />;
+  if (integrationObj === null) {
+    // if integration not found, return error message
+    return <ComponentContainerError message={`Integration "${integration}" not found`} />;
+  }
+
+  if (isError(ErrorBoundary.INSTALLATION_LIST, integrationErrorKey)) {
+    const errorMessage = 'Error retrieving installation information for integration '
+    + `"${integrationObj?.name || 'unknown'}"`;
+    return <ComponentContainerError message={errorMessage} />;
+  }
+
+  return (
+    <InstallIntegrationContext.Provider value={props}>
+      {children}
+    </InstallIntegrationContext.Provider>
+  );
 }

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -3,7 +3,6 @@ import {
   useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Integration } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -39,7 +38,7 @@ export function IntegrationListProvider(
   { projectIdOrName, children }: IntegrationListContextProviderProps,
 ) {
   const apiKey = useApiKey();
-  const { setError, isError } = useErrorState();
+  const { setError } = useErrorState();
   const [integrations, setIntegrations] = useState<Integration[] | null>(null);
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
@@ -64,12 +63,8 @@ export function IntegrationListProvider(
   }), [integrations, isLoading]);
 
   return (
-    isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
-      ? <ErrorTextBox message="Error retrieving integrations for the project, double check the API key" />
-      : (
-        <IntegrationListContext.Provider value={contextValue}>
-          { children}
-        </IntegrationListContext.Provider>
-      )
+    <IntegrationListContext.Provider value={contextValue}>
+      { children}
+    </IntegrationListContext.Provider>
   );
 }

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -2,7 +2,6 @@ import {
   createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 
-import { ErrorTextBox } from 'components/ErrorTextBox/ErrorTextBox';
 import { api, Project } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -46,7 +45,7 @@ export function ProjectProvider(
   { projectIdOrName, children }: ProjectProviderProps,
 ) {
   const apiKey = useApiKey();
-  const { isError, setError } = useErrorState();
+  const { setError } = useErrorState();
   const [project, setProject] = useState<Project | null>(null);
   const [isLoading, setLoadingState] = useState<boolean>(true);
 
@@ -75,12 +74,8 @@ export function ProjectProvider(
   }), [projectIdOrName, project, isLoading]);
 
   return (
-    isError(ErrorBoundary.PROJECT, projectIdOrName)
-      ? <ErrorTextBox message={`Error loading project ${projectIdOrName}`} />
-      : (
-        <ProjectContext.Provider value={contextValue}>
-          {children}
-        </ProjectContext.Provider>
-      )
+    <ProjectContext.Provider value={contextValue}>
+      {children}
+    </ProjectContext.Provider>
   );
 }


### PR DESCRIPTION
### Summary 
[previous work](https://github.com/amp-labs/react/pull/747) moved loading outside of Ampersand Provider, we will need to move the error ui so that UI problems at the top level do not occur for the builder
- move error ui to InstallIntegration
- move error ui to ConnectProvider
- create ComponentContainer to wrap outer layer and error components
- swap out `<LoadingCentered/>` and `<ErrorTextBox/>` to include a Component Border (`<ComponentContainerLoading/>`, `<ComponentContainerError/>` )

#### screenshots with container
![Screenshot 2024-12-09 at 4 30 17 PM](https://github.com/user-attachments/assets/6f0d88d1-df33-4b23-991c-29ffa8633436)

![Screenshot 2024-12-09 at 4 23 13 PM](https://github.com/user-attachments/assets/cb6d87d4-9428-43a3-9a68-6aa924a56215)

![Screenshot 2024-12-09 at 4 22 57 PM](https://github.com/user-attachments/assets/614c590e-248c-4db9-8e6a-69903d83c5f6)
![Screenshot 2024-12-09 at 4 22 38 PM](https://github.com/user-attachments/assets/40b42ddc-b5cc-453d-afe1-32110b5073d9)

![Screenshot 2024-12-09 at 4 24 09 PM](https://github.com/user-attachments/assets/6270c9e7-3085-4c1c-a4c5-f5d125c6ce0a)

