### PR TITLE
chore: add oauth description text

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
@@ -1,6 +1,6 @@
 import { AuthErrorAlert } from 'components/auth/AuthErrorAlert/AuthErrorAlert';
 import { Button } from 'components/ui-base/Button';
-import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
+import { AuthCardLayout, AuthDescription, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
 
 import { LandingContentProps } from './LandingContentProps';
 
@@ -10,6 +10,9 @@ export function NoWorkspaceEntryContent({
   return (
     <AuthCardLayout>
       <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
+      <AuthDescription>
+        {`Click Next to sign into the ${providerName} account you'd like to sync.`}
+      </AuthDescription>
       <AuthErrorAlert error={error} />
       <Button
         style={{ marginTop: '1em', width: '100%' }}

--- a/src/layout/AuthCardLayout/AuthCardLayout.tsx
+++ b/src/layout/AuthCardLayout/AuthCardLayout.tsx
@@ -25,3 +25,9 @@ export function AuthTitle({ children }: AuthCardLayoutProps) {
     <h1 style={{ fontWeight: 600, lineHeight: 1.2, fontSize: '1.2em' }}>{children}</h1>
   );
 }
+
+export function AuthDescription({ children }: AuthCardLayoutProps) {
+  return (
+    <p style={{ padding: '.5em 0' }}>{children}</p>
+  );
+}


### PR DESCRIPTION
### Summary
adds description text to oauth (no workspace entry) for more context.

<img width="630" alt="Screenshot 2025-02-25 at 10 41 23 AM" src="https://github.com/user-attachments/assets/6929a80f-b041-45a3-8858-6e2653dcebad" />
