### PR TITLE
[ENG-1818] fix: optional field mappings

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMapping.tsx
@@ -25,8 +25,8 @@ export function FieldMapping(
   const { configureState, selectedObjectName, setConfigureState } = useSelectedConfigureState();
   const [disabled, setDisabled] = useState(true);
 
-  const selectedRequiredMapFields = configureState?.read?.selectedFieldMappings;
-  const fieldValue = selectedRequiredMapFields?.[field.mapToName];
+  const selectedFieldMappings = configureState?.read?.selectedFieldMappings;
+  const fieldValue = selectedFieldMappings?.[field.mapToName];
 
   useEffect(() => {
     /* eslint no-underscore-dangle: ["error", { "allow": ["_default"] }] */

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -62,8 +62,11 @@ export function RequiredFieldMappings() {
 
   const selectedFieldMappings = configureState?.read?.selectedFieldMappings || {};
   const selectedKeys = Object.keys(selectedFieldMappings);
-  const allowedKeys = integrationFieldMappings.map((field) => field.mapToName);
 
+  // Get allowed fields (not oudated) from required mappings, optional mappings, and dynamic mappings
+  const optionalFieldMappings = configureState?.read?.optionalMapFields || [];
+  const allMappings = integrationFieldMappings.concat(optionalFieldMappings);
+  const allowedKeys = allMappings.map((field) => field.mapToName);
   const outdatedKeys = findOutdatedKeys(selectedKeys, allowedKeys);
 
   if (!!selectedObjectName && outdatedKeys.length) {


### PR DESCRIPTION
### Summary 
Optional field mappings were broken. 
- fixes outdated keys to include checking optional fields

**root cause**: broken field mappings occur when the amp.yaml spec or dynamic fields are updated yet the field still exists in the config. There is a filter that checks dynamic and required fields. Optional fields were not checked in the filter so the optional fields were always set to null. 

#### Followup
Logic living in required field mappings made difficult to debug for broken optional fields. 

**followup:** Refactor outdated keys logic to be easier to find. Unset logic currently renders every time config is updated in the required fields directory affecting optional state. 

#### Demo

![fix-optional-fields](https://github.com/user-attachments/assets/a94c9ff4-5bf9-4235-882b-1a4f083f5802)

