### PR TITLE
[ENG-1837] build: add tanstack query

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-tabs": "^1.1.1",
+    "@tanstack/react-query": "^5.64.2",
     "classnames": "^2.5.1",
     "downshift": "^9.0.8",
     "immer": "^10.0.3",

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { createContext, useContext } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { ApiKeyProvider } from '../ApiKeyContextProvider';
 import { ErrorStateProvider } from '../ErrorContextProvider';
@@ -29,6 +30,8 @@ interface AmpersandProviderProps {
   children: React.ReactNode
 }
 
+const queryClient = new QueryClient();
+
 export function AmpersandProvider(props: AmpersandProviderProps) {
   const { options: { apiKey, projectId, project }, children } = props;
   const projectIdOrName = project || projectId;
@@ -44,15 +47,17 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
   }
 
   return (
-    <ErrorStateProvider>
-      <ApiKeyProvider value={apiKey}>
-        <ProjectProvider projectIdOrName={projectIdOrName}>
-          <IntegrationListProvider projectIdOrName={projectIdOrName}>
-            {children}
-          </IntegrationListProvider>
-        </ProjectProvider>
-      </ApiKeyProvider>
-    </ErrorStateProvider>
+    <QueryClientProvider client={queryClient}>
+      <ErrorStateProvider>
+        <ApiKeyProvider value={apiKey}>
+          <ProjectProvider projectIdOrName={projectIdOrName}>
+            <IntegrationListProvider projectIdOrName={projectIdOrName}>
+              {children}
+            </IntegrationListProvider>
+          </ProjectProvider>
+        </ApiKeyProvider>
+      </ErrorStateProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,6 +1979,18 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@tanstack/query-core@5.64.2":
+  version "5.64.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.64.2.tgz#be06e7c7966d14ea3e7c82bea1086b463f2f6809"
+  integrity sha512-hdO8SZpWXoADNTWXV9We8CwTkXU88OVWRBcsiFrk7xJQnhm6WRlweDzMD+uH+GnuieTBVSML6xFa17C2cNV8+g==
+
+"@tanstack/react-query@^5.64.2":
+  version "5.64.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.64.2.tgz#199c8a5a8ff92a8565f8cdd378747398347512a2"
+  integrity sha512-3pakNscZNm8KJkxmovvtZ4RaXLyiYYobwleTMvpIGUoKRa8j8VlrQKNl5W8VUEfVfZKkikvXVddLuWMbcSCA1Q==
+  dependencies:
+    "@tanstack/query-core" "5.64.2"
+
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"


### PR DESCRIPTION
### Summary
Adds react-query.

### Tested
imported amp-labs/react into dashboard. tested that this branch work: 
1. in current dashboard (same react-query version) 
2. dashboard with down graded react-query (v. 4.3)
![Screenshot 2025-01-27 at 3 48 55 PM](https://github.com/user-attachments/assets/96541ac6-9474-4d68-a188-e3b260796527)

To test locally 
1. Compile react lib into a tar ``` tar --exclude='node_modules' --exclude='.git' -vczf amp-react-rq.tgz .```
2. Install tar package locally in client ```npm i ../react/amp-react-rq.tgz ```


### Context

#### Assessing React Query vs SWR as an async state manager in React. 

##### We currently use react query as an async state manager. 
- Manages fetching, caching, requests through policies and smart defaults. 
- Also ships with significant dev tooling that allows debugging by overriding fetching, loading, error state per requests. 

##### Why should we bring this tech to React repo? 
- Simplify our fetching logic in place of home rolled useEffect based fetching. 
- Less code. Easier to maintain. Consistent with dashboard codebase. 

##### React-Query: What’s the risk? 
- Untested - what happens if there are react-query dependencies in builder app? 
- Adds a potential dependency/complexity issue that could result in rollback. 

##### What’s the alternative
- Home rolled useEffect (difficult to debug and easy to mess up dependency arrays)
- SWR: similar syntax and functionality as React Query. Much lighter footprint and less dependency conflict risk. Less dev tooling. 

##### Risk Reward
- Home rolled: Medium High Risk to maintain. Complexity will increase. Reward: none. 
- SWR: Low Risk to implement, rollback. High reward for reducing complexity. 
- React-Query: Medium risk (could be lowered with more testing) of future dependency issue, Higher reward for reusing learnings from client, additional debugging and maintaining for devs and possibly exposing to builders. 

##### How: Does POC’s work?
- Yes adding react query or SWR in mail monkey works as dependencies. (Not tested as peer dependencies)
- Dev tooling for react query works
- SWR dev tooling is limited and not maintained in Chrome.

