### PR TITLE
[ENG-1778, ENG-1837] refactor: connections to use react query (connections part 1) 

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -113,7 +113,7 @@ export function InstallIntegration(
         onUninstallSuccess={onUninstallSuccess}
         fieldMapping={fieldMapping}
       >
-        <ConnectionsProvider groupRef={groupRef}>
+        <ConnectionsProvider>
           <ProtectedConnectionLayout
             consumerRef={consumerRef}
             consumerName={consumerName}

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -11,9 +11,8 @@ import { useInstallIntegrationProps } from 'context/InstallIntegrationContextPro
 import {
   api, HydratedIntegrationRead, HydratedIntegrationWriteObject, HydratedRevision,
 } from 'services/api';
+import { ComponentContainerError, ComponentContainerLoading } from 'src/components/Configure/ComponentContainer';
 import { handleServerError } from 'src/utils/handleServerError';
-
-import { ComponentContainerError } from '../ComponentContainer';
 
 interface HydratedRevisionContextValue {
   hydratedRevision: HydratedRevision | null;
@@ -69,6 +68,7 @@ export function HydratedRevisionProvider({
       && connectionId
       && apiKey
     ) {
+      setLoading(true);
       api().revisionApi.getHydratedRevision({
         projectIdOrName: projectId,
         integrationId,
@@ -81,14 +81,14 @@ export function HydratedRevisionProvider({
       })
         .then((data) => {
           setHydratedRevision(data);
-          setLoading(false);
           removeError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier);
         })
         .catch((err) => {
           console.error(`Error loading integration ${errorIntegrationIdentifier}.`);
           handleServerError(err);
-          setLoading(false);
           setError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier);
+        }).finally(() => {
+          setLoading(false);
         });
     }
   }, [
@@ -107,6 +107,10 @@ export function HydratedRevisionProvider({
     readAction: hydratedRevision?.content?.read,
     writeObjects: hydratedRevision?.content?.write?.objects || [],
   }), [hydratedRevision, loading]);
+
+  if (loading) {
+    return <ComponentContainerLoading />;
+  }
 
   if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {
     const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -44,7 +44,7 @@ const useConnectionsListQuery = () => {
   return useQuery({
     queryKey: ['amp', 'connections', projectIdOrName, groupRef, provider],
     queryFn: async () => {
-      if (!projectIdOrName) throw new Error('Project ID not found.');
+      if (!projectIdOrName) throw new Error('Project ID or name not found. Please wrap this component inside of AmpersandProvider');
       if (!groupRef) throw new Error('Group reference not found.');
       if (!provider) throw new Error('Provider not found.');
 


### PR DESCRIPTION
### Summary
We add react query to simplify how to manage syncing connections. This is prep work for [ENG-1778] bug. Simplifying logic in connections manager via react query helps avoid re-render issues when switching connections

- simplify connections context
- derive connection from connections list
- remove manual set connections/ connection
- adds loading state to hydrated revision which previously showed an error when connection was set.

#### Previously
1. useEffect, deps, prop changes, and actions from user (auth) trigger a re-fetch of listConnections
2. based on oauth and connections, we use a useEffect connections manager to set the selected connection and keep them in sync

issues: syncing selectedConnection and connections can create a endless cycle has they trigger multiple useEffects to update each other

#### Now
1. we create a useConnectionsListQuery that will only fetch and cache the connections list.
2. instead of tracking a separate state for selected connection, connection is always derived from connection list (the first connection)
3. any mutation like an auth flow login will invalidate connections cache - asking react query to refetch.

we have some placeholder functions like setConnections and setSelectedConnections which will just invalidate the cache behind the scenes until mutate functions with their own cache invalidation calls are also migrated to react-query.

#### followup
part 2: https://github.com/amp-labs/react/pull/848
Oauth connections logic is not fully migrated yet but will still use the connections from react query. All manual connection sets will invalidate cache until deleted in the future.

#### demo
![connections-demo](https://github.com/user-attachments/assets/a2d9f29d-6319-40ae-95a9-1f3443ff9a6a)


