### PR TITLE
[ENG-1920] fix: provider display name

### DIFF
--- a/src/components/Configure/content/fields/ObjectMapping.tsx
+++ b/src/components/Configure/content/fields/ObjectMapping.tsx
@@ -1,9 +1,7 @@
-import {
-  useInstallIntegrationProps,
-} from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { FormCalloutBox } from 'src/components/FormCalloutBox';
 import { useProject } from 'src/context/ProjectContextProvider';
-import { capitalize, getProviderName } from 'src/utils';
+import { useProvider } from 'src/hooks/useProvider';
+import { capitalize } from 'src/utils';
 
 import { useHydratedRevision } from '../../state/HydratedRevisionContext';
 import { useSelectedConfigureState } from '../useSelectedConfigureState';
@@ -16,10 +14,10 @@ export function ReadObjectMapping() {
   const { project } = useProject();
   const { hydratedRevision } = useHydratedRevision();
   const { selectedObjectName } = useSelectedConfigureState();
-  const { provider } = useInstallIntegrationProps();
+
+  const { providerName } = useProvider();
 
   const appName = project?.appName;
-  const providerName = getProviderName(provider);
 
   const selectedReadObject = hydratedRevision?.content?.read?.objects?.find(
     (obj) => obj.objectName === selectedObjectName,

--- a/src/components/Configure/layout/ConditionalProxyLayout/InstalledSuccessBox.tsx
+++ b/src/components/Configure/layout/ConditionalProxyLayout/InstalledSuccessBox.tsx
@@ -1,5 +1,5 @@
 import { SuccessTextBox } from 'components/SuccessTextBox/SuccessTextBox';
-import { getProviderName } from 'src/utils';
+import { useProvider } from 'src/hooks/useProvider';
 
 import { UninstallButton } from '../UninstallButton';
 
@@ -8,9 +8,8 @@ type InstalledSuccessBoxProps = {
 };
 
 export function InstalledSuccessBox({ provider }: InstalledSuccessBoxProps) {
-  const text = `You have successfully installed your ${getProviderName(
-    provider,
-  )} integration.`;
+  const { providerName } = useProvider(provider);
+  const text = `You have successfully installed your ${providerName} integration.`;
   return (
     <SuccessTextBox text={text}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -8,8 +8,8 @@ import { useInstallIntegrationProps } from 'context/InstallIIntegrationContextPr
 import { useProject } from 'context/ProjectContextProvider';
 import { VerticalTabs } from 'src/components/Configure/nav/ObjectManagementNav/v2/Tabs';
 import { NavObject } from 'src/components/Configure/types';
+import { useProvider } from 'src/hooks/useProvider';
 import { AmpersandFooter } from 'src/layout/AuthCardLayout/AmpersandFooter';
-import { getProviderName } from 'src/utils';
 
 import { useObjectsConfigureState } from '../../../state/ConfigurationStateProvider';
 import { useHydratedRevision } from '../../../state/HydratedRevisionContext';
@@ -36,7 +36,8 @@ export function ObjectManagementNavV2({
   children,
 }: ObjectManagementNavProps) {
   const { project } = useProject();
-  const { installation, provider } = useInstallIntegrationProps();
+  const { installation } = useInstallIntegrationProps();
+  const { providerName } = useProvider();
   const { hydratedRevision } = useHydratedRevision();
   const { objectConfigurationsState } = useObjectsConfigureState();
 
@@ -89,7 +90,7 @@ export function ObjectManagementNavV2({
             }}
           >
             <div style={{ width: '20rem' }}>
-              <h1 style={{ fontSize: 'small', fontWeight: '400' }}>{getProviderName(provider)} integration
+              <h1 style={{ fontSize: 'small', fontWeight: '400' }}>{providerName} integration
               </h1>
               <h3 style={{ marginBottom: '20px', fontSize: 'large', fontWeight: '500' }}>{appName}
               </h3>

--- a/src/components/Connect/ConnectedSuccessBox.tsx
+++ b/src/components/Connect/ConnectedSuccessBox.tsx
@@ -1,6 +1,6 @@
 import { useProject } from 'context/ProjectContextProvider';
+import { useProvider } from 'src/hooks/useProvider';
 import { Connection } from 'src/services/api';
-import { getProviderName } from 'src/utils';
 
 import { SuccessTextBox } from '../SuccessTextBox/SuccessTextBox';
 
@@ -13,7 +13,8 @@ interface ConnectedSuccessBoxProps {
 }
 export function ConnectedSuccessBox({ provider, onDisconnectSuccess, resetComponent }: ConnectedSuccessBoxProps) {
   const { appName } = useProject();
-  const text = `You have successfully connected your ${getProviderName(provider)} account to ${appName}.`;
+  const { providerName } = useProvider(provider);
+  const text = `You have successfully connected your ${providerName} account to ${appName}.`;
   return (
     <SuccessTextBox text={text}>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -4,7 +4,8 @@ import { AuthCardLayoutTemplate } from 'components/auth/AuthCardLayoutTemplate';
 import { DocsHelperText } from 'components/Docs/DocsHelperText';
 import { FormComponent } from 'src/components/form';
 import { Button } from 'src/components/ui-base/Button';
-import { getProviderName } from 'src/utils';
+import { useProvider } from 'src/hooks/useProvider';
+import { capitalize } from 'src/utils';
 
 import { LandingContentProps } from './LandingContentProps';
 
@@ -15,10 +16,10 @@ function ApiKeyAuthContentForm({
   const onToggleShowHide = () => setShow((prevShow) => !prevShow);
   const [apiKey, setApiKey] = useState('');
   const handlePasswordChange = (event: React.FormEvent<HTMLInputElement>) => setApiKey(event.currentTarget.value);
+  const { providerName } = useProvider(provider);
 
   const isApiKeyValid = apiKey.length > 0;
   const isSubmitDisabled = isButtonDisabled || !isApiKeyValid;
-  const providerName = getProviderName(provider, providerInfo);
   const docsURL = providerInfo.apiKeyOpts?.docsURL;
 
   return (
@@ -35,7 +36,7 @@ function ApiKeyAuthContentForm({
         {docsURL && (
         <DocsHelperText
           url={docsURL}
-          providerDisplayName={providerName}
+          providerDisplayName={providerName || capitalize(provider)}
           credentialName="API key"
         />
         )}

--- a/src/components/auth/BasicAuth/BasicAuthContent.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthContent.tsx
@@ -4,7 +4,8 @@ import { AuthCardLayoutTemplate } from 'components/auth/AuthCardLayoutTemplate';
 import { DocsHelperText } from 'components/Docs/DocsHelperText';
 import { FormComponent } from 'src/components/form';
 import { Button } from 'src/components/ui-base/Button';
-import { getProviderName } from 'src/utils';
+import { useProvider } from 'src/hooks/useProvider';
+import { capitalize } from 'src/utils';
 
 import { LandingContentProps } from './LandingContentProps';
 
@@ -15,8 +16,9 @@ function BasicAuthContentForm({
   const onToggleShowHide = () => setShow((prevShow) => !prevShow);
   const [formData, setFormData] = useState({ username: '', password: '' });
   const { username, password } = formData;
+  const { providerName } = useProvider(provider);
 
-  const providerName = getProviderName(provider, providerInfo);
+  const providerNameDisplayName = providerName || capitalize(provider);
   const docsURL = providerInfo.basicOpts?.docsURL;
   const isUserValid = username.length > 0;
   const isSubmitDisabled = isButtonDisabled || !isUserValid;
@@ -46,7 +48,7 @@ function BasicAuthContentForm({
         {docsURL && (
         <DocsHelperText
           url={docsURL}
-          providerDisplayName={providerName}
+          providerDisplayName={providerNameDisplayName}
           credentialName="credentials"
         />
         )}

--- a/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
+++ b/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
@@ -1,5 +1,5 @@
 import { Connection, ProviderInfo } from 'services/api';
-import { getProviderName } from 'src/utils';
+import { useProvider } from 'src/hooks/useProvider';
 
 import { NoWorkspaceOauthFlow } from '../AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow';
 import { WorkspaceOauthFlow } from '../AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow';
@@ -23,12 +23,12 @@ type OauthFlowProps = {
 export function OauthFlow({
   provider, providerInfo, consumerRef, consumerName, groupRef, groupName, selectedConnection, setSelectedConnection,
 }: OauthFlowProps) {
+  const { providerName } = useProvider(provider);
   if (providerInfo.oauth2Opts === undefined) {
     return <em>Provider is missing OAuth2 options</em>;
   }
 
   const { grantType, explicitScopesRequired, explicitWorkspaceRequired } = providerInfo.oauth2Opts;
-  const providerName = getProviderName(provider, providerInfo);
 
   const sharedProps = {
     provider,

--- a/src/hooks/useProvider.tsx
+++ b/src/hooks/useProvider.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useAPI } from 'services/api';
+import { useInstallIntegrationProps } from
+  'src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
+import { getProviderName } from 'src/utils';
+
+const useProviderInfoQuery = (provider?: string) => {
+  const getAPI = useAPI();
+  const { provider: providerFromProps } = useInstallIntegrationProps();
+  const selectedProvider = provider || providerFromProps;
+
+  return useQuery({
+    queryKey: ['amp', 'providerInfo', selectedProvider],
+    queryFn: async () => {
+      if (!selectedProvider) {
+        throw new Error('Provider not found');
+      }
+      const api = await getAPI();
+      return api.providerApi.getProvider({ provider: selectedProvider });
+    },
+    enabled: !!selectedProvider,
+  });
+};
+
+/**
+ * Extends useProviderInfoQuery (react-query) to include derived providerName and selectedProvider
+ * optional provider prop is used when passed in from ConnectProvider Component
+ * @param provider
+ * @returns
+ */
+export const useProvider = (provider?: string) => {
+  const providerInfoQuery = useProviderInfoQuery(provider);
+  const { data: providerInfo } = providerInfoQuery;
+  const { provider: providerFromProps } = useInstallIntegrationProps();
+  const providerName = (providerInfo) && getProviderName(providerInfo?.name, providerInfo);
+
+  // passed in from ConnectProvider Component or from installation provider info
+  const selectedProvider = provider || providerFromProps;
+
+  return {
+    ...providerInfoQuery, // react query data
+    providerName,
+    selectedProvider,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,7 +19,9 @@ export function capitalize(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export function getProviderName(provider: string, providerInfo?: ProviderInfo) {
+// use useProvider hook instead when possible to get provider name
+// this util function fetches the provider name from the provider info object
+export function getProviderName(provider: string, providerInfo: ProviderInfo) {
   return providerInfo?.displayName ?? capitalize(provider);
 }
 


### PR DESCRIPTION
### Summary
Sometimes provider displayName does not show correctly. We move the util function inside a new hook `useProvider` which extends the providerInfoQuery with derived state.
- adds useProvider hook
- enforce providerInfo as when getting the displayname

#### Screenshot
![Screenshot 2025-02-12 at 2 03 57 PM](https://github.com/user-attachments/assets/f22dffb6-08dc-44c5-9845-d32759cbd45e)

![Screenshot 2025-02-12 at 2 03 33 PM](https://github.com/user-attachments/assets/ee0e2052-81ac-49f9-ab36-2bcc535105be)




