### PR TITLE
[ENG-1778] fix/refactor: isIntegrationDeleted during prop change

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -1,6 +1,6 @@
 import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
-import { InstallIntegrationProvider } from 'context/InstallIntegrationContextProvider';
+import { InstallIntegrationProvider } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { Config, IntegrationFieldMapping } from 'services/api';
 import { useIntegrationList } from 'src/context/IntegrationListContextProvider';

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -3,7 +3,9 @@ import { FormEventHandler } from 'react';
 import { FormErrorBox } from 'components/FormErrorBox';
 import { LoadingCentered } from 'components/Loading';
 import { Box } from 'components/ui-base/Box/Box';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { Button } from 'src/components/ui-base/Button';
 
 import { UNINSTALL_INSTALLATION_CONST, WRITE_CONST } from '../nav/ObjectManagementNav/constant';

--- a/src/components/Configure/content/InstallationContent.tsx
+++ b/src/components/Configure/content/InstallationContent.tsx
@@ -1,4 +1,6 @@
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 
 import { ErrorTextBox } from '../../ErrorTextBox/ErrorTextBox';
 

--- a/src/components/Configure/content/UninstallContent.tsx
+++ b/src/components/Configure/content/UninstallContent.tsx
@@ -1,4 +1,6 @@
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 
 import { UninstallButton } from '../layout/UninstallButton';

--- a/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
+import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { FormControl } from 'src/components/form/FormControl';
-import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
 
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 import { FieldHeader } from '../FieldHeader';

--- a/src/components/Configure/content/fields/FieldMappings/useClearOldFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/useClearOldFieldMappings.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 
-import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 

--- a/src/components/Configure/content/fields/ObjectMapping.tsx
+++ b/src/components/Configure/content/fields/ObjectMapping.tsx
@@ -1,5 +1,7 @@
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { FormCalloutBox } from 'src/components/FormCalloutBox';
-import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
 import { useProject } from 'src/context/ProjectContextProvider';
 import { capitalize, getProviderName } from 'src/utils';
 

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -3,8 +3,10 @@ import {
 } from 'react';
 
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { FormControl } from 'src/components/form/FormControl';
-import { useInstallIntegrationProps } from 'src/context/InstallIntegrationContextProvider';
 
 import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -3,7 +3,9 @@ import { useCallback } from 'react';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 
 import { useNextIncompleteTabIndex, useSelectedObjectName } from '../nav/ObjectManagementNav/ObjectManagementNavContext';

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { HydratedRevision } from 'services/api';
 

--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -7,7 +7,9 @@ import { OauthFlow } from 'components/auth/Oauth/OauthFlow/OauthFlow';
 import { useConnectionHandler } from 'components/Connect/useConnectionHandler';
 import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useConnections } from 'context/ConnectionsContextProvider';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import {
+  useInstallIntegrationProps,
+} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { api, Connection, ProviderInfo } from 'services/api';
 import { SuccessTextBox } from 'src/components/SuccessTextBox/SuccessTextBox';
 import { Button } from 'src/components/ui-base/Button';

--- a/src/components/Configure/layout/UninstallButton.tsx
+++ b/src/components/Configure/layout/UninstallButton.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useApiKey } from 'context/ApiKeyContextProvider';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { api } from 'services/api';
 import { Button } from 'src/components/ui-base/Button';

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -4,7 +4,7 @@ import {
 
 import { Box } from 'components/ui-base/Box/Box';
 import { Container } from 'components/ui-base/Container/Container';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
 import { VerticalTabs } from 'src/components/Configure/nav/ObjectManagementNav/v2/Tabs';
 import { NavObject } from 'src/components/Configure/types';

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import { Draft, produce } from 'immer';
 
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 
 import { WRITE_CONST } from '../nav/ObjectManagementNav/constant';
 import { ConfigureState, ObjectConfigurationsState } from '../types';

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -7,7 +7,7 @@ import { useConnections } from 'context/ConnectionsContextProvider';
 import {
   ErrorBoundary, useErrorState,
 } from 'context/ErrorContextProvider';
-import { useInstallIntegrationProps } from 'context/InstallIntegrationContextProvider';
+import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import {
   api, HydratedIntegrationRead, HydratedIntegrationWriteObject, HydratedRevision,
 } from 'services/api';

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -7,8 +7,8 @@ import { Connection, useAPI } from 'services/api';
 import { ComponentContainerError, ComponentContainerLoading } from 'src/components/Configure/ComponentContainer';
 import { handleServerError } from 'src/utils/handleServerError';
 
+import { useInstallIntegrationProps } from './InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
-import { useInstallIntegrationProps } from './InstallIntegrationContextProvider';
 import { useProject } from './ProjectContextProvider';
 
 interface ConnectionsContextValue {

--- a/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
@@ -10,12 +10,12 @@ import { ComponentContainerError, ComponentContainerLoading } from 'src/componen
 import { FieldMapping } from 'src/components/Configure/InstallIntegration';
 import { findIntegrationFromList } from 'src/utils';
 
-import { useIsInstallationDeleted } from '../hooks/useIsInstallationDeleted';
+import { useApiKey } from '../ApiKeyContextProvider';
+import { ErrorBoundary, useErrorState } from '../ErrorContextProvider';
+import { useIntegrationList } from '../IntegrationListContextProvider';
+import { useProject } from '../ProjectContextProvider';
 
-import { useApiKey } from './ApiKeyContextProvider';
-import { ErrorBoundary, useErrorState } from './ErrorContextProvider';
-import { useIntegrationList } from './IntegrationListContextProvider';
-import { useProject } from './ProjectContextProvider';
+import { useIsInstallationDeleted } from './useIsInstallationDeleted';
 
 // Define the context value type
 interface InstallIntegrationContextValue {
@@ -86,7 +86,7 @@ export function InstallIntegrationProvider({
   const { projectId } = useProject();
   const { integrations } = useIntegrationList();
   const { setError, isError } = useErrorState();
-  const { isIntegrationDeleted, setIntegrationDeleted } = useIsInstallationDeleted();
+  const { isIntegrationDeleted, setIntegrationDeleted, resetIntegrationDeleted } = useIsInstallationDeleted();
 
   const [installations, setInstallations] = useState<Installation[]>([]);
   const [isLoading, setLoadingState] = useState<boolean>(true);
@@ -97,6 +97,12 @@ export function InstallIntegrationProvider({
     () => findIntegrationFromList(integration, integrations || []),
     [integration, integrations],
   );
+
+  // resets the isIntegrationDeleted state when InstallIntegrationProps change
+  useEffect(() => {
+    resetIntegrationDeleted();
+  }, [integration, consumerRef, consumerName, groupRef, groupName,
+    onInstallSuccess, onUpdateSuccess, onUninstallSuccess, fieldMapping, resetIntegrationDeleted]);
 
   useEffect(() => {
     if (integrationObj === null && integrations?.length) {

--- a/src/context/InstallIIntegrationContextProvider/useIsInstallationDeleted.ts
+++ b/src/context/InstallIIntegrationContextProvider/useIsInstallationDeleted.ts
@@ -9,5 +9,9 @@ export const useIsInstallationDeleted = () => {
     setIsIntegrationDeleted(true);
   }, [setIsIntegrationDeleted]);
 
-  return { isIntegrationDeleted, setIntegrationDeleted };
+  const resetIntegrationDeleted = useCallback(() => {
+    setIsIntegrationDeleted(false);
+  }, [setIsIntegrationDeleted]);
+
+  return { isIntegrationDeleted, setIntegrationDeleted, resetIntegrationDeleted };
 };


### PR DESCRIPTION
### Summary
Problem: when InstallIntegration is passed in different props, the isIntegrationDeleted state stays the same. The useIsIntegrationDeleted hook was not a global context.
Solution: reset the integrationDeleted state when props change. 
- resets the isIntegrationDeleted state when InstallIntegration props change
- refactors useIsInstallationDeleted hook inside InstallIntegrationContextProvider
- updates import paths
- deletes files being moved

#### Testing
1. Setup props in mailmonkey to switch between hubspot and salesforce
2. Authenticate hubspot proxy - see success screen
3. Switch to Salesforce 
4. Switch back to hubspot - uninstall - see uninstall screen
5. Switch back to Saleforce and back to Hubspot
6. Hubspot should now have restarted flow.

#### demo
![deleted-installation-refreshed](https://github.com/user-attachments/assets/9ffebc44-c5a6-42b1-b30f-f203c7aa0ea2)

