### PR TITLE
[ENG-1784] feat: adds field default ui builder

### DIFF
--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueMapping.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueMapping.tsx
@@ -1,6 +1,8 @@
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 import { FieldHeader } from '../FieldHeader';
 
+import { FieldDefaultValueTable } from './FieldDefaultValueTable';
+
 export function FieldDefaultValueMapping() {
   const {
     configureState,
@@ -13,7 +15,7 @@ export function FieldDefaultValueMapping() {
       {writeObjects.map((field) => (
         <>
           <FieldHeader string={`Defaults for ${field.displayName} `} />
-          <div>new component</div>
+          <FieldDefaultValueTable objectName={field.objectName} />
         </>
       ))}
     </>

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+
+import { Input } from 'src/components/form/Input';
+import { Button } from 'src/components/ui-base/Button';
+
+import { NewDefaultValueUI } from './NewDefaultValueUI';
+
+interface FieldDefaultValueRowProps {
+  objectName: string,
+}
+
+type FieldDefaultValue = {
+  field: string,
+  fieldDisplayName: string,
+  defaultValue: string,
+};
+
+export function FieldDefaultValueTable({
+  objectName,
+}: FieldDefaultValueRowProps) {
+  const [defaultValueList, setDefaultValueList] = useState<FieldDefaultValue[]>([]);
+
+  const onAddDefaultValue = (field: string, fieldDisplayName: string, defaultValue: string) => {
+    if (defaultValueList.some((df) => df.field === field)) {
+      console.error(`Field ${field} already has a default value. Delete to update field default value.`);
+      return;
+    }
+    setDefaultValueList((prev) => [...prev, { field, fieldDisplayName, defaultValue }]);
+  };
+
+  const onDeleteDefaultValue = (field: string) => {
+    setDefaultValueList((prev) => prev.filter((df) => df.field !== field));
+  };
+
+  return (
+    <>
+      <div style={{
+        paddingBottom: '1rem', display: 'flex', flexDirection: 'column', gap: '.5rem',
+      }}
+      >
+        {defaultValueList.length === 0 && <div>No default values</div>}
+        {defaultValueList?.length > 0 && (
+        <div style={{ height: '1rem' }}>
+          <div>Field Default Values</div>
+        </div>
+        )}
+        {defaultValueList.map(({ field, fieldDisplayName, defaultValue: df }) => (
+          <div
+            key={`${field}-${df}`}
+            style={{ display: 'flex', flexDirection: 'row', gap: '.25rem' }}
+          >
+            <Input id={field} type="text" disabled value={fieldDisplayName} style={{ width: '100%' }} />
+            <Input id={`${field}-${df}`} type="text" disabled value={df} style={{ width: '10rem' }} />
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onDeleteDefaultValue(field)}
+            >
+              x
+            </Button>
+          </div>
+        ))}
+      </div>
+      <NewDefaultValueUI objectName={objectName} onAddDefaultValue={onAddDefaultValue} />
+    </>
+  );
+}

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/NewDefaultValueUI.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/NewDefaultValueUI.tsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { HydratedIntegrationFieldExistent } from '@generated/api/src';
+
+import { useHydratedRevision } from 'src/components/Configure/state/HydratedRevisionContext';
+import { getObjectFromAction } from 'src/components/Configure/utils';
+import { Input } from 'src/components/form/Input';
+import { Button } from 'src/components/ui-base/Button';
+import { ComboBox } from 'src/components/ui-base/ComboBox/ComboBox';
+
+type FieldOption = {
+  label: string;
+  value: string;
+};
+
+type NewDefaultValueUIProps = {
+  objectName: string;
+  onAddDefaultValue: (field: string, displayFieldName: string, defaultValue: string) => void;
+};
+
+export function NewDefaultValueUI({ objectName, onAddDefaultValue }: NewDefaultValueUIProps) {
+  const { hydratedRevision, loading } = useHydratedRevision();
+
+  const [selectedField, setSelectedField] = useState<FieldOption | null>(null);
+  const [newDefaultValue, setNewDefaultValue] = useState<string>('');
+
+  // todo: move all hydrated revisions to an immutable providers
+  const readAction = hydratedRevision?.content?.read;
+  const object = readAction && getObjectFromAction(readAction, objectName);
+  const allFields = useMemo(
+    () => object?.allFields as HydratedIntegrationFieldExistent[] || [],
+    [object],
+  );
+
+  const isDisabled = loading || !allFields || allFields.length === 0;
+
+  const items = useMemo(() => (allFields).map((f) => ({
+    id: f.fieldName,
+    label: f.displayName,
+    value: f.fieldName,
+  })), [allFields]);
+
+  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { value, name } = e.target;
+    if (!value) {
+      // if place holder value is chosen, we don't change state
+      return;
+    }
+    setSelectedField({ label: name, value });
+  };
+
+  const onDefaultValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setNewDefaultValue(value);
+  };
+
+  const onAddDefaultValueHelper = () => {
+    if (newDefaultValue && selectedField?.value) {
+      onAddDefaultValue(selectedField?.value, selectedField.label, newDefaultValue);
+      // reset new default value state
+      setSelectedField(null);
+      setNewDefaultValue('');
+    }
+  };
+  const SelectComponet = (
+    <ComboBox
+      style={{ width: '100%' }}
+      disabled={isDisabled}
+      items={items}
+      selectedValue={selectedField?.value || null}
+      onSelectedItemChange={(item) => {
+        onSelectChange({
+          target: {
+            name: item?.label,
+            value: item?.value,
+          } as HTMLSelectElement,
+        } as React.ChangeEvent<HTMLSelectElement>);
+      }}
+      placeholder="Please select field."
+    />
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'row', gap: '.25rem' }}>
+      {SelectComponet}
+      <Input
+        id="new-default-value"
+        type="text"
+        value={newDefaultValue}
+        onChange={onDefaultValueChange}
+        style={{ width: '10rem' }}
+        placeholder="default-value"
+      />
+      <Button type="button" onClick={onAddDefaultValueHelper} variant="ghost">+</Button>
+    </div>
+  );
+}

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -19,6 +19,7 @@ interface ComboBoxProps {
   onSelectedItemChange: (item: Option | null) => void;
   placeholder: string;
   disabled?: boolean;
+  style?: React.CSSProperties;
 }
 
 function getOptionsFilter(inputValue: string) {
@@ -40,6 +41,7 @@ export function ComboBox({
   // label,
   placeholder,
   disabled,
+  style,
 }: ComboBoxProps) {
   const [filteredItems, setFilteredItems] = useState<Option[]>(items);
   const inputRef = useRef<HTMLInputElement | null>(null); // Ref to the input element
@@ -89,7 +91,7 @@ export function ComboBox({
   const handleBlur = () => setInputValue(selectedValueLabel || '');
 
   return (
-    <div>
+    <div style={{ position: 'relative', ...style }}>
       <div className={styles.comboboxContainer}>
         {/* input  */}
         <div className={styles.inputContainer}>


### PR DESCRIPTION
### Summary
creates a new component to add FieldValueDefaults. The change does not update the objectConfiguration state yet and is just a localized component. 
- adds FieldDefaultValueTable component
- adds FieldDefaultValueMapping component
- style: update default value mapping ui styling
- refactor: move new default value UI to separate component

note: this feature is behind an internal FF `DEFAULT_VALUE_FF`

#### followup 
Connect to objectConfiguration state and add save to server functionality.

#### demo
![feat-field-default-value-ui](https://github.com/user-attachments/assets/7687412b-b311-4afa-a257-9a8e69a1ef57)



#### screenshot / dark mode
![Screenshot 2025-01-15 at 2 00 20 PM](https://github.com/user-attachments/assets/948e84ba-c6f1-443e-810c-8f2646483b78)

