### PR TITLE
[ENG-1784] feat: adds displayName lookup to field default value list

### DIFF
--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { HydratedIntegrationFieldExistent, HydratedIntegrationRead } from 'services/api';
+import { HydratedIntegrationRead } from 'services/api';
 import { useHydratedRevision } from 'src/components/Configure/state/HydratedRevisionContext';
 import { getObjectFromAction } from 'src/components/Configure/utils';
 import { Input } from 'src/components/form/Input';
@@ -32,8 +32,8 @@ const getDisplayNameFromField = (
   readAction: HydratedIntegrationRead,
 ) => {
   const object = readAction && getObjectFromAction(readAction, objectName);
-  const allFields = object?.allFields as HydratedIntegrationFieldExistent[] || [];
-  return allFields.find((_field) => _field.fieldName === field)?.displayName || field;
+  const allFieldsMetadata = object?.allFieldsMetadata;
+  return allFieldsMetadata?.[field]?.displayName || field;
 };
 
 export function FieldDefaultValueTable({

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/NewDefaultValueUI.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/NewDefaultValueUI.tsx
@@ -18,13 +18,10 @@ type NewDefaultValueUIProps = {
 };
 
 export function NewDefaultValueUI({ objectName, onAddDefaultValue }: NewDefaultValueUIProps) {
-  const { hydratedRevision, loading } = useHydratedRevision();
-
+  const { readAction, loading } = useHydratedRevision();
   const [selectedField, setSelectedField] = useState<FieldOption | null>(null);
   const [newDefaultValue, setNewDefaultValue] = useState<string>('');
 
-  // todo: move all hydrated revisions to an immutable providers
-  const readAction = hydratedRevision?.content?.read;
   const object = readAction && getObjectFromAction(readAction, objectName);
   const allFields = useMemo(
     () => object?.allFields as HydratedIntegrationFieldExistent[] || [],

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -8,7 +8,7 @@ import {
   ErrorBoundary, useErrorState,
 } from 'context/ErrorContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
-import { api, HydratedRevision } from 'services/api';
+import { api, HydratedIntegrationRead, HydratedRevision } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { ComponentContainerError } from '../ComponentContainer';
@@ -16,11 +16,13 @@ import { ComponentContainerError } from '../ComponentContainer';
 interface HydratedRevisionContextValue {
   hydratedRevision: HydratedRevision | null;
   loading: boolean;
+  readAction?: HydratedIntegrationRead;
 }
 
 export const HydratedRevisionContext = createContext<HydratedRevisionContextValue>({
   hydratedRevision: null,
   loading: false,
+  readAction: undefined,
 });
 
 export const useHydratedRevision = () => {
@@ -98,6 +100,7 @@ export function HydratedRevisionProvider({
   const contextValue = useMemo(() => ({
     hydratedRevision,
     loading,
+    readAction: hydratedRevision?.content?.read,
   }), [hydratedRevision, loading]);
 
   if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {


### PR DESCRIPTION
### Summary 
This PR adds the default value displayname looked up via the hydratedRevision.
- adds readAction into hydratedRevision context

#### screenshot
Displayname "Account Currency" is pulled correctly.
<img width="423" alt="Screenshot 2025-01-17 at 10 04 42 AM" src="https://github.com/user-attachments/assets/38ad0f4e-2849-4a5d-b464-01c3fc4ed21f" />
