### PR TITLE
[ENG-1818] refactor: clear old field mappings

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -11,8 +11,6 @@ import { FieldHeader } from '../FieldHeader';
 import { FieldMapping } from './FieldMapping';
 import { setFieldMapping } from './setFieldMapping';
 
-const findOutdatedKeys = (selectedKeys: string[], allowedKeys: string[]) => selectedKeys.filter((key) => !allowedKeys.includes(key));
-
 export function RequiredFieldMappings() {
   const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
   const { fieldMapping } = useInstallIntegrationProps();
@@ -59,25 +57,6 @@ export function RequiredFieldMappings() {
 
     return combinedFieldMappings;
   }, [configureState, fieldMapping, selectedObjectName]);
-
-  const selectedFieldMappings = configureState?.read?.selectedFieldMappings || {};
-  const selectedKeys = Object.keys(selectedFieldMappings);
-
-  // Get allowed fields (not oudated) from required mappings, optional mappings, and dynamic mappings
-  const optionalFieldMappings = configureState?.read?.optionalMapFields || [];
-  const allMappings = integrationFieldMappings.concat(optionalFieldMappings);
-  const allowedKeys = allMappings.map((field) => field.mapToName);
-  const outdatedKeys = findOutdatedKeys(selectedKeys, allowedKeys);
-
-  if (!!selectedObjectName && outdatedKeys.length) {
-    // For old field mappings that have now been removed by the builder, unset the values for those keys.
-    setFieldMapping(selectedObjectName, setConfigureState, outdatedKeys.map((key) => ({
-      field: key,
-      value: null,
-    })));
-
-    return null;
-  }
 
   return integrationFieldMappings?.length ? (
     <>

--- a/src/components/Configure/content/fields/FieldMappings/useClearOldFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/useClearOldFieldMappings.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+
+import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
+
+import { useSelectedConfigureState } from '../../useSelectedConfigureState';
+
+import { setFieldMapping } from './setFieldMapping';
+
+const findOutdatedKeys = (
+  selectedKeys: string[],
+  allowedKeysSet: Set<string>,
+) => selectedKeys.filter((key) => !allowedKeysSet.has(key));
+
+/**
+ *  Custom hook to unset values for old field mappings:
+ *
+ *  Active field mappings come from required mappings, optional mappings, and dynamic mappings.
+ *  Old mappings may still exists in the config even after removing them from the amp.yaml file
+ *  or dyanmic mappings
+ *
+ *  This hook will unset the values for old field mappings that are no longer allowed by the builder
+ *  (i.e. old amp.yaml / dynamic mapping configs keys)
+ */
+export function useClearOldFieldMappings() {
+  const { selectedObjectName, configureState, setConfigureState } = useSelectedConfigureState();
+  const { fieldMapping } = useInstallIntegrationProps();
+
+  // Get field mappings with user selected values
+  const selectedFieldMappings = configureState?.read?.selectedFieldMappings || {};
+  const selectedKeys = Object.keys(selectedFieldMappings); // may include outdated keys from config
+
+  // Get allowed fields (not oudated) from required mappings, optional mappings, and dynamic mappings
+  const requiredFieldMappings = configureState?.read?.requiredMapFields || [];
+  const optionalFieldMappings = configureState?.read?.optionalMapFields || [];
+  const dynamicFieldMappings = selectedObjectName && fieldMapping
+    ? Object.values(fieldMapping[selectedObjectName] || {}).flat().filter((mapping) => !mapping.fieldName) : [];
+
+  // merge all allowed keys
+  const allowedKeys = requiredFieldMappings
+    .concat(dynamicFieldMappings, optionalFieldMappings)
+    .map((field) => field.mapToName);
+
+  // create a set for faster lookup, remove duplicates
+  const allowKeysSet = new Set(allowedKeys);
+
+  // find keys that are outdated
+  const outdatedKeys = findOutdatedKeys(selectedKeys, allowKeysSet);
+
+  useEffect(() => {
+    if (!!selectedObjectName && outdatedKeys.length) {
+      // For old field mappings that have now been removed by the builder, unset the values for those keys.
+      setFieldMapping(selectedObjectName, setConfigureState, outdatedKeys.map((key) => ({
+        field: key,
+        value: null,
+      })));
+    }
+  }, [selectedObjectName, setConfigureState, outdatedKeys]);
+}

--- a/src/components/Configure/content/fields/ReadFields.tsx
+++ b/src/components/Configure/content/fields/ReadFields.tsx
@@ -1,3 +1,4 @@
+import { useClearOldFieldMappings } from './FieldMappings/useClearOldFieldMappings';
 import { OptionalFieldMappings, RequiredFieldMappings } from './FieldMappings';
 import { ReadObjectMapping } from './ObjectMapping';
 import { OptionalFields } from './OptionalFields';
@@ -5,6 +6,8 @@ import { RequiredFields } from './RequiredFields';
 import { ValueMappings } from './ValueMapping';
 
 export function ReadFields() {
+  useClearOldFieldMappings();
+
   return (
     <>
       <ReadObjectMapping />


### PR DESCRIPTION
### Summary
followup to fixing optional field mappings. https://github.com/amp-labs/react/pull/831
- moves logic from RequiredFieldMappings to useClearOldFieldMappings hook
- updates ReadFields to use hook



#### demo
optional field mappings works as expected
![refactor-clear-field-mappings](https://github.com/user-attachments/assets/30c48de5-a928-4da2-b780-a7e40e9af166)




