### PR TITLE
[ENG-1757] fix: logo rendering issues and use the correct logo for light/dark mode

### DIFF
--- a/src/layout/AuthCardLayout/AmpersandFooter.tsx
+++ b/src/layout/AuthCardLayout/AmpersandFooter.tsx
@@ -24,7 +24,7 @@ export function AmpersandFooter() {
         aria-label="Go to Ampersand"
         rel="noreferrer noopener"
       >
-        <img style={{ height: '.8em' }} src="https://ampersand-website.vercel.app/logo-black.svg" alt="Ampersand" />
+        <img style={{ height: '.8em' }} src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black_fwzpfw.svg" alt="Ampersand" />
       </a>
     </footer>
   );

--- a/src/layout/AuthCardLayout/AmpersandFooter.tsx
+++ b/src/layout/AuthCardLayout/AmpersandFooter.tsx
@@ -24,7 +24,24 @@ export function AmpersandFooter() {
         aria-label="Go to Ampersand"
         rel="noreferrer noopener"
       >
-        <img style={{ height: '.8em' }} src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black_fwzpfw.svg" alt="Ampersand" />
+
+        <picture>
+          <source
+            srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1735853540/ampersand_logo_white.svg"
+            media="(prefers-color-scheme: dark)"
+          />
+          <source
+            srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg"
+            media="(prefers-color-scheme: light)"
+          />
+          {/* Default */}
+          <img 
+            style={{ height: '.8em' }} 
+            src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg" 
+            alt="Ampersand"
+          />
+        </picture>
+
       </a>
     </footer>
   );

--- a/src/layout/AuthCardLayout/AmpersandFooter.tsx
+++ b/src/layout/AuthCardLayout/AmpersandFooter.tsx
@@ -27,17 +27,17 @@ export function AmpersandFooter() {
 
         <picture>
           <source
-            srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1735853540/ampersand_logo_white.svg"
-            media="(prefers-color-scheme: dark)"
-          />
-          <source
             srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg"
             media="(prefers-color-scheme: light)"
           />
+          <source
+            srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1735853540/ampersand_logo_white.svg"
+            media="(prefers-color-scheme: dark)"
+          />
           {/* Default */}
-          <img 
-            style={{ height: '.8em' }} 
-            src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg" 
+          <img
+            style={{ height: '.8em' }}
+            src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg"
             alt="Ampersand"
           />
         </picture>


### PR DESCRIPTION
Replace previous logo URL with cloudinary URL, since cloudinary sets CORS headers properly which will help us avoid having some builders not being able to render the logo in their app (see Linear ticket for screenshot of bug)

![Screenshot 2025-01-02 at 2 19 00 PM](https://github.com/user-attachments/assets/825f70c4-cad4-4418-a325-a6fb9c02f60d)

This PR also makes use of the `picture` element to conditionally render the right logo for light and dark mode, picture element seems to supported by all major browsers: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture

![Screenshot 2025-01-02 at 2 15 29 PM](https://github.com/user-attachments/assets/dd5236e3-c3d5-4698-bdb0-d5506014afc5)
![Screenshot 2025-01-02 at 2 15 54 PM](https://github.com/user-attachments/assets/d2095a81-1bac-477f-a255-720260f23c50)
