### PR TITLE
[ENG-1910] fix: useIsIntegrationInstalled 

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -72,7 +72,7 @@ export function InstallIntegration(
     onUninstallSuccess, fieldMapping,
   }: InstallIntegrationProps,
 ) {
-  const { projectId, projectIdOrName, isLoading: isProjectLoading } = useProject();
+  const { projectIdOrName, isLoading: isProjectLoading } = useProject();
   const { isLoading: isIntegrationListLoading } = useIntegrationList();
   const { isError, errorState } = useErrorState();
   const { seed, reset } = useForceUpdate();
@@ -121,7 +121,7 @@ export function InstallIntegration(
             groupName={groupName}
             resetComponent={reset}
           >
-            <HydratedRevisionProvider projectId={projectId}>
+            <HydratedRevisionProvider>
               <ConditionalProxyLayout>
                 <ConfigurationProvider>
                   <ObjectManagementNav>

--- a/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/ConditionalProxyLayout.tsx
@@ -36,7 +36,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
     integrationObj, installation, groupRef, consumerRef, setInstallation, onInstallSuccess,
     isIntegrationDeleted,
   } = useInstallIntegrationProps();
-  const { selectedConnection } = useConnections();
+  const { selectedConnection, isConnectionsLoading } = useConnections();
   const [createInstallLoading, setCreateInstallLoading] = useState(false);
   const isLoading = hydratedRevisionLoading || createInstallLoading;
 
@@ -49,7 +49,7 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
   };
 
   useEffect(() => {
-    if (!isLoading && hydratedRevision && isProxyOnly
+    if (!isLoading && !isConnectionsLoading && hydratedRevision && isProxyOnly
       && !installation && selectedConnection && apiKey && integrationObj?.id && !isIntegrationDeleted) {
       setCreateInstallLoading(true);
       onCreateInstallationProxyOnly({
@@ -70,9 +70,10 @@ export function ConditionalProxyLayout({ children }: ConditionalProxyLayoutProps
         console.error('Error when creating proxy installation:', e);
       });
     }
-  }, [hydratedRevision, isProxyOnly, installation, selectedConnection, apiKey,
-    projectId, integrationObj?.id, groupRef, consumerRef, setInstallation,
-    isLoading, onInstallSuccess, isIntegrationDeleted]);
+  }, [hydratedRevision,
+    isProxyOnly, installation, selectedConnection, apiKey, projectId,
+    integrationObj?.id, groupRef, consumerRef, setInstallation, isLoading, onInstallSuccess,
+    isIntegrationDeleted, isConnectionsLoading]);
 
   if (!integrationObj) return <ComponentContainerError message={"We can't load the integration"} />;
   if (isLoading) return <ComponentContainerLoading />;

--- a/src/components/Configure/layout/ProtectedConnectionLayout.tsx
+++ b/src/components/Configure/layout/ProtectedConnectionLayout.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { ApiKeyAuthFlow } from 'components/auth/ApiKeyAuth/ApiKeyAuthFlow';
 import { BasicAuthFlow } from 'components/auth/BasicAuth/BasicAuthFlow';
@@ -54,6 +55,7 @@ export function ProtectedConnectionLayout({
   const { provider: providerFromProps, isIntegrationDeleted } = useInstallIntegrationProps();
   const { selectedConnection, setSelectedConnection } = useConnections();
   useConnectionHandler({ onSuccess });
+  const queryClient = useQueryClient();
 
   const selectedProvider = provider || providerFromProps;
 
@@ -68,6 +70,11 @@ export function ProtectedConnectionLayout({
     });
   }, [apiKey, selectedProvider]);
 
+  const reinstallIntegration = useCallback(() => {
+    queryClient.clear(); // clears all queries in react-query cache
+    resetComponent();
+  }, [resetComponent, queryClient]);
+
   if (!provider && !providerFromProps) {
     throw new Error('ProtectedConnectionLayout must be given a provider prop or be used within InstallIntegrationProvider');
   }
@@ -80,7 +87,7 @@ export function ProtectedConnectionLayout({
       >
         <Button
           type="button"
-          onClick={resetComponent}
+          onClick={reinstallIntegration}
           style={{ width: '100%' }}
         >Reinstall Integration
         </Button>

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -3,7 +3,7 @@ import React, {
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
-import { useConnectionsListQuery } from 'context/ConnectionsContextProvider';
+import { useConnections } from 'context/ConnectionsContextProvider';
 import {
   ErrorBoundary, useErrorState,
 } from 'context/ErrorContextProvider';
@@ -41,11 +41,11 @@ export const useHydratedRevision = () => {
 
 const useHydratedRevisionQuery = () => {
   const getAPI = useAPI();
-  const { data: connectionsData, isLoading: isConnectionsLoading } = useConnectionsListQuery();
+  const { selectedConnection, isConnectionsLoading } = useConnections();
   const { projectIdOrName } = useProject();
   const { integrationId, integrationObj } = useInstallIntegrationProps();
 
-  const connectionId = connectionsData?.[0]?.id;
+  const connectionId = selectedConnection?.id;
   const revisionId = integrationObj?.latestRevision?.id;
 
   return useQuery({

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -51,7 +51,7 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
       <ErrorStateProvider>
         <ApiKeyProvider value={apiKey}>
           <ProjectProvider projectIdOrName={projectIdOrName}>
-            <IntegrationListProvider projectIdOrName={projectIdOrName}>
+            <IntegrationListProvider>
               {children}
             </IntegrationListProvider>
           </ProjectProvider>

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -37,14 +37,16 @@ export const useConnections = (): ConnectionsContextValue => {
   return context;
 };
 
-const useConnectionsListQuery = () => {
+export const useConnectionsListQuery = () => {
   const { projectIdOrName } = useProject();
   const { groupRef, provider } = useInstallIntegrationProps();
   const getAPI = useAPI();
   return useQuery({
     queryKey: ['amp', 'connections', projectIdOrName, groupRef, provider],
     queryFn: async () => {
-      if (!projectIdOrName) throw new Error('Project ID or name not found. Please wrap this component inside of AmpersandProvider');
+      if (!projectIdOrName) {
+        throw new Error('Project ID or name not found. Please wrap this component inside of AmpersandProvider');
+      }
       if (!groupRef) throw new Error('Group reference not found.');
       if (!provider) throw new Error('Provider not found.');
 

--- a/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
@@ -95,15 +95,17 @@ export function InstallIntegrationProvider({
     data: installations,
     isLoading,
     isError: isInstallationError, error: installationError,
-  } = useListInstallationsQuery(integrationObj?.id, groupRef);
+  } = useListInstallationsQuery(integration, groupRef);
 
   const installation = installations?.[0] || null; // there should only be one installation for mvp
 
   // resets the isIntegrationDeleted state when InstallIntegrationProps change
   useEffect(() => {
     resetIntegrationDeleted();
-  }, [integration, consumerRef, consumerName, groupRef, groupName,
-    onInstallSuccess, onUpdateSuccess, onUninstallSuccess, fieldMapping, resetIntegrationDeleted]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [integration, consumerRef, consumerName, groupRef, groupName, fieldMapping,
+    // onInstallSuccess, onUpdateSuccess, onUninstallSuccess, fieldMapping, resetIntegrationDeleted
+  ]);
 
   useEffect(() => {
     if (integrationObj === null && integrations?.length) {

--- a/src/hooks/query/useListInstallationsQuery.ts
+++ b/src/hooks/query/useListInstallationsQuery.ts
@@ -1,26 +1,30 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { useProject } from 'context/ProjectContextProvider';
+import { useIntegrationList } from 'src/context/IntegrationListContextProvider';
 import { useAPI } from 'src/services/api';
 
-export const useListInstallationsQuery = (integrationId?: string, groupRef?: string) => {
+export const useListInstallationsQuery = (integration?: string, groupRef?: string) => {
   const getAPI = useAPI();
-  const { projectId } = useProject();
+  const { projectIdOrName } = useProject(); // in AmpersandProvider
+  const { integrations } = useIntegrationList(); // in AmpersandProvider
+
+  const integrationId = integrations?.find((_integration) => _integration.name === integration)?.id;
 
   return useQuery({
-    queryKey: ['amp', 'installations', projectId, integrationId, groupRef],
+    queryKey: ['amp', 'installations', projectIdOrName, integrationId, groupRef],
     queryFn: async () => {
-      if (!projectId) throw new Error('Project ID is required');
+      if (!projectIdOrName) throw new Error('Project ID is required');
       if (!integrationId) throw new Error('Integration ID is required');
       if (!groupRef) throw new Error('Group reference is required');
 
       const api = await getAPI();
       return api.installationApi.listInstallations({
-        projectIdOrName: projectId,
+        projectIdOrName,
         integrationId,
         groupRef,
       });
     },
-    enabled: !!projectId && !!integrationId && !!groupRef,
+    enabled: !!projectIdOrName && !!integrationId && !!groupRef && !!integrations && integrations.length > 0,
   });
 };


### PR DESCRIPTION
### Summary
the `useIsIntegrationInstalled` hook is out of sync from the installations query. After refactoring list installations to use react query, 
- add in some cache invalidation logic to enable the hook state to be synced. 
- fixes some unnecessary fetches

followup to https://github.com/amp-labs/react/pull/844

#### demo 
##### configure
integration installed hook tested in mailmonkey
![fix-integration-installed-hook](https://github.com/user-attachments/assets/ff621e06-0f53-4a04-b4eb-5752fc525cb9)

##### proxy
![proxy-test](https://github.com/user-attachments/assets/1bc20e72-8863-4166-9cef-933fc9a5ae69)
