### PR TITLE
style: adjust padding and size of combobox

### DIFF
--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -86,6 +86,7 @@ export function ObjectManagementNavV2({
               display: 'flex',
               gap: '1rem',
               padding: '3rem',
+              paddingBottom: '6rem',
               backgroundColor: 'var(--amp-colors-bg-primary)',
             }}
           >

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -21,7 +21,7 @@ interface ComboBoxProps {
   placeholder: string;
   disabled?: boolean;
   style?: React.CSSProperties;
-  menuPostion?: 'top' | 'bottom';
+  menuPosition?: 'top' | 'bottom';
 }
 
 function getOptionsFilter(inputValue: string) {

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -21,6 +21,7 @@ interface ComboBoxProps {
   placeholder: string;
   disabled?: boolean;
   style?: React.CSSProperties;
+  menuPostion?: 'top' | 'bottom';
 }
 
 function getOptionsFilter(inputValue: string) {
@@ -43,6 +44,7 @@ export function ComboBox({
   placeholder,
   disabled,
   style,
+  menuPosition = 'bottom',
 }: ComboBoxProps) {
   const [filteredItems, setFilteredItems] = useState<Option[]>(items);
   const inputRef = useRef<HTMLInputElement | null>(null); // Ref to the input element
@@ -130,7 +132,9 @@ export function ComboBox({
       </div>
       {/* menu */}
       <ul
-        className={`${styles.menu} ${isOpen && items.length ? '' : styles.hidden}`}
+        className={`${styles.menu} ${isOpen && items.length ? '' : styles.hidden} ${
+          menuPosition === 'top' ? styles.menuTop : styles.menuBottom
+        }`}
         {...getMenuProps()}
       >
         {isOpen

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -40,7 +40,7 @@
   position: absolute;
   background-color: var(--amp-colors-input-surface-default);
   width: 100%;
-  max-height: 200px;
+  max-height: 120px;
   overflow-y: auto;
   margin-top: 0.25rem;
   border: 1px solid;
@@ -49,6 +49,18 @@
   border-radius: var(--amp-default-border-radius);
   padding: 0;
   font-size: .8rem;
+}
+
+/* Default (menu appears below input) */
+.menuBottom {
+  top: 100%;
+  margin-top: 4px;
+}
+
+/* If space is limited, flip the menu above */
+.menuTop {
+  bottom: 100%;
+  margin-right: 4px;
 }
 
 .menuItem {

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -60,7 +60,7 @@
 /* If space is limited, flip the menu above */
 .menuTop {
   bottom: 100%;
-  margin-right: 4px;
+  margin-bottom: 4px;
 }
 
 .menuItem {


### PR DESCRIPTION
### Summary
- adds styling for top menu
- adjust padding for allowing space for bottom menu
- reduces combobox menu length

### adds padding to bottom of form 

<img width="744" alt="Screenshot 2025-02-25 at 4 07 11 PM" src="https://github.com/user-attachments/assets/91f20353-ae0c-4f96-9c74-123ef96668cd" />

<img width="689" alt="Screenshot 2025-02-25 at 4 07 44 PM" src="https://github.com/user-attachments/assets/88dc64ca-6253-4c30-bcf1-9c37228ac97e" />

#### top menu positioning added (not used yet)
<img width="433" alt="Screenshot 2025-02-25 at 4 13 51 PM" src="https://github.com/user-attachments/assets/56da9691-b83a-4a98-a849-aef9613a64ec" />


