### PR TITLE
[ENG-1709] style: add dark mode light-dark palette (part 2)

### DIFF
--- a/src/assets/TrashIcon.tsx
+++ b/src/assets/TrashIcon.tsx
@@ -2,17 +2,17 @@
 export function TrashIcon() {
   return (
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M2.25 4.5H3.75H15.75" stroke="#991B1B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2.25 4.5H3.75H15.75" stroke="#E73D3D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
       <path
         // eslint-disable-next-line max-len
         d="M14.25 4.5V15C14.25 15.3978 14.092 15.7794 13.8107 16.0607C13.5294 16.342 13.1478 16.5 12.75 16.5H5.25C4.85218 16.5 4.47064 16.342 4.18934 16.0607C3.90804 15.7794 3.75 15.3978 3.75 15V4.5M6 4.5V3C6 2.60218 6.15804 2.22064 6.43934 1.93934C6.72064 1.65804 7.10218 1.5 7.5 1.5H10.5C10.8978 1.5 11.2794 1.65804 11.5607 1.93934C11.842 2.22064 12 2.60218 12 3V4.5"
-        stroke="#991B1B"
+        stroke="#E73D3D"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="M7.5 8.25V12.75" stroke="#991B1B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="M10.5 8.25V12.75" stroke="#991B1B" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M7.5 8.25V12.75" stroke="#E73D3D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M10.5 8.25V12.75" stroke="#E73D3D" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 }

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/tabs.module.css
@@ -27,7 +27,7 @@
 }
 
 .danger {
-  color: var(--amp-colors-status-critical-dark);
+  color: var(--amp-colors-status-critical);
 }
 
 

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -4,7 +4,7 @@
     border-radius: var(--amp-default-border-radius);
 
     border: 1px solid;
-    border-color: inherit;
+    border-color: var(--amp-colors-border);
     height: 2.5rem;
     font-size: 1rem;
     font-weight: 500;
@@ -39,7 +39,7 @@
 }
 
 .ghost {
-    border-color: var(--amp-colors-neutral-200);
+    border-color: var(--amp-colors-border);
     background-color: var(--amp-colors-bg-highlight);    
     color: var(--amp-colors-black);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -24,17 +24,17 @@
     /* SEMANTIC COLORS */
 
     /* typography colors */
-    --amp-colors-text-standout: var(--amp-colors-black);
-    --amp-colors-text-regular: var(--amp-colors-neutral-900);
-    --amp-colors-text-muted: var(--amp-colors-neutral-700);
+    --amp-colors-text-standout: light-dark(var(--amp-colors-black), var(--amp-colors-white));
+    --amp-colors-text-regular: light-dark(var(--amp-colors-neutral-900), var(--amp-colors-neutral-100));
+    --amp-colors-text-muted: light-dark(var(--amp-colors-neutral-700), var(--amp-colors-neutral-200));
 
     /* bg-surfaces */
-    --amp-colors-bg-primary: var(--amp-colors-white);
-    --amp-colors-bg-secondary: var(--amp-colors-neutral-50);
-    --amp-colors-bg-highlight: var(--amp-colors-neutral-300);
+    --amp-colors-bg-primary: light-dark(var(--amp-colors-white), var(--amp-colors-neutral-800));
+    --amp-colors-bg-secondary: light-dark(var(--amp-colors-neutral-50), var(--amp-colors-neutral-900));
+    --amp-colors-bg-highlight: light-dark(var(--amp-colors-neutral-300), var(--amp-colors-neutral-700));
 
     /* default border */
-    --amp-colors-border: var(--amp-colors-neutral-300);
+    --amp-colors-border: light-dark(var(--amp-colors-neutral-300), var(--amp-colors-neutral-700));
     --amp-default-border-radius: 6px;
 
     /* status */
@@ -43,26 +43,27 @@
     --amp-colors-status-critical-muted: #FFD9D9;
      
     /* links */
-    --amp-colors-link-text: var(--amp-colors-text-muted);
-    --amp-colors-link-focus: var(--amp-colors-text-standout);
-    --amp-colors-link-active: var(--amp-colors-text-regular);
+    --amp-colors-link-text: light-dark(var(--amp-colors-neutral-900), var(--amp-colors-neutral-50));
+    --amp-colors-link-focus: light-dark(var(--amp-colors-neutral-700), var(--amp-colors-neutral-700));
+    /* optional use brand colors */
+    --amp-colors-link-active: light-dark(var(--amp-colors-neutral-700), var(--amp-colors-neutral-200));
 
     /* button */
     --amp-colors-button-primary: var(--amp-colors-primary);
     --amp-colors-button-text: var(--amp-colors-white);
 
     /* input */
-    --amp-colors-input-border-default: var(--amp-colors-neutral-500);
-    --amp-colors-input-border-disabled: var(--amp-colors-neutral-500);
-    --amp-colors-input-border-focus: var(--amp-colors-neutral-900);
-    --amp-colors-input-border-hover: var(--amp-colors-neutral-500);
+    --amp-colors-input-border-default: light-dark(var(--amp-colors-neutral-500), var(--amp-colors-neutral-700));
+    --amp-colors-input-border-disabled: light-dark(var(--amp-colors-neutral-500), var(--amp-colors-neutral-600));
+    --amp-colors-input-border-focus: light-dark(var(--amp-colors-neutral-900), var(--amp-colors-neutral-50));
+    --amp-colors-input-border-hover: light-dark(var(--amp-colors-neutral-500), var(--amp-colors-neutral-600));
     
-    --amp-colors-input-content-default: var(--amp-colors-black);
+    --amp-colors-input-content-default: light-dark(var(--amp-colors-black), var(--amp-colors-white));
     --amp-colors-input-content-disabled: var(--amp-colors-neutral-600);
     --amp-colors-input-content-placeholder-text: var(--amp-colors-neutral-600);
     
-    --amp-colors-input-surface-default: var(--amp-colors-white);
-    --amp-colors-input-surface-disabled: var(--amp-colors-neutral-200);
-    --amp-colors-input-surface-focus: var(--amp-colors-white);
-    --amp-colors-input-surface-hover: var(--amp-colors-neutral-200);
+    --amp-colors-input-surface-default: light-dark(var(--amp-colors-white), var(--amp-colors-neutral-900));
+    --amp-colors-input-surface-disabled: light-dark(var(--amp-colors-neutral-200), var(--amp-colors-neutral-700));
+    --amp-colors-input-surface-focus: light-dark(var(--amp-colors-white), var(--amp-colors-black));
+    --amp-colors-input-surface-hover: light-dark(var(--amp-colors-neutral-200), var(--amp-colors-neutral-800));
 }


### PR DESCRIPTION
### Summary 
To support dark mode the user must create their own style override if not already turned on in the app 
- adds dark mode to semantic variables

part 1: https://github.com/amp-labs/react/pull/755

```css
// your style overrides App.css, imported after stylesheet
:root {
 color-scheme: light dark;
}
```
### Dark Mode Screenshots

<img width="791" alt="Screenshot 2024-12-16 at 11 27 25 AM" src="https://github.com/user-attachments/assets/aacbc876-bcdf-458f-bb0e-1f5e22ea38ac" />
 
<img width="211" alt="Screenshot 2024-12-16 at 11 30 59 AM" src="https://github.com/user-attachments/assets/0cc8a1d5-8744-42a3-b73f-ca0f27f18757" />


<img width="440" alt="Screenshot 2024-12-16 at 11 27 15 AM" src="https://github.com/user-attachments/assets/06aac847-4b7f-4c6c-87c4-c75fe5d15de7" />


### Light Mode (mostly unchanged)
- trash icon / tab red color change

<img width="813" alt="Screenshot 2024-12-16 at 11 35 55 AM" src="https://github.com/user-attachments/assets/137f3fe5-f051-4e08-b6f0-c428ac69fa6c" />
