### PR TITLE
[ENG-1780] fix: reinstall proxy flow connections (part 2b)

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -101,9 +101,10 @@ export function InstallIntegration(
             consumerName={consumerName}
             groupRef={groupRef}
             groupName={groupName}
+            resetComponent={reset}
           >
             <HydratedRevisionProvider projectId={projectId}>
-              <ConditionalProxyLayout resetComponent={reset}>
+              <ConditionalProxyLayout>
                 <ConfigurationProvider>
                   <ObjectManagementNav>
                     <InstallationContent />

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -5,8 +5,6 @@ import { useConnections } from 'context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { HydratedRevision } from 'services/api';
-import { SuccessTextBox } from 'src/components/SuccessTextBox/SuccessTextBox';
-import { Button } from 'src/components/ui-base/Button';
 
 import { onCreateInstallationProxyOnly } from '../../actions/proxy/onCreateInstallationProxyOnly';
 import { ComponentContainerError, ComponentContainerLoading } from '../../ComponentContainer';
@@ -23,7 +21,6 @@ const getIsProxyOnly = (hydratedRevision: HydratedRevision | null) => {
 
 interface ConditionalProxyLayoutProps {
   children: React.ReactNode;
-  resetComponent: () => void; // resets installation integration component
 }
 
 /**
@@ -31,7 +28,7 @@ interface ConditionalProxyLayoutProps {
  * then it will not render the ConfigureInstallation
  * @returns
  */
-export function ConditionalProxyLayout({ children, resetComponent }: ConditionalProxyLayoutProps) {
+export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps) {
   const { projectId } = useProject();
   const apiKey = useApiKey();
   const { hydratedRevision, loading: hydratedRevisionLoading } = useHydratedRevision();
@@ -77,20 +74,6 @@ export function ConditionalProxyLayout({ children, resetComponent }: Conditional
     projectId, integrationObj?.id, groupRef, consumerRef, setInstallation,
     isLoading, onInstallSuccess, isIntegrationDeleted]);
 
-  if (isIntegrationDeleted) {
-    return (
-      <SuccessTextBox
-        text="Integration successfully uninstalled."
-      >
-        <Button
-          type="button"
-          onClick={resetComponent}
-          style={{ width: '100%' }}
-        >Reinstall Integration
-        </Button>
-      </SuccessTextBox>
-    );
-  }
   if (!integrationObj) return <ComponentContainerError message={"We can't load the integration"} />;
   if (isLoading) return <ComponentContainerLoading />;
   if (isProxyOnly && provider && installation) return <InstalledSuccessBox provider={provider} />;

--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -50,7 +50,7 @@ export function ProtectedConnectionLayout({
   const [providerInfo, setProviderInfo] = useState<ProviderInfo | null>(null);
 
   const { provider: providerFromProps, isIntegrationDeleted } = useInstallIntegrationProps();
-  const { selectedConnection, setSelectedConnection, connections } = useConnections();
+  const { selectedConnection, setSelectedConnection } = useConnections();
   useConnectionHandler({ onSuccess });
 
   const selectedProvider = provider || providerFromProps;
@@ -58,18 +58,13 @@ export function ProtectedConnectionLayout({
   const providerName = providerInfo?.displayName ?? capitalize(selectedProvider);
 
   useEffect(() => {
-    if (!selectedConnection && connections && connections.length > 0) {
-      const [connection] = connections;
-      setSelectedConnection(connection);
-    }
-
     getProviderInfo(apiKey, selectedProvider).then((info) => {
       setProviderInfo(info);
     }).catch((err) => {
       console.error('Error loading provider info.');
       handleServerError(err);
     });
-  }, [connections, selectedConnection, setSelectedConnection, apiKey, selectedProvider]);
+  }, [apiKey, selectedProvider]);
 
   if (!provider && !providerFromProps) {
     throw new Error('ProtectedConnectionLayout must be given a provider prop or be used within InstallIntegrationProvider');

--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -9,6 +9,8 @@ import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
 import { api, Connection, ProviderInfo } from 'services/api';
+import { SuccessTextBox } from 'src/components/SuccessTextBox/SuccessTextBox';
+import { Button } from 'src/components/ui-base/Button';
 import { capitalize } from 'src/utils';
 import { handleServerError } from 'src/utils/handleServerError';
 
@@ -21,6 +23,7 @@ interface ProtectedConnectionLayoutProps {
   onSuccess?: (connection: Connection) => void;
   children: JSX.Element,
   onDisconnectSuccess?: (connection: Connection) => void,
+  resetComponent: () => void, // resets installation integration component
 }
 
 export const getProviderInfo = async (
@@ -41,11 +44,12 @@ export const getProviderInfo = async (
 
 export function ProtectedConnectionLayout({
   provider, consumerRef, consumerName, groupRef, groupName, children, onSuccess, onDisconnectSuccess,
+  resetComponent,
 }: ProtectedConnectionLayoutProps) {
   const apiKey = useApiKey();
   const [providerInfo, setProviderInfo] = useState<ProviderInfo | null>(null);
 
-  const { provider: providerFromProps } = useInstallIntegrationProps();
+  const { provider: providerFromProps, isIntegrationDeleted } = useInstallIntegrationProps();
   const { selectedConnection, setSelectedConnection, connections } = useConnections();
   useConnectionHandler({ onSuccess });
 
@@ -69,6 +73,22 @@ export function ProtectedConnectionLayout({
 
   if (!provider && !providerFromProps) {
     throw new Error('ProtectedConnectionLayout must be given a provider prop or be used within InstallIntegrationProvider');
+  }
+
+  // integration (and connection) was deleted, show success message with reinstall button
+  if (isIntegrationDeleted) {
+    return (
+      <SuccessTextBox
+        text="Integration successfully uninstalled."
+      >
+        <Button
+          type="button"
+          onClick={resetComponent}
+          style={{ width: '100%' }}
+        >Reinstall Integration
+        </Button>
+      </SuccessTextBox>
+    );
   }
 
   // a selected connection exists, render children

--- a/src/components/Configure/layout/UninstallButton.tsx
+++ b/src/components/Configure/layout/UninstallButton.tsx
@@ -5,6 +5,7 @@ import { useInstallIntegrationProps } from 'context/InstallIntegrationContextPro
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
 import { Button } from 'src/components/ui-base/Button';
+import { useConnections } from 'src/context/ConnectionsContextProvider';
 import { handleServerError } from 'src/utils/handleServerError';
 
 interface UninstallButtonProps {
@@ -20,6 +21,7 @@ export function UninstallButton({
 }: UninstallButtonProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
+  const { setSelectedConnection } = useConnections();
   const {
     integrationId,
     installation,
@@ -52,7 +54,8 @@ export function UninstallButton({
         console.warn('successfully uninstalled installation:', installation.id);
         onUninstallSuccess?.(installation?.id); // callback
         resetInstallations();
-        setIntegrationDeleted();
+        setSelectedConnection(null); // reset the connection
+        setIntegrationDeleted(); // set the ui terminal deleted state
       } catch (e) {
         console.error('Error uninstalling installation.');
         handleServerError(e);

--- a/src/components/Configure/layout/UninstallButton.tsx
+++ b/src/components/Configure/layout/UninstallButton.tsx
@@ -5,7 +5,6 @@ import { useInstallIntegrationProps } from 'context/InstallIntegrationContextPro
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
 import { Button } from 'src/components/ui-base/Button';
-import { useConnections } from 'src/context/ConnectionsContextProvider';
 import { handleServerError } from 'src/utils/handleServerError';
 
 interface UninstallButtonProps {
@@ -21,7 +20,6 @@ export function UninstallButton({
 }: UninstallButtonProps) {
   const apiKey = useApiKey();
   const { projectId } = useProject();
-  const { setSelectedConnection } = useConnections();
   const {
     integrationId,
     installation,
@@ -54,7 +52,6 @@ export function UninstallButton({
         console.warn('successfully uninstalled installation:', installation.id);
         onUninstallSuccess?.(installation?.id); // callback
         resetInstallations();
-        setSelectedConnection(null); // reset the connection
         setIntegrationDeleted(); // set the ui terminal deleted state
       } catch (e) {
         console.error('Error uninstalling installation.');

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -73,7 +73,7 @@ export function ConnectionsProvider({
     async function fetchConnections() {
       const api = await getAPI();
       if (!projectId) {
-        throw new Error('Project ID not found. ConnectionsProvider must be used within AmpersandProvider');
+        throw new Error('Project ID not found. Component must be used within AmpersandProvider');
       }
       api.connectionApi.listConnections(
         { projectIdOrName: projectId, groupRef, provider: selectedProvider },

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -104,23 +104,27 @@ export function ConnectionsProvider({
       // If the provider has changed, reset the selected connection if it does
       // not match the new provider
       if (selectedConnection.provider !== selectedProvider) {
+        console.warn('Provider has changed, resetting selected connection');
         setSelectedConnection(null);
 
       // if selectedConnection is not in the connections list, reset it
-      } else if (connections) {
+      } else if (connections?.length) {
         const connectionExists = connections.some((conn) => conn.id === selectedConnection.id);
         if (!connectionExists) {
+          console.warn('Selected connection not found in connections list, resetting selected connection');
           setSelectedConnection(null);
         }
       }
     }
+  }, [connections, selectedConnection, selectedProvider]);
 
+  useEffect(() => {
     // If there is no selected connection, select the first connection in the list
     if (!selectedConnection && connections && connections.length > 0) {
       const [connection] = connections;
       setSelectedConnection(connection);
     }
-  }, [connections, selectedConnection, selectedProvider]);
+  }, [connections, selectedConnection]);
 
   const contextValue = useMemo(
     () => ({

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -81,11 +81,6 @@ export function ConnectionsProvider({
         .then((_connections) => {
           setLoadingState(false);
           setConnections(_connections);
-          // If the provider has changed, reset the selected connection if it does
-          // not match the new provider
-          if (selectedConnection && selectedConnection.provider !== selectedProvider) {
-            setSelectedConnection(null);
-          }
         })
         .catch((err) => {
           console.error(
@@ -97,10 +92,35 @@ export function ConnectionsProvider({
         });
     }
 
+    // Fetch connections if connection params change or if the integration was deleted
     if (projectId) {
       fetchConnections();
     }
-  }, [projectId, groupRef, selectedProvider, setError, getAPI, selectedConnection]);
+  }, [projectId, groupRef, selectedProvider, setError, getAPI, isIntegrationDeleted]);
+
+  // connections manager useEffect
+  useEffect(() => {
+    // If the provider has changed, reset the selected connection if it does
+    // not match the new provider
+    if (selectedConnection && selectedConnection.provider !== selectedProvider) {
+      setSelectedConnection(null);
+    }
+
+    // if selectedConnection is not in the connections list, reset it
+    if (selectedConnection && connections) {
+      const connectionExists = connections.some((conn) => conn.id === selectedConnection.id);
+      if (!connectionExists) {
+        console.warn('resetting connection');
+        setSelectedConnection(null);
+      }
+    }
+
+    // If there is no selected connection, select the first connection in the list
+    if (!selectedConnection && connections && connections.length > 0) {
+      const [connection] = connections;
+      setSelectedConnection(connection);
+    }
+  }, [connections, selectedConnection, selectedProvider]);
 
   const contextValue = useMemo(
     () => ({

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -100,18 +100,18 @@ export function ConnectionsProvider({
 
   // connections manager useEffect
   useEffect(() => {
-    // If the provider has changed, reset the selected connection if it does
-    // not match the new provider
-    if (selectedConnection && selectedConnection.provider !== selectedProvider) {
-      setSelectedConnection(null);
-    }
-
-    // if selectedConnection is not in the connections list, reset it
-    if (selectedConnection && connections) {
-      const connectionExists = connections.some((conn) => conn.id === selectedConnection.id);
-      if (!connectionExists) {
-        console.warn('resetting connection');
+    if (selectedConnection) {
+      // If the provider has changed, reset the selected connection if it does
+      // not match the new provider
+      if (selectedConnection.provider !== selectedProvider) {
         setSelectedConnection(null);
+
+      // if selectedConnection is not in the connections list, reset it
+      } else if (connections) {
+        const connectionExists = connections.some((conn) => conn.id === selectedConnection.id);
+        if (!connectionExists) {
+          setSelectedConnection(null);
+        }
       }
     }
 


### PR DESCRIPTION
### Summary
Part 2 rewrite based on feedback from https://github.com/amp-labs/react/pull/786

The uninstall flow will now be connection dependent. 
- delete connection when installation is deleted
- move reinstall layout to connections level
- migrate connections api to use new api service hook

#### demo
##### Salesforce
![hubspot-proxy-uninstall-flow](https://github.com/user-attachments/assets/3673d7d9-3084-4d11-ab64-c2572c432975)

##### Hubspot Proxy
![salesforce-uninstall-flow](https://github.com/user-attachments/assets/f5b4feb9-c0b7-41d8-b84a-c374a3870b23)

