### PR TITLE
fix: empty dynamic optional field mappings 

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
@@ -64,7 +64,10 @@ export function OptionalFieldMappings() {
     return combinedFieldMappings;
   }, [configureState, dynamicFieldMappings]);
 
-  return (integrationFieldMappings.length || dynamicFieldMappings.length) ? (
+  const showDynamicFieldMappings = dynamicFieldMappings.length > 0;
+  const showIntegrationFieldMappings = integrationFieldMappings.length > 0;
+
+  return (showIntegrationFieldMappings || showDynamicFieldMappings) ? (
     <>
       <FieldHeader string="Map the following optional fields" />
       <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
@@ -77,7 +80,7 @@ export function OptionalFieldMappings() {
             />
           </FormControl>
         ))}
-        {dynamicFieldMappings?.length && (
+        {showDynamicFieldMappings && (
           <DynamicFieldMappings
             dynamicFieldMappings={dynamicFieldMappings}
             onSelectChange={onSelectChange}


### PR DESCRIPTION
### Summary
0 is rendered with dynamicFieldMappings is length 0.

#### before
![Screenshot 2025-01-30 at 11 25 58 AM](https://github.com/user-attachments/assets/aeb2bd49-ab5d-4af3-8a62-690c338f8f36)

#### after
![Screenshot 2025-01-30 at 11 26 25 AM](https://github.com/user-attachments/assets/ea51e107-f0f8-4bec-b626-2a324fdbdbb1)
