### PR TITLE
[ENG-1837] refactor: basic auth flow to use react-query

### DIFF
--- a/src/components/auth/BasicAuth/BasicAuthFlow.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthFlow.tsx
@@ -1,34 +1,13 @@
 import { useCallback } from 'react';
 import { GenerateConnectionOperationRequest } from '@generated/api/src';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useProject } from 'context/ProjectContextProvider';
-import { useAPI } from 'services/api';
-import { handleServerError } from 'src/utils/handleServerError';
+
+import { useCreateConnectionMutation } from '../useCreateConnectionMutation';
 
 import { BasicAuthContent } from './BasicAuthContent';
 import { BasicAuthFlowProps } from './BasicAuthFlowProps';
 import { BasicCreds } from './LandingContentProps';
-
-export function useCreateConnectionMutation() {
-  const getAPI = useAPI();
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationKey: ['createConnection'],
-    mutationFn: async (params: GenerateConnectionOperationRequest) => {
-      const api = await getAPI();
-      return api.connectionApi.generateConnection(params);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['amp', 'connections'] });
-    },
-    onError: (error) => {
-      console.error('Error creating connection and loading provider info');
-      handleServerError(error);
-    },
-  });
-}
 
 export function BasicAuthFlow({
   provider, providerInfo, consumerRef, consumerName, groupRef, groupName,

--- a/src/components/auth/BasicAuth/BasicAuthFlow.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthFlow.tsx
@@ -1,55 +1,60 @@
-import { useEffect, useState } from 'react';
-import { GenerateConnectionRequest } from '@generated/api/src';
+import { useCallback } from 'react';
+import { GenerateConnectionOperationRequest } from '@generated/api/src';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
-import { api } from 'services/api';
+import { useAPI } from 'services/api';
 import { handleServerError } from 'src/utils/handleServerError';
 
 import { BasicAuthContent } from './BasicAuthContent';
 import { BasicAuthFlowProps } from './BasicAuthFlowProps';
 import { BasicCreds } from './LandingContentProps';
 
+export function useCreateConnectionMutation() {
+  const getAPI = useAPI();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['createConnection'],
+    mutationFn: async (params: GenerateConnectionOperationRequest) => {
+      const api = await getAPI();
+      return api.connectionApi.generateConnection(params);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['amp', 'connections'] });
+    },
+    onError: (error) => {
+      console.error('Error creating connection and loading provider info');
+      handleServerError(error);
+    },
+  });
+}
+
 export function BasicAuthFlow({
   provider, providerInfo, consumerRef, consumerName, groupRef, groupName,
-  children, selectedConnection, setSelectedConnection,
+  children, selectedConnection,
 }: BasicAuthFlowProps) {
-  const project = useProject();
-  const [nextStep, setNextStep] = useState<boolean>(false);
-  const [creds, setCreds] = useState<BasicCreds | null>(null);
-  const apiKey = useApiKey();
+  const { projectIdOrName } = useProject();
+  const createConnectionMutation = useCreateConnectionMutation();
 
-  useEffect(() => {
-    if (provider && api && nextStep && creds != null) {
-      const req: GenerateConnectionRequest = {
+  const onNext = useCallback((form: BasicCreds) => {
+    const { user, pass } = form;
+    const req: GenerateConnectionOperationRequest = {
+      projectIdOrName,
+      generateConnectionParams: {
         groupName,
         groupRef,
         consumerName,
         consumerRef,
         provider,
         basicAuth: {
-          username: creds.user,
-          password: creds.pass,
+          username: user,
+          password: pass,
         },
-      };
-
-      api().connectionApi.generateConnection({ projectIdOrName: project.projectId, generateConnectionParams: req }, {
-        headers: { 'X-Api-Key': apiKey ?? '', 'Content-Type': 'application/json' },
-      }).then((conn) => {
-        setSelectedConnection(conn);
-      }).catch((err) => {
-        console.error('Error loading provider info.');
-        handleServerError(err);
-      });
-    }
-  }, [apiKey, provider, nextStep, consumerName, consumerRef, groupName,
-    groupRef, project, creds, setSelectedConnection]);
-
-  const onNext = (form: BasicCreds) => {
-    const { user, pass } = form;
-    setCreds({ user, pass });
-    setNextStep(true);
-  };
+      },
+    };
+    createConnectionMutation.mutate(req);
+  }, [projectIdOrName, groupName, groupRef, consumerName, consumerRef, provider, createConnectionMutation]);
 
   if (selectedConnection === null) {
     return (

--- a/src/components/auth/NoAuth/NoAuthFlow.tsx
+++ b/src/components/auth/NoAuth/NoAuthFlow.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { GenerateConnectionRequest } from '@generated/api/src';
+import { useCallback } from 'react';
+import { GenerateConnectionOperationRequest } from '@generated/api/src';
 
-import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
-import { api, Connection } from 'services/api';
-import { handleServerError } from 'src/utils/handleServerError';
+import { Connection } from 'services/api';
+
+import { useCreateConnectionMutation } from '../useCreateConnectionMutation';
 
 import { NoAuthContent } from './NoAuthContent';
 
@@ -17,7 +17,6 @@ type NoAuthFlowProps = {
   providerName?: string;
   children: JSX.Element,
   selectedConnection: Connection | null;
-  setSelectedConnection: (connection: Connection | null) => void;
 };
 
 /**
@@ -27,36 +26,24 @@ type NoAuthFlowProps = {
  */
 export function NoAuthFlow({
   provider, consumerRef, consumerName, groupRef, groupName,
-  children, selectedConnection, setSelectedConnection, providerName,
+  children, selectedConnection, providerName,
 }: NoAuthFlowProps) {
-  const project = useProject();
-  const apiKey = useApiKey();
-  const [nextStep, setNextStep] = useState<boolean>(false);
+  const { projectIdOrName } = useProject();
+  const createConnectionMutation = useCreateConnectionMutation();
 
-  useEffect(() => {
-    if (provider && api && nextStep) {
-      const req: GenerateConnectionRequest = {
+  const onNext = useCallback(() => {
+    const req: GenerateConnectionOperationRequest = {
+      projectIdOrName,
+      generateConnectionParams: {
         groupName,
         groupRef,
         consumerName,
         consumerRef,
         provider,
-      };
-
-      api().connectionApi.generateConnection({ projectIdOrName: project.projectId, generateConnectionParams: req }, {
-        headers: { 'X-Api-Key': apiKey ?? '', 'Content-Type': 'application/json' },
-      }).then((conn) => {
-        setSelectedConnection(conn);
-      }).catch((err) => {
-        console.error('Error loading provider info.');
-        handleServerError(err);
-      });
-    }
-  }, [apiKey, provider, nextStep, consumerName, consumerRef, groupName, groupRef, setSelectedConnection, project]);
-
-  const onNext = () => {
-    setNextStep(true);
-  };
+      },
+    };
+    createConnectionMutation.mutate(req);
+  }, [projectIdOrName, groupName, groupRef, consumerName, consumerRef, provider, createConnectionMutation]);
 
   if (selectedConnection === null) {
     return <NoAuthContent handleSubmit={onNext} error={null} providerName={providerName} />;

--- a/src/components/auth/useCreateConnectionMutation.ts
+++ b/src/components/auth/useCreateConnectionMutation.ts
@@ -1,0 +1,25 @@
+import { GenerateConnectionOperationRequest } from '@generated/api/src';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useAPI } from 'services/api';
+import { handleServerError } from 'src/utils/handleServerError';
+
+export function useCreateConnectionMutation() {
+  const getAPI = useAPI();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['createConnection'],
+    mutationFn: async (params: GenerateConnectionOperationRequest) => {
+      const api = await getAPI();
+      return api.connectionApi.generateConnection(params);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['amp', 'connections'] });
+    },
+    onError: (error) => {
+      console.error('Error creating connection and loading provider info');
+      handleServerError(error);
+    },
+  });
+}


### PR DESCRIPTION
### Summary
Refactors basic auth flow to use a react-query mutation. 
- removes cred unnecessary form state <useState>
- migrates api service
- removes useEffect

merges in refactor no auth
- only used in testing. 

followup: https://github.com/amp-labs/react/pull/871

#### demo
![basic-auth-refactor](https://github.com/user-attachments/assets/f1814a90-61e0-466c-8e04-b802ba16bac9)
