### PR TITLE
fix: FieldMapping type export

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -2,7 +2,7 @@ import { ConnectionsProvider } from 'context/ConnectionsContextProvider';
 import { ErrorBoundary, useErrorState } from 'context/ErrorContextProvider';
 import { InstallIntegrationProvider } from 'context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useProject } from 'context/ProjectContextProvider';
-import { Config, IntegrationFieldMapping } from 'services/api';
+import { Config } from 'services/api';
 import { useIntegrationList } from 'src/context/IntegrationListContextProvider';
 import { useForceUpdate } from 'src/hooks/useForceUpdate';
 import resetStyles from 'src/styles/resetCss.module.css';
@@ -20,19 +20,35 @@ export interface MappedValue {
   mappedDisplayValue: string;
 }
 
-export type FieldMappingWithMappedValues = IntegrationFieldMapping & {
+export type FieldMappingEntry = {
   /**
-   * The name of the field to map from the source
+   * The name of the field in your application.
    */
-  fieldName?: string;
+  mapToName: string;
   /**
-   * The app-specific values to map provider API values to
+   * Optional display name of the field to show the user in the mapping UI.
+   */
+  mapToDisplayName?: string;
+  /**
+   * Optional prompt to show the user in the mapping UI.
+   */
+  prompt?: string;
+  /**
+   * If you would like the user to map a set of possible values,
+   * this is the list of possible values of the field in your application.
    */
   mappedValues?: MappedValue[];
+  /**
+ * The name of the field in SaaS provider, if present, then we will not prompt the user to map it.
+ */
+  fieldName?: string;
 };
 
+/**
+ * A map of object names to FieldMappingEntry arrays, with each FieldMappingEntry representing a field.
+ */
 export type FieldMapping = {
-  [key: string]: Array<FieldMappingWithMappedValues>
+  [key: string]: Array<FieldMappingEntry>
 };
 
 interface InstallIntegrationProps {

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -39,8 +39,8 @@ export type FieldMappingEntry = {
    */
   mappedValues?: MappedValue[];
   /**
- * The name of the field in SaaS provider, if present, then we will not prompt the user to map it.
- */
+   * The name of the field in SaaS provider, if present, then we will not prompt the user to map the field.
+   */
   fieldName?: string;
 };
 

--- a/src/components/Configure/content/fields/FieldMappings/DynamicFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/DynamicFieldMappings.tsx
@@ -1,7 +1,7 @@
 import { FormControl } from 'src/components/form/FormControl';
 import { HydratedIntegrationFieldExistent, IntegrationFieldMapping } from 'src/services/api';
 
-import { FieldMapping } from './FieldMapping';
+import { FieldMappingRow } from './FieldMappingRow';
 
 export function DynamicFieldMappings({
   dynamicFieldMappings,
@@ -16,7 +16,7 @@ export function DynamicFieldMappings({
     <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
       {dynamicFieldMappings.map((field) => (
         <FormControl id={field.mapToName} key={field.mapToName}>
-          <FieldMapping
+          <FieldMappingRow
             allFields={allFields}
             field={field}
             onSelectChange={onSelectChange}

--- a/src/components/Configure/content/fields/FieldMappings/FieldMappingRow.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMappingRow.tsx
@@ -17,17 +17,17 @@ import { setFieldMapping } from './setFieldMapping';
 
 export const DUPLICATE_FIELD_ERROR_MESSAGE = 'Each field must be mapped to a unique value';
 
-interface FieldMappingProps {
+interface FieldMappingRowProps {
   field: IntegrationFieldMapping;
   onSelectChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   allFields: HydratedIntegrationFieldExistent[];
 }
 
-export function FieldMapping({
+export function FieldMappingRow({
   field,
   onSelectChange,
   allFields,
-}: FieldMappingProps) {
+}: FieldMappingRowProps) {
   const { configureState, selectedObjectName, setConfigureState } = useSelectedConfigureState();
   const [disabled, setDisabled] = useState(true);
   const { isError, removeError, getError } = useErrorState();

--- a/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/OptionalFieldMappings.tsx
@@ -9,7 +9,7 @@ import { FieldHeader } from '../FieldHeader';
 
 import { checkDuplicateFieldError } from './checkDuplicateFieldError';
 import { DynamicFieldMappings } from './DynamicFieldMappings';
-import { FieldMapping } from './FieldMapping';
+import { FieldMappingRow } from './FieldMappingRow';
 import { setFieldMapping } from './setFieldMapping';
 
 export function OptionalFieldMappings() {
@@ -92,7 +92,7 @@ export function OptionalFieldMappings() {
       <div style={{ display: 'flex', gap: '1rem', flexDirection: 'column' }}>
         {integrationFieldMappings?.map((field) => (
           <FormControl id={field.mapToName} key={field.mapToName}>
-            <FieldMapping
+            <FieldMappingRow
               allFields={allFields}
               field={field}
               onSelectChange={onSelectChange}

--- a/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/RequiredFieldMappings.tsx
@@ -7,7 +7,7 @@ import { useSelectedConfigureState } from '../../useSelectedConfigureState';
 import { FieldHeader } from '../FieldHeader';
 
 import { checkDuplicateFieldError } from './checkDuplicateFieldError';
-import { FieldMapping } from './FieldMapping';
+import { FieldMappingRow } from './FieldMappingRow';
 import { setFieldMapping } from './setFieldMapping';
 
 export function RequiredFieldMappings() {
@@ -69,7 +69,7 @@ export function RequiredFieldMappings() {
             isInvalid={isError(ErrorBoundary.MAPPING, field.mapToName)}
             errorMessage="* required"
           >
-            <FieldMapping
+            <FieldMappingRow
               allFields={configureState?.read?.allFields || []}
               field={field}
               onSelectChange={onSelectChange}

--- a/src/components/Configure/content/fields/FieldMappings/index.ts
+++ b/src/components/Configure/content/fields/FieldMappings/index.ts
@@ -1,9 +1,9 @@
-import { FieldMapping } from './FieldMapping';
+import { FieldMappingRow } from './FieldMappingRow';
 import { OptionalFieldMappings } from './OptionalFieldMappings';
 import { RequiredFieldMappings } from './RequiredFieldMappings';
 
 export {
-  FieldMapping,
+  FieldMappingRow as FieldMapping,
   RequiredFieldMappings,
   OptionalFieldMappings,
 };

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -12,11 +12,9 @@ export * from '../hooks/useIsIntegrationInstalled';
 /**
  *  Exported types which are helpful for builders
  */
-
-// For defining dynamic mappings
 export type {
-  FieldMapping,
-  FieldMappingEntry,
+  FieldMapping, // For defining dynamic mappings
+  FieldMappingEntry, // For defining dynamic mappings
   Connection, // For ConnectProvider callbacks
   Config, // For InstallIntegration callbacks
 };

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -1,3 +1,4 @@
+import { FieldMapping, FieldMappingEntry } from 'src/components/Configure/InstallIntegration';
 import { Config, Connection } from 'src/services/api';
 
 /**
@@ -13,8 +14,9 @@ export * from '../hooks/useIsIntegrationInstalled';
  */
 
 // For defining dynamic mappings
-export { FieldMapping } from 'src/components/Configure/content/fields/FieldMappings';
 export type {
+  FieldMapping,
+  FieldMappingEntry,
   Connection, // For ConnectProvider callbacks
   Config, // For InstallIntegration callbacks
 };


### PR DESCRIPTION
Looks like the export broke at some point, and we were accidentally exporting the React component named FieldMapping and not the type. This PR rename the React component to FieldMappingRow to differentiate it from the FieldMapping type (which is a prop of InstallIntegration), and also updated the docstrings to make them more builder-friendly. 