### PR TITLE
[ENG-1780] fix: uninstall / reinstall proxy flow (part 1)

### DIFF
--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -53,7 +53,7 @@ export function ConditionalProxyLayout({ children, resetComponent }: Conditional
 
   useEffect(() => {
     if (!isLoading && hydratedRevision && isProxyOnly
-      && !installation && selectedConnection && apiKey && integrationObj?.id) {
+      && !installation && selectedConnection && apiKey && integrationObj?.id && !isIntegrationDeleted) {
       setCreateInstallLoading(true);
       onCreateInstallationProxyOnly({
         apiKey,
@@ -73,8 +73,9 @@ export function ConditionalProxyLayout({ children, resetComponent }: Conditional
         console.error('Error when creating proxy installation:', e);
       });
     }
-  }, [hydratedRevision, isProxyOnly, installation, selectedConnection, apiKey, projectId,
-    integrationObj?.id, groupRef, consumerRef, setInstallation, isLoading, onInstallSuccess]);
+  }, [hydratedRevision, isProxyOnly, installation, selectedConnection, apiKey,
+    projectId, integrationObj?.id, groupRef, consumerRef, setInstallation,
+    isLoading, onInstallSuccess, isIntegrationDeleted]);
 
   if (isIntegrationDeleted) {
     return (


### PR DESCRIPTION
### Summary
Reinstall proxy flow is triggered automatically after deleting proxy integration. Part 1:
- if integration is deleted, do not retrigger create flow if integration is deleted.
- does not persist when refreshed (followup below)

See https://linear.app/ampersand/issue/ENG-1780/bug-uninstall-proxy-reinstalls-automatically for root issue in uninstall flow.

#### followup
if page is refreshed, the create proxy integration flow will still re-trigger since  a connection is still available and triggers after detecting connection. will still need 

#### before
<img width="1138" alt="Screenshot 2025-01-06 at 5 23 21 PM" src="https://github.com/user-attachments/assets/0daedf59-83cd-48c8-8217-092ea213c92e" />

#### after
![Screenshot 2025-01-07 at 4 12 26 PM](https://github.com/user-attachments/assets/a3aea5f0-2a9f-4807-8064-0c8e26ffedd0)



