### PR TITLE
[ENG-1805] Bug: field mapping should not persist old mappings

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -32,7 +32,7 @@ export function FieldMapping(
       setFieldMapping(selectedObjectName, setConfigureState, [{
         field: field.mapToName,
         value: field._default,
-      }]);g
+      }]);
     }
     setDisabled(false);
   }, [field, setConfigureState, selectedObjectName, fieldValue, configureState]);

--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -29,7 +29,11 @@ export function FieldMapping(
     /* eslint no-underscore-dangle: ["error", { "allow": ["_default"] }] */
     if (!!field._default && !fieldValue && selectedObjectName && !!configureState) {
       // set field mapping default value if no value exists
-      setFieldMapping(selectedObjectName, setConfigureState, field.mapToName, field._default);
+      setFieldMapping(selectedObjectName, setConfigureState, [{
+        field: field.mapToName,
+        value: field._default,
+        idDeleted: false,
+      }]);
     }
     setDisabled(false);
   }, [field, setConfigureState, selectedObjectName, fieldValue, configureState]);

--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -32,8 +32,7 @@ export function FieldMapping(
       setFieldMapping(selectedObjectName, setConfigureState, [{
         field: field.mapToName,
         value: field._default,
-        idDeleted: false,
-      }]);
+      }]);g
     }
     setDisabled(false);
   }, [field, setConfigureState, selectedObjectName, fieldValue, configureState]);

--- a/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
@@ -21,7 +21,13 @@ export function OptionalFieldMappings() {
     }
 
     if (selectedObjectName) {
-      setFieldMapping(selectedObjectName, setConfigureState, name, value);
+      setFieldMapping(selectedObjectName, setConfigureState, [
+        {
+          field: name,
+          value,
+          idDeleted: false,
+        },
+      ]);
     }
 
     if (isError(ErrorBoundary.MAPPING, name)) {

--- a/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
@@ -25,7 +25,6 @@ export function OptionalFieldMappings() {
         {
           field: name,
           value,
-          idDeleted: false,
         },
       ]);
     }

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -18,6 +18,26 @@ export function RequiredFieldMappings() {
   const { fieldMapping } = useInstallIntegrationProps();
   const { isError, removeError } = useErrorState();
 
+  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const { value, name } = e.target;
+    if (!value) {
+      // if place holder value is chosen, we don't change state
+      return;
+    }
+
+    if (selectedObjectName) {
+      setFieldMapping(selectedObjectName, setConfigureState, [{
+        field: name,
+        value,
+        idDeleted: false,
+      }]);
+    }
+
+    if (isError(ErrorBoundary.MAPPING, name)) {
+      removeError(ErrorBoundary.MAPPING, name);
+    }
+  };
+
   const integrationFieldMappings = useMemo(() => {
     // 1. Extract required map fields from configureState
     const requiredFieldMappings = configureState?.read?.requiredMapFields || [];
@@ -38,26 +58,6 @@ export function RequiredFieldMappings() {
 
     return combinedFieldMappings;
   }, [configureState, fieldMapping, selectedObjectName]);
-
-  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const { value, name } = e.target;
-    if (!value) {
-      // if place holder value is chosen, we don't change state
-      return;
-    }
-
-    if (selectedObjectName) {
-      setFieldMapping(selectedObjectName, setConfigureState, [{
-        field: name,
-        value,
-        idDeleted: false,
-      }]);
-    }
-
-    if (isError(ErrorBoundary.MAPPING, name)) {
-      removeError(ErrorBoundary.MAPPING, name);
-    }
-  };
 
   const selectedFieldMappings = configureState?.read?.selectedFieldMappings || {};
   const selectedKeys = Object.keys(selectedFieldMappings);

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -65,6 +65,7 @@ export function RequiredFieldMappings() {
   const outdatedKeys = findOutdatedKeys(selectedKeys, allowedKeys);
 
   if (!!selectedObjectName && outdatedKeys.length) {
+    // For old field mappings that have now been removed by the builder, unset the values for those keys.
     setFieldMapping(selectedObjectName, setConfigureState, outdatedKeys.map((key) => ({
       field: key,
       value: null,

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -11,7 +11,7 @@ import { FieldHeader } from '../FieldHeader';
 import { FieldMapping } from './FieldMapping';
 import { setFieldMapping } from './setFieldMapping';
 
-const findDeprecatedKeys = (selectedKeys: string[], allowedKeys: string[]) => selectedKeys.filter((key) => !allowedKeys.includes(key));
+const findOutdatedKeys = (selectedKeys: string[], allowedKeys: string[]) => selectedKeys.filter((key) => !allowedKeys.includes(key));
 
 export function RequiredFieldMappings() {
   const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
@@ -29,7 +29,6 @@ export function RequiredFieldMappings() {
       setFieldMapping(selectedObjectName, setConfigureState, [{
         field: name,
         value,
-        idDeleted: false,
       }]);
     }
 
@@ -63,13 +62,12 @@ export function RequiredFieldMappings() {
   const selectedKeys = Object.keys(selectedFieldMappings);
   const allowedKeys = integrationFieldMappings.map((field) => field.mapToName);
 
-  const deprecatedKeys = findDeprecatedKeys(selectedKeys, allowedKeys);
+  const outdatedKeys = findOutdatedKeys(selectedKeys, allowedKeys);
 
-  if (!!selectedObjectName && deprecatedKeys.length) {
-    setFieldMapping(selectedObjectName, setConfigureState, deprecatedKeys.map((key) => ({
+  if (!!selectedObjectName && outdatedKeys.length) {
+    setFieldMapping(selectedObjectName, setConfigureState, outdatedKeys.map((key) => ({
       field: key,
-      value: '',
-      idDeleted: true,
+      value: null,
     })));
 
     return null;

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -11,6 +11,8 @@ import { FieldHeader } from '../FieldHeader';
 import { FieldMapping } from './FieldMapping';
 import { setFieldMapping } from './setFieldMapping';
 
+const findDeprecatedKeys = (selectedKeys: string[], allowedKeys: string[]) => selectedKeys.filter((key) => !allowedKeys.includes(key));
+
 export function RequiredFieldMappings() {
   const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
   const { fieldMapping } = useInstallIntegrationProps();
@@ -70,11 +72,9 @@ export function RequiredFieldMappings() {
       idDeleted: true,
     })));
 
-    return null
+    return null;
   }
 
-
-  console.log(integrationFieldMappings)
   return integrationFieldMappings?.length ? (
     <>
       <FieldHeader string="Map the following fields" />
@@ -96,9 +96,4 @@ export function RequiredFieldMappings() {
       </div>
     </>
   ) : null;
-}
-
-
-const findDeprecatedKeys = (selectedKeys: string[], allowedKeys: string[]) => {
-  return selectedKeys.filter((key) => !allowedKeys.includes(key));
 }

--- a/src/components/Configure/content/fields/FieldMappings/setFieldMapping.ts
+++ b/src/components/Configure/content/fields/FieldMappings/setFieldMapping.ts
@@ -9,7 +9,6 @@ export type MappingFields = {
   idDeleted: boolean
 };
 
-
 function setFieldMappingProducer(
   draft: Draft<ConfigureState>,
   fields: Array<MappingFields>,
@@ -23,8 +22,7 @@ function setFieldMappingProducer(
     } else {
       draftRequiredMapFields[field] = value;
     }
-  })
-
+  });
 
   if (draft?.read) {
     const savedFields = draft.read.savedConfig.requiredMapFields;

--- a/src/components/Configure/content/fields/FieldMappings/setFieldMapping.ts
+++ b/src/components/Configure/content/fields/FieldMappings/setFieldMapping.ts
@@ -3,13 +3,29 @@ import { Draft } from 'immer';
 import { isFieldObjectEqual } from '../../../state/utils';
 import { ConfigureState } from '../../../types';
 
+export type MappingFields = {
+  field: string
+  value: string
+  idDeleted: boolean
+};
+
+
 function setFieldMappingProducer(
   draft: Draft<ConfigureState>,
-  fieldKey: string,
-  newValue: string,
+  fields: Array<MappingFields>,
 ) {
   const draftRequiredMapFields = draft?.read?.selectedFieldMappings || {};
-  draftRequiredMapFields[fieldKey] = newValue;
+
+  fields.forEach((mapping) => {
+    const { field, value, idDeleted } = mapping;
+    if (idDeleted) {
+      delete draftRequiredMapFields[field];
+    } else {
+      draftRequiredMapFields[field] = value;
+    }
+  })
+
+
   if (draft?.read) {
     const savedFields = draft.read.savedConfig.requiredMapFields;
     const updatedFields = draftRequiredMapFields;
@@ -24,11 +40,10 @@ export function setFieldMapping(
   selectedObjectName: string,
   setConfigureState: (objectName: string,
     producer: (draft: Draft<ConfigureState>) => void) => void,
-  fieldKey: string,
-  newValue: string,
+  fields: Array<MappingFields>,
 ) {
   setConfigureState(
     selectedObjectName,
-    (draft) => setFieldMappingProducer(draft, fieldKey, newValue),
+    (draft) => setFieldMappingProducer(draft, fields),
   );
 }

--- a/src/components/Configure/content/fields/FieldMappings/setFieldMapping.ts
+++ b/src/components/Configure/content/fields/FieldMappings/setFieldMapping.ts
@@ -5,8 +5,7 @@ import { ConfigureState } from '../../../types';
 
 export type MappingFields = {
   field: string
-  value: string
-  idDeleted: boolean
+  value: string | null
 };
 
 function setFieldMappingProducer(
@@ -16,8 +15,8 @@ function setFieldMappingProducer(
   const draftRequiredMapFields = draft?.read?.selectedFieldMappings || {};
 
   fields.forEach((mapping) => {
-    const { field, value, idDeleted } = mapping;
-    if (idDeleted) {
+    const { field, value } = mapping;
+    if (value === null) {
       delete draftRequiredMapFields[field];
     } else {
       draftRequiredMapFields[field] = value;


### PR DESCRIPTION
This PR fixes the field mapping bug where the field mapToName fed to `<InstallIntegration>` component changes, bug was introduced because previously selected mappings were not removed even thought it is removed from UI. 

This PR removes deprecated mappings that was present prior to code change to builders. 

## Test Results
- Before Update
![Screenshot 2025-01-16 at 3 36 54 PM](https://github.com/user-attachments/assets/a8742c31-c94f-48ac-b3bc-a4a1957adea4)

- After Code Update and updating installation
![Screenshot 2025-01-16 at 3 37 00 PM](https://github.com/user-attachments/assets/1298c9d9-6ba0-46d1-89a9-d3d8a6c76a6f)
