### PR TITLE
[ENG-1837] refactor: api key flow

### DIFF
--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthFlow.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthFlow.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
-import { GenerateConnectionRequest, ProviderInfo } from '@generated/api/src';
+import { useCallback } from 'react';
+import { GenerateConnectionOperationRequest, ProviderInfo } from '@generated/api/src';
 
-import { useApiKey } from 'context/ApiKeyContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
-import { api, Connection } from 'services/api';
-import { handleServerError } from 'src/utils/handleServerError';
+import { Connection } from 'services/api';
+
+import { useCreateConnectionMutation } from '../useCreateConnectionMutation';
 
 import { ApiKeyAuthContent } from './ApiKeyAuthContent';
 import { IFormType } from './LandingContentProps';
@@ -18,45 +18,31 @@ type ApiKeyAuthFlowProps = {
   groupName?: string;
   children: JSX.Element,
   selectedConnection: Connection | null;
-  setSelectedConnection: (connection: Connection | null) => void;
+
 };
 
 export function ApiKeyAuthFlow({
   provider, providerInfo, consumerRef, consumerName, groupRef, groupName, children,
-  selectedConnection, setSelectedConnection,
+  selectedConnection,
 }: ApiKeyAuthFlowProps) {
-  const project = useProject();
-  const [nextStep, setNextStep] = useState<boolean>(false);
-  const [providerApiKey, setProviderApiKey] = useState<string | null>(null);
-  const apiKey = useApiKey();
+  const { projectIdOrName } = useProject();
+  const createConnectionMutation = useCreateConnectionMutation();
 
-  useEffect(() => {
-    if (provider && api && nextStep && providerApiKey != null) {
-      const req: GenerateConnectionRequest = {
+  const onNext = useCallback((form: IFormType) => {
+    const { apiKey } = form;
+    const req: GenerateConnectionOperationRequest = {
+      projectIdOrName,
+      generateConnectionParams: {
         groupName,
         groupRef,
         consumerName,
         consumerRef,
         provider,
-        apiKey: providerApiKey,
-      };
-
-      api().connectionApi.generateConnection({ projectIdOrName: project.projectId, generateConnectionParams: req }, {
-        headers: { 'X-Api-Key': apiKey ?? '', 'Content-Type': 'application/json' },
-      }).then((conn) => {
-        setSelectedConnection(conn);
-      }).catch((err) => {
-        console.error('Error loading provider info.');
-        handleServerError(err);
-      });
-    }
-  }, [apiKey, provider, nextStep, consumerName, consumerRef, groupName, groupRef,
-    project, setSelectedConnection, providerApiKey]);
-
-  const onNext = (form: IFormType) => {
-    setProviderApiKey(form.apiKey);
-    setNextStep(true);
-  };
+        apiKey,
+      },
+    };
+    createConnectionMutation.mutate(req);
+  }, [projectIdOrName, groupName, groupRef, consumerName, consumerRef, provider, createConnectionMutation]);
 
   if (selectedConnection === null) {
     return <ApiKeyAuthContent provider={provider} providerInfo={providerInfo} handleSubmit={onNext} error={null} />;


### PR DESCRIPTION
### Summary
continue refactoring generate connections in API key flow
- use react-query for api key flow
- remove useState and useEffect

followup to: https://github.com/amp-labs/react/pull/869
