### PR TITLE
[ENG-1784] feat: add state management for value default write

### DIFF
--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueMapping.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueMapping.tsx
@@ -7,17 +7,27 @@ export function FieldDefaultValueMapping() {
   const {
     configureState,
   } = useSelectedConfigureState();
+
   const writeObjects = configureState?.write?.writeObjects;
+  const selectedWriteObjects = configureState?.write?.selectedWriteObjects;
   const shouldRender = !!(writeObjects);
+
   return (
     shouldRender && (
     <>
-      {writeObjects.map((field) => (
-        <>
-          <FieldHeader string={`Defaults for ${field.displayName} `} />
-          <FieldDefaultValueTable objectName={field.objectName} />
-        </>
-      ))}
+      {writeObjects.map((field) => {
+        // only render default value if the object has write access.
+        // TODO: add check to hydrated revision: valueDefaults.allowAnyFields
+        if (selectedWriteObjects?.[field.objectName]) {
+          return (
+            <>
+              <FieldHeader string={`Defaults for ${field.displayName} `} />
+              <FieldDefaultValueTable objectName={field.objectName} />
+            </>
+          );
+        }
+        return null;
+      })}
     </>
     )
   );

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
@@ -46,12 +46,6 @@ export function FieldDefaultValueTable({
         paddingBottom: '1rem', display: 'flex', flexDirection: 'column', gap: '.5rem',
       }}
       >
-        {defaultValueList.length === 0 && <div>No default values</div>}
-        {defaultValueList?.length > 0 && (
-        <div style={{ height: '1rem' }}>
-          <div>Field Default Values</div>
-        </div>
-        )}
         {defaultValueList.map(({ field, fieldDisplayName, defaultValue: df }) => (
           <div
             key={`${field}-${df}`}
@@ -70,6 +64,13 @@ export function FieldDefaultValueTable({
         ))}
       </div>
       <NewDefaultValueUI objectName={objectName} onAddDefaultValue={onAddDefaultValue} />
+      <div style={{
+        textAlign: 'right',
+        padding: '.25rem 0',
+        color: 'var(--amp-colors-text-muted)',
+      }}
+      >click + to confirm
+      </div>
     </>
   );
 }

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { Input } from 'src/components/form/Input';
 import { Button } from 'src/components/ui-base/Button';
 
+import { useSelectedConfigureState } from '../../useSelectedConfigureState';
+
 import { NewDefaultValueUI } from './NewDefaultValueUI';
+import { setValueDefaultWriteField } from './setValueDefaultWriteField';
 
 interface FieldDefaultValueRowProps {
   objectName: string,
@@ -18,19 +21,24 @@ type FieldDefaultValue = {
 export function FieldDefaultValueTable({
   objectName,
 }: FieldDefaultValueRowProps) {
-  const [defaultValueList, setDefaultValueList] = useState<FieldDefaultValue[]>([]);
+  const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
+  const selectedWriteObjects = configureState?.write?.selectedWriteObjects;
+  const writeObject = selectedWriteObjects?.[objectName];
+  const selectedValueDefaultsMap = useMemo(() => writeObject?.selectedValueDefaults || {}, [writeObject]);
 
-  const onAddDefaultValue = (field: string, fieldDisplayName: string, defaultValue: string) => {
-    if (defaultValueList.some((df) => df.field === field)) {
-      console.error(`Field ${field} already has a default value. Delete to update field default value.`);
-      return;
-    }
-    setDefaultValueList((prev) => [...prev, { field, fieldDisplayName, defaultValue }]);
-  };
+  const onAddDefaultValue = useCallback((field: string, fieldDisplayName: string, defaultValue: string) => {
+    setValueDefaultWriteField(selectedObjectName || '', objectName, field, defaultValue, setConfigureState);
+  }, [objectName, selectedObjectName, setConfigureState]);
 
   const onDeleteDefaultValue = (field: string) => {
-    setDefaultValueList((prev) => prev.filter((df) => df.field !== field));
+    setValueDefaultWriteField(selectedObjectName || '', objectName, field, null, setConfigureState);
   };
+
+  const defaultValueList: FieldDefaultValue[] = Object.keys(selectedValueDefaultsMap).map((field) => ({
+    field,
+    defaultValue: selectedValueDefaultsMap[field],
+    fieldDisplayName: field, // update to use field display name
+  }));
 
   return (
     <>

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/NewDefaultValueUI.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/NewDefaultValueUI.tsx
@@ -88,7 +88,7 @@ export function NewDefaultValueUI({ objectName, onAddDefaultValue }: NewDefaultV
         value={newDefaultValue}
         onChange={onDefaultValueChange}
         style={{ width: '10rem' }}
-        placeholder="default-value"
+        placeholder="default value"
       />
       <Button type="button" onClick={onAddDefaultValueHelper} variant="ghost">+</Button>
     </div>

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/setValueDefaultWriteField.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/setValueDefaultWriteField.tsx
@@ -1,0 +1,70 @@
+import { Draft } from 'immer';
+
+import { isWriteObjectsEqual } from '../../../state/utils';
+import { ConfigureState } from '../../../types';
+
+function setValueDefaultWriteFieldProducer(
+  draft: Draft<ConfigureState>,
+  objectName: string, // object that the field belongs to
+  fieldKey: string,
+  defaultValue: string | null,
+) {
+  if (draft?.write?.selectedWriteObjects === null) {
+    // eslint-disable-next-line no-param-reassign
+    draft.write.selectedWriteObjects = {};
+  }
+
+  if (draft?.write) {
+    const draftSelectedWriteFields = draft.write.selectedWriteObjects;
+    if (defaultValue) {
+      if (!draftSelectedWriteFields[objectName]) {
+        draftSelectedWriteFields[objectName] = { };
+      }
+
+      if (!draftSelectedWriteFields[objectName].selectedValueDefaults) {
+        draftSelectedWriteFields[objectName].selectedValueDefaults = {};
+      }
+
+      // eslint-disable-next-line no-param-reassign
+      draftSelectedWriteFields[objectName].selectedValueDefaults[fieldKey] = defaultValue;
+    }
+
+    if (!defaultValue) {
+      if (draftSelectedWriteFields[objectName]?.selectedValueDefaults) {
+        // delete the field key if the default value is null / empty
+        delete draftSelectedWriteFields[objectName].selectedValueDefaults[fieldKey];
+      }
+    }
+
+    // check is modified
+    if (draft?.write?.savedConfig?.selectedWriteObjects) {
+      const savedWriteObjects = draft.write.savedConfig.selectedWriteObjects;
+      const updatedWriteObjects = draftSelectedWriteFields;
+      const isModified = !isWriteObjectsEqual(savedWriteObjects, updatedWriteObjects);
+      // immer syntax to set a value
+      // eslint-disable-next-line no-param-reassign
+      draft.write.isWriteModified = isModified;
+    }
+
+    // DEBUG: print out the draft
+    // console.debug('Set default value', JSON.stringify(draft?.write, null, 2));
+  }
+}
+
+export function setValueDefaultWriteField(
+  // Note: this needs to be the selected tab object name, which is the "WRITE" tab object name
+  selectedObjectName: string, // "WRITE" object for write tab.
+  // Note: this is the object name of the object that the field belongs to
+  objectName: string,
+  fieldKey: string,
+  defaultValue: string | null,
+  setConfigureState: (objectName: string,
+    producer: (draft: Draft<ConfigureState>) => void) => void,
+) {
+  setConfigureState(
+    selectedObjectName, // "WRITE" object, for write tab
+    (draft) => {
+      setValueDefaultWriteFieldProducer(draft, objectName, fieldKey, defaultValue);
+    },
+  );
+}


### PR DESCRIPTION
### Summary
- add "add" ability for default value write field state
- add "delete" ability for default value write field state
- adds setValueDefaultWriteField producer to modify state (using immer)
- supports showing/hiding default value mapping section only when write access is selected.
- save / modify functionality 

note: This feature is still behind feature flag `DEFAULT_VALUE_FF `. You will need to manually set this in the code to turn this on.

#### followup
Add display name support to fields for default value (needs to fetch from hydrated revision)

#### demo
![default-value-state-managment](https://github.com/user-attachments/assets/1e68ac2d-176f-4652-bfb7-3e8aa62f3e3f)

#### updated ui based on feedback

![Screenshot 2025-01-16 at 5 32 24 PM](https://github.com/user-attachments/assets/9c3a8528-c22c-4af1-a5fa-4465150fc4c3)
