### PR TITLE
[ENG-1670] refactor: move api key to API service config

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -110,11 +110,15 @@ export const api = () => apiValue;
 
 /**
  * hook to access the API service
+ *
+ *
  * @returns
  */
 export function useAPI(): () => Promise<ApiService> {
   const apiKey = useApiKey();
 
+  /** Even though it doesn't need to be be async right now, we want to be able to support other ways
+   * to authenticating to the API in the future which may require async operations */
   const getAPI = useCallback(async () => {
     if (!apiKey) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
### Summary
- create a useAPI hook like in the client
- refactor `project` api call to use new service


#### not included / followup 
- migrating all instances of api 
- setting / overriding api key service instance

#### data fetched as expected
![Screenshot 2024-12-18 at 12 19 22 PM](https://github.com/user-attachments/assets/76b2e173-94fb-4429-b140-d39f55a517ce)
