### PR TITLE
[ENG-1784] refactor: write objects state in configurationState

### DIFF
--- a/src/components/Configure/actions/write/generateConfigWriteObjects.ts
+++ b/src/components/Configure/actions/write/generateConfigWriteObjects.ts
@@ -1,11 +1,5 @@
 import { ConfigureState } from '../../types';
 
-type WriteObject = {
-  objectName: string;
-};
-type WriteObjects = {
-  [objectName: string]: WriteObject;
-};
 /**
  * example type
  * "objects":
@@ -13,6 +7,10 @@ type WriteObjects = {
     objects: {
       account: {
         objectName: 'account',
+        selectedValueDefaults: {
+          first: 'Joe',
+          lastName: 'Default',
+        },
       },
       contact: {
         objectName: 'contact',
@@ -23,23 +21,6 @@ type WriteObjects = {
  * @param configureState
  * @returns
  */
-export const generateConfigWriteObjects = (configureState: ConfigureState) => {
-  const configWriteObjects: WriteObjects = {}; // `any` is listed type in generated SDK
-  const configStateWriteObjects = configureState.write?.writeObjects;
-  const selected = configureState.write?.selectedNonConfigurableWriteFields;
-  const selectedKeys = selected ? Object.keys(selected) : [];
-
-  if (configStateWriteObjects) {
-    configStateWriteObjects.forEach((configStateWriteObject) => {
-      const obj = configStateWriteObject.objectName;
-      // object exists in config form
-      if (selectedKeys.includes(obj)) {
-        // insert objectName into configWriteObjects
-        configWriteObjects[obj] = {
-          objectName: obj,
-        };
-      }
-    });
-  }
-  return configWriteObjects;
-};
+export const generateConfigWriteObjects = (
+  configureState: ConfigureState,
+) => ({ ...configureState.write?.selectedWriteObjects });

--- a/src/components/Configure/content/fields/WriteFields/WriteFieldsV2.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFieldsV2.tsx
@@ -12,7 +12,7 @@ export function WriteFieldsV2() {
   const {
     appName, selectedObjectName, configureState, setConfigureState,
   } = useSelectedConfigureState();
-  const selectedWriteFields = configureState?.write?.selectedNonConfigurableWriteFields;
+  const selectedWriteFields = configureState?.write?.selectedWriteObjects;
   const writeObjects = configureState?.write?.writeObjects;
 
   const onCheckboxChange = (checked: boolean | 'indeterminate', name: string) => {

--- a/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
+++ b/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
@@ -1,6 +1,6 @@
 import { Draft } from 'immer';
 
-import { isFieldObjectEqual } from '../../../state/utils';
+import { isWriteObjectsEqual } from '../../../state/utils';
 import { ConfigureState } from '../../../types';
 
 function setNonConfigurableWriteFieldProducer(
@@ -8,29 +8,34 @@ function setNonConfigurableWriteFieldProducer(
   fieldKey: string,
   checked: boolean,
 ) {
-  if (draft?.write?.selectedNonConfigurableWriteFields === null) {
+  if (draft?.write?.selectedWriteObjects === null) {
     // immer syntax to set a value
     // eslint-disable-next-line no-param-reassign
-    draft.write.selectedNonConfigurableWriteFields = {};
+    draft.write.selectedWriteObjects = {};
   }
 
   if (draft?.write) {
-    const draftSelectedWriteFields = draft.write.selectedNonConfigurableWriteFields;
-    draftSelectedWriteFields[fieldKey] = checked;
+    const draftSelectedWriteFields = draft.write.selectedWriteObjects;
+    if (checked) {
+      draftSelectedWriteFields[fieldKey] = { objectName: fieldKey };
+    }
 
     if (!checked) {
       delete draftSelectedWriteFields[fieldKey];
     }
 
     // check is modified
-    if (draft?.write?.savedConfig?.selectedNonConfigurableWriteFields) {
-      const savedFields = draft.write.savedConfig.selectedNonConfigurableWriteFields;
-      const updatedFields = draftSelectedWriteFields;
-      const isModified = !isFieldObjectEqual(savedFields, updatedFields);
+    if (draft?.write?.savedConfig?.selectedWriteObjects) {
+      const savedWriteObjects = draft.write.savedConfig.selectedWriteObjects;
+      const updatedWriteObjects = draftSelectedWriteFields;
+      const isModified = !isWriteObjectsEqual(savedWriteObjects, updatedWriteObjects);
       // immer syntax to set a value
       // eslint-disable-next-line no-param-reassign
       draft.write.isWriteModified = isModified;
     }
+
+    // DEBUG: print out the draft
+    // console.debug(JSON.stringify(draft, null, 2));
   }
 }
 

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -13,7 +13,7 @@ import {
   ConfigureStateRead,
   ConfigureStateWrite,
   ObjectConfigurationsState,
-  SelectedNonConfigurableWriteFields,
+  SelectedWriteObjects,
   SelectMappingFields,
   SelectOptionalFields,
 } from '../types';
@@ -25,6 +25,14 @@ import {
   getRequiredFieldsFromObject,
   getRequiredMapFieldsFromObject,
 } from '../utils';
+
+// uses lodash deep equality check to compare two saved write objects (typed checked)
+export function isWriteObjectsEqual(
+  prevWriteObjects: SelectedWriteObjects,
+  currentWriteObjects: SelectedWriteObjects,
+): boolean {
+  return isEqual(prevWriteObjects, currentWriteObjects);
+}
 
 // uses lodash deep equality check to compare two saved fields objects
 export function isFieldObjectEqual(
@@ -92,18 +100,13 @@ const generateConfigurationStateWrite = (
   }
 
   const writeObjects = config?.content?.write?.objects;
-  const fields = Object.keys(writeObjects || {});
-
-  const selectedWriteFields: SelectedNonConfigurableWriteFields = {};
-  fields.forEach((field) => { selectedWriteFields[field] = true; });
-  const savedFields = { ...selectedWriteFields };
 
   return {
     writeObjects: writeAction?.objects || [],
-    selectedNonConfigurableWriteFields: selectedWriteFields,
+    selectedWriteObjects: writeObjects || {},
     isWriteModified: false,
     savedConfig: {
-      selectedNonConfigurableWriteFields: savedFields,
+      selectedWriteObjects: writeObjects || {},
     },
   };
 };

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -1,22 +1,24 @@
 import {
+  BaseWriteConfigObject,
   HydratedIntegrationField,
   HydratedIntegrationFieldExistent,
   HydratedIntegrationWriteObject,
   IntegrationFieldMapping,
 } from 'services/api';
 
-export type SelectedNonConfigurableWriteFields = {
-  [key: string]: boolean,
+export type SelectedWriteObjects = {
+  [objectName: string]: BaseWriteConfigObject,
 };
 
 type SavedWriteConfigureState = {
-  selectedNonConfigurableWriteFields: SelectedNonConfigurableWriteFields,
+  selectedWriteObjects: SelectedWriteObjects,
 };
 
 // write state slice
+// currently tracks all write objects insteaad of just a single objectname
 export type ConfigureStateWrite = {
   writeObjects: HydratedIntegrationWriteObject[] | null,
-  selectedNonConfigurableWriteFields: SelectedNonConfigurableWriteFields | null,
+  selectedWriteObjects: SelectedWriteObjects | null,
   isWriteModified: boolean,
   savedConfig: SavedWriteConfigureState, // check when to know if config is saved / modified
 };
@@ -58,7 +60,7 @@ type SavedConfigureState = {
 export type ConfigureState = {
   // read state slice
   read: ConfigureStateRead | null,
-  // separating write for possible state slice
+  // separating write for possible state slice in the future
   write: ConfigureStateWrite | null,
 };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 import {
   BackfillConfig,
+  BaseWriteConfigObject,
   Config,
   Configuration, Connection,
   CreateInstallationOperationRequest,
@@ -145,6 +146,7 @@ export function useAPI(): () => Promise<ApiService> {
    */
 export type {
   BackfillConfig,
+  BaseWriteConfigObject,
   Config,
   Connection,
   CreateInstallationOperationRequest,


### PR DESCRIPTION
### Summary
Simplify and prep the write draft state to allow tracking write access in both non-configure state and configure state (type includes default value field)
- remove old array transformation logic
- use config type when setting write objects in form

#### testing
![write-state-refactor](https://github.com/user-attachments/assets/c29177c3-76d1-4e40-82de-f0e77ae9ef7a)

