### PR TITLE
chore: increase query retries for hydrated revision

### DIFF
--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -64,6 +64,7 @@ const useHydratedRevisionQuery = () => {
         connectionId,
       });
     },
+    retry: 3, // retry 3 times before showing error
     enabled: !!projectIdOrName && !!integrationId && !!revisionId && !!connectionId && !isConnectionsLoading,
   });
 };

--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -53,6 +53,7 @@ export const useConnectionsListQuery = () => {
       const api = await getAPI();
       return api.connectionApi.listConnections({ projectIdOrName, groupRef, provider });
     },
+    retry: 3, // retry 3 times before showing error
     enabled: !!projectIdOrName && !!groupRef && !!provider,
   });
 };


### PR DESCRIPTION
### Summary
add a little bit of margin to the hydrated revision logic, since we're running into possible errors with connection id not ready yet.
 - adds retries to hydrated revision
 - adds retries to connections before showing error

#### Followup
longer term solution would migrate the create connections logic to use react query, simplifying connections logic more and revisit issue.


