### PR TITLE
[ENG-1837] refactor: add react query to installations

### DIFF
--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -56,7 +56,7 @@ export function ConnectProvider({
 
   return (
     <div className={resetStyles.resetContainer} key={seed}>
-      <ConnectionsProvider provider={provider} groupRef={groupRef}>
+      <ConnectionsProvider>
         <ProtectedConnectionLayout
           resetComponent={reset}
           provider={provider}

--- a/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
@@ -154,6 +154,7 @@ export function InstallIntegrationProvider({
   // updates cache with new installation object
   const setInstallation = useCallback((installationObj: Installation) => {
     queryClient.setQueryData(['amp', 'installations'], [installationObj]);
+    queryClient.invalidateQueries({ queryKey: ['amp', 'installations'] });
   }, [queryClient]);
 
   const integrationErrorKey: string = integrationObj?.id || '';

--- a/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
@@ -2,10 +2,11 @@ import {
   createContext, useCallback,
   useContext, useEffect, useMemo,
 } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 
+import { useListInstallationsQuery } from 'hooks/query/useListInstallationsQuery';
 import {
-  Config, Installation, Integration, useAPI,
+  Config, Installation, Integration,
 } from 'services/api';
 import { ComponentContainerError, ComponentContainerLoading } from 'src/components/Configure/ComponentContainer';
 import { FieldMapping } from 'src/components/Configure/InstallIntegration';
@@ -14,7 +15,6 @@ import { handleServerError } from 'src/utils/handleServerError';
 
 import { ErrorBoundary, useErrorState } from '../ErrorContextProvider';
 import { useIntegrationList } from '../IntegrationListContextProvider';
-import { useProject } from '../ProjectContextProvider';
 
 import { useIsInstallationDeleted } from './useIsInstallationDeleted';
 
@@ -64,28 +64,6 @@ export function useInstallIntegrationProps() {
   }
   return context;
 }
-
-const useListInstallationsQuery = (integrationId?: string, groupRef?: string) => {
-  const getAPI = useAPI();
-  const { projectId } = useProject();
-
-  return useQuery({
-    queryKey: ['amp', 'installations', projectId, integrationId, groupRef],
-    queryFn: async () => {
-      if (!projectId) throw new Error('Project ID is required');
-      if (!integrationId) throw new Error('Integration ID is required');
-      if (!groupRef) throw new Error('Group reference is required');
-
-      const api = await getAPI();
-      return api.installationApi.listInstallations({
-        projectIdOrName: projectId,
-        integrationId,
-        groupRef,
-      });
-    },
-    enabled: !!projectId && !!integrationId && !!groupRef,
-  });
-};
 
 interface InstallIntegrationProviderProps {
   integration: string, // integration name

--- a/src/hooks/query/useListInstallationsQuery.ts
+++ b/src/hooks/query/useListInstallationsQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useProject } from 'context/ProjectContextProvider';
+import { useAPI } from 'src/services/api';
+
+export const useListInstallationsQuery = (integrationId?: string, groupRef?: string) => {
+  const getAPI = useAPI();
+  const { projectId } = useProject();
+
+  return useQuery({
+    queryKey: ['amp', 'installations', projectId, integrationId, groupRef],
+    queryFn: async () => {
+      if (!projectId) throw new Error('Project ID is required');
+      if (!integrationId) throw new Error('Integration ID is required');
+      if (!groupRef) throw new Error('Group reference is required');
+
+      const api = await getAPI();
+      return api.installationApi.listInstallations({
+        projectIdOrName: projectId,
+        integrationId,
+        groupRef,
+      });
+    },
+    enabled: !!projectId && !!integrationId && !!groupRef,
+  });
+};


### PR DESCRIPTION
### Summary
adds react query to installations
- adds react query in place of useEffect triggered installations
- does not include migration for installation mutations.
- installations logic is now always derived from list installations. (no need to manually set installation)

#### followup
needed to fix https://github.com/amp-labs/react/pull/862

