### PR TITLE
[ENG-1768] feat: allow multiple fields per object for value mapping

### DIFF
--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -64,13 +64,17 @@ export function ValueMappings() {
 
   useEffect(() => {
     if (selectedObjectName && selectedMappings) {
-      // assuming the selectedObject only has one field with mappedValues array
-      const valueMappingsForObject = fieldMapping?.[selectedObjectName].find((f) => f.fieldName)!;
+      // Find all fields that have mappedValues
+      const fieldsWithMappings = fieldMapping?.[selectedObjectName]
+        .filter((f) => f.fieldName && f.mappedValues!.length > 0) || [];
 
-      const allValuesMapped = Object.keys(selectedMappings[Object.keys(selectedMappings)[0]] || {}).length
-        === Object.keys(valueMappingsForObject?.mappedValues || []).length;
+      // Check if all values are mapped for all fields
+      const allFieldsFullyMapped = fieldsWithMappings.every((field) => {
+        const mappingsForField = selectedMappings[field.fieldName!] || {};
+        return Object.keys(mappingsForField).length === Object.keys(field.mappedValues!).length;
+      });
 
-      if (allValuesMapped) {
+      if (allFieldsFullyMapped && fieldsWithMappings.length > 0) {
         // Only set modified flag if we haven't set it before and it's currently false
         if (!isValueMappingsModified && !hasSetModified.current) {
           setValueMappingModified(selectedObjectName, setConfigureState, true);


### PR DESCRIPTION
**This PR allows multiple fields per object to be saved with value mapping.**

<img width="640" alt="Screenshot 2025-01-17 at 5 51 03 PM" src="https://github.com/user-attachments/assets/7a217495-252f-436a-aae6-6c0031024782" />

<img width="1512" alt="Screenshot 2025-01-17 at 5 50 19 PM" src="https://github.com/user-attachments/assets/4515770b-3ca3-42ef-967a-a4f87b85d474" />





**The "save" button only gets enabled when all the fields are fully mapped with values:** 

<img width="635" alt="Screenshot 2025-01-17 at 6 07 41 PM" src="https://github.com/user-attachments/assets/968b427c-bece-4c84-bfa0-2bb2e90469b7" />
