### PR TITLE
[ENG-1784] feat: checks hydratedRevision if default values are allowed

### DIFF
--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueMapping.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/FieldDefaultValueMapping.tsx
@@ -1,14 +1,25 @@
+import { HydratedIntegrationWriteObject } from '@generated/api/src';
+
+import { useHydratedRevision } from 'src/components/Configure/state/HydratedRevisionContext';
+
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 import { FieldHeader } from '../FieldHeader';
 
 import { FieldDefaultValueTable } from './FieldDefaultValueTable';
+
+// checks if the object supports default values from hydratedRevision
+const isFieldDefaultValueSupported = (
+  objectName: string,
+  writeObjects: HydratedIntegrationWriteObject[],
+) => !!writeObjects.find((writeObject) => writeObject.objectName === objectName
+   && writeObject?.valueDefaults?.allowAnyFields);
 
 export function FieldDefaultValueMapping() {
   const {
     configureState,
   } = useSelectedConfigureState();
 
-  const writeObjects = configureState?.write?.writeObjects;
+  const { writeObjects } = useHydratedRevision();
   const selectedWriteObjects = configureState?.write?.selectedWriteObjects;
   const shouldRender = !!(writeObjects);
 
@@ -17,8 +28,9 @@ export function FieldDefaultValueMapping() {
     <>
       {writeObjects.map((field) => {
         // only render default value if the object has write access.
-        // TODO: add check to hydrated revision: valueDefaults.allowAnyFields
-        if (selectedWriteObjects?.[field.objectName]) {
+        if (selectedWriteObjects?.[field.objectName]
+          // check to hydrated revision for support - valueDefaults.allowAnyFields
+          && isFieldDefaultValueSupported(field.objectName, writeObjects)) {
           return (
             <>
               <FieldHeader string={`Defaults for ${field.displayName} `} />

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -8,7 +8,9 @@ import {
   ErrorBoundary, useErrorState,
 } from 'context/ErrorContextProvider';
 import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
-import { api, HydratedIntegrationRead, HydratedRevision } from 'services/api';
+import {
+  api, HydratedIntegrationRead, HydratedIntegrationWriteObject, HydratedRevision,
+} from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { ComponentContainerError } from '../ComponentContainer';
@@ -17,12 +19,14 @@ interface HydratedRevisionContextValue {
   hydratedRevision: HydratedRevision | null;
   loading: boolean;
   readAction?: HydratedIntegrationRead;
+  writeObjects: HydratedIntegrationWriteObject[];
 }
 
 export const HydratedRevisionContext = createContext<HydratedRevisionContextValue>({
   hydratedRevision: null,
   loading: false,
   readAction: undefined,
+  writeObjects: [],
 });
 
 export const useHydratedRevision = () => {
@@ -101,6 +105,7 @@ export function HydratedRevisionProvider({
     hydratedRevision,
     loading,
     readAction: hydratedRevision?.content?.read,
+    writeObjects: hydratedRevision?.content?.write?.objects || [],
   }), [hydratedRevision, loading]);
 
   if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {


### PR DESCRIPTION
### Summary
checks hydratedRevision if default values are allowed
- moves write objects to hydrated revision 

note: this feature is hidden behind internal feature flag`DEFAULT_VALUE_FF`

#### end to end testing 
resolved: ~https://ampersand-company.slack.com/archives/D059B9LTELS/p1737140314929909~

#### screenshot
<img width="817" alt="Screenshot 2025-01-17 at 11 10 32 AM" src="https://github.com/user-attachments/assets/6594467f-dbd2-483c-9065-5be6169a2ff3" />

##### hidden as not deployed in manifest
<img width="840" alt="Screenshot 2025-01-17 at 11 12 08 AM" src="https://github.com/user-attachments/assets/9e6131b4-8e0a-4aaf-b64c-9b9af21014ce" />

