### PR TITLE
[ENG-1798] fix: allow pending states to persist

### DIFF
--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -58,11 +58,6 @@ export function UpdateInstallation(
     if (!configureState) { resetState(); }
   }, [configureState, resetState]);
 
-  // reset state when installation (i.e. config) is reloaded.
-  useEffect(() => {
-    if (installation) resetState();
-  }, [installation, resetState]);
-
   const hydratedObject = useMemo(() => {
     const hydrated = hydratedRevision?.content?.read?.objects?.find(
       (obj) => obj?.objectName === selectedObjectName,


### PR DESCRIPTION
### Summary

#### problem
- pending state resets when install / save button is clicked. 
- whenever tab switched the pending state will also reset. 

#### solution
remove the `useEffect` reset that tracks `installations` / config changes. 

#### root cause
`installations` is updated after install (updating config), which we do not want to call a reset state which also wipes pending draft states. Additionally if we track reset state in any useEffect dependencies, the reset will also activate whenever the tab `selectedObjectName` switches which causes undesirable resets.


### Demo
![fix-pending-state-switch-tabs](https://github.com/user-attachments/assets/893f6186-9850-4cb8-b9dd-cdf51b09d9b5)


