### PR TITLE
[ENG-1709] style: update input semantic variables

### DIFF
--- a/src/components/Configure/content/fields/OptionalFields/optionalFields.module.css
+++ b/src/components/Configure/content/fields/OptionalFields/optionalFields.module.css
@@ -1,6 +1,6 @@
 .checkboxGroupContainer {
     margin-bottom: 10px;
-    border: 2px solid var(--amp-colors-border);
+    border: 1px solid var(--amp-colors-border);
     border-radius: var(--amp-default-border-radius);
 }
 .stack {
@@ -10,13 +10,13 @@
   
 .selectAllContainer {
     background-color: var(--amp-colors-bg-highlight);
-    padding: 8px 16px;
+    padding: 8px 10px;
     display: flex;
     align-items: center;
 }
   
 .fieldContainer {
-    padding: 8px 16px;
+    padding: 8px 10px;
     border-bottom: 1px solid var(--amp-colors-border);
     display: flex;
     align-items: center;
@@ -25,22 +25,21 @@
 .checkbox {
     margin-right: 10px;
     background-color: var(--amp-colors-bg-primary);
-    width: 25px;
-    height: 25px;
+    width: 20px;
+    height: 20px;
     border-radius: 4px;
     display: flex;
-    align-items: center;
     justify-content: center;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.07);
-    border: 1px solid var(--amp-colors-border);
+    border: 1px solid var(--amp-colors-input-border-default);
     cursor: pointer;
+    flex: none;
 }
 
 .checkbox:hover {
-    background-color: var(--amp-colors-input-hover); 
+    background-color: var(--amp-colors-input-surface-hover);
+    border-color: var(--amp-colors-input-border-hover);
 }
   
 .checkbox:focus {
-    box-shadow: 0 0 0 2px var(--amp-colors-focus-border);
+    border-color: var(--amp-colors-input-border-focus);
 }
-  

--- a/src/components/form/Input/input.module.css
+++ b/src/components/form/Input/input.module.css
@@ -1,11 +1,12 @@
 .input {
     border-radius: var(--amp-default-border-radius);
     border: 1px solid;
-    border-color: inherit;
+    border-color: var(--amp-colors-input-border-default);
     height: 2.5rem;
     transition: all .20s ease-in;
 
-    color: var(--amp-colors-text-regular);
+    color: var(--amp-colors-input-content-default);
+    background-color: var(--amp-colors-input-surface-default);
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.5rem; /* 150% */
@@ -14,18 +15,29 @@
     transition: all .1s ease;
 }
 
+.input:hover {
+    border-color: var(--amp-colors-input-border-hover);
+    background-color: var(--amp-colors-input-surface-hover);
+}
+
+.input::placeholder {
+    color: var(--amp-colors-input-content-placeholder-text);
+}
+
 .inputError {
     border: 1px solid var(--amp-colors-status-critical);
 }
 
 .input:focus:enabled {
-    border: 2px solid var(--amp-colors-focus-border);
+    border: 2px solid var(--amp-colors-input-border-focus);
     outline: none;
+    background-color: var(--amp-colors-input-surface-focus);
 }
 
 .input:disabled {
-    background-color: var( --amp-colors-bg-highlight);
-    border: 1px solid var(--amp-colors-neutral-400);
+    background-color: var(--amp-colors-input-surface-disabled);
+    border: 1px solid var(--amp-colors-input-border-disabled);
+    color: var(--amp-colors-input-content-disabled) ;
 }
 
 .error {

--- a/src/components/form/Textarea/textarea.module.css
+++ b/src/components/form/Textarea/textarea.module.css
@@ -1,9 +1,9 @@
 .textarea {
     border-radius: var(--amp-default-border-radius);
     border: 1px solid;
-    border-color: inherit;
-    background-color: var(--amp-colors-bg-primary);
-    color: var(--amp-colors-text-regular);
+    border-color: var(--amp-colors-input-border-default);
+    background-color: var(--amp-colors-input-surface-default);
+    color: var(--amp-colors-input-content-default);
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.5rem; /* 150% */
@@ -16,13 +16,14 @@
 }
 
 .textarea:focus:enabled {
-    border: 2px solid var(--amp-colors-focus-border);
+    border: 2px solid var(--amp-colors-input-border-focus);
     outline: none;
 }
 
 .textarea:disabled {
-    background-color: var(--amp-colors-bg-highlight);
-    border: 1px solid var(--amp-colors-neutral-400);
+    color: var(--amp-colors-input-content-disabled);
+    background-color: var(--amp-colors-input-surface-disabled);
+    border: 1px solid var(--amp-colors-input-border-disabled);
 }
 
 .error {

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -23,7 +23,7 @@
 }
 
 .button:focus:enabled {
-    border: 2px solid var(--amp-colors-input-hover);
+    border: 2px solid var(--amp-colors-input-border-focus);
     outline: none;
 }
 

--- a/src/components/ui-base/Checkbox/checkbox.module.css
+++ b/src/components/ui-base/Checkbox/checkbox.module.css
@@ -30,16 +30,17 @@
     border-radius: 4px;
     display: flex;
     justify-content: center;
-    border: 1px solid var(--amp-colors-border);
+    border: 1px solid var(--amp-colors-input-border-default);
     cursor: pointer;
     flex: none;
 }
 
 .checkbox:hover {
-    background-color: var(--amp-colors-input-hover); 
+    background-color: var(--amp-colors-input-surface-hover);
+    border-color: var(--amp-colors-input-border-hover);
 }
   
 .checkbox:focus {
     box-shadow: 0 0 0 2px var(--amp-colors-focus-border);
+    border-color: var(--amp-colors-input-border-focus);
 }
- 

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -11,9 +11,8 @@
 
 .inputContainer {
   display: flex;
-  background-color: var(--amp-colors-bg-primary);
   border: 1px solid;
-  border-color: var(--amp-colors-border);
+  border-color: var(--amp-colors-input-border-default);
   border-radius: var(--amp-default-border-radius);
 }
 
@@ -21,6 +20,14 @@
   padding: 0.5rem;
   width: 100%;
   font-size: 1rem;
+  background-color: var(--amp-colors-input-surface-default);
+  color: var(--amp-colors-input-content-default);
+  border-top-left-radius: var(--amp-default-border-radius);
+  border-bottom-left-radius: var(--amp-default-border-radius);
+}
+
+.input:focus-visible {
+  outline: 1px solid var(--amp-colors-input-border-focus);
 }
 
 .toggleButton {
@@ -31,13 +38,13 @@
 
 .menu {
   position: absolute;
-  background-color: var(--amp-colors-bg-primary);
+  background-color: var(--amp-colors-input-surface-default);
   width: 100%;
   max-height: 200px;
   overflow-y: auto;
   margin-top: 0.25rem;
   border: 1px solid;
-  border-color: var(--amp-colors-border);
+  border-color: var(--amp-colors-input-border-default);
   z-index: 10;
   border-radius: var(--amp-default-border-radius);
   padding: 0;
@@ -52,7 +59,7 @@
 
 .menuItem:hover,
 .highlighted {
-  background-color: var(--amp-colors-input-hover);
+  background-color: var(--amp-colors-input-surface-hover);
 }
 
 .selected {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -31,9 +31,9 @@
     /* bg-surfaces */
     --amp-colors-bg-primary: var(--amp-colors-white);
     --amp-colors-bg-secondary: var(--amp-colors-neutral-50);
-    --amp-colors-bg-highlight: var(--amp-colors-neutral-200);
+    --amp-colors-bg-highlight: var(--amp-colors-neutral-300);
 
-    /* border */
+    /* default border */
     --amp-colors-border: var(--amp-colors-neutral-300);
     --amp-default-border-radius: 6px;
 
@@ -52,6 +52,17 @@
     --amp-colors-button-text: var(--amp-colors-white);
 
     /* input */
-    --amp-colors-input-hover: var(--amp-colors-bg-highlight);
-    --amp-colors-focus-border: var(--amp-colors-neutral-800);
+    --amp-colors-input-border-default: var(--amp-colors-neutral-500);
+    --amp-colors-input-border-disabled: var(--amp-colors-neutral-500);
+    --amp-colors-input-border-focus: var(--amp-colors-neutral-900);
+    --amp-colors-input-border-hover: var(--amp-colors-neutral-500);
+    
+    --amp-colors-input-content-default: var(--amp-colors-black);
+    --amp-colors-input-content-disabled: var(--amp-colors-neutral-600);
+    --amp-colors-input-content-placeholder-text: var(--amp-colors-neutral-600);
+    
+    --amp-colors-input-surface-default: var(--amp-colors-white);
+    --amp-colors-input-surface-disabled: var(--amp-colors-neutral-200);
+    --amp-colors-input-surface-focus: var(--amp-colors-white);
+    --amp-colors-input-surface-hover: var(--amp-colors-neutral-200);
 }


### PR DESCRIPTION
### Summary
Adds additional semantic variables for specific input css color control. Preps variables for dark mode. 
- fixes input css bug with input border radius
- removes default outline in input

followup part 2: https://github.com/amp-labs/react/pull/756

note: this may introduce breaking changes with css variable name change @laurenzlong 

#### demo
css changes are minor
<img width="816" alt="Screenshot 2024-12-16 at 7 21 06 AM" src="https://github.com/user-attachments/assets/4fa59fe3-096c-4ce7-8175-79c12ec62114" />

input outline can border radius fix
<img width="438" alt="Screenshot 2024-12-16 at 11 05 25 AM" src="https://github.com/user-attachments/assets/6bd312f9-39d5-442f-a0be-f8cc6e3bac86" />


