### PR TITLE
[ENG-1966] fix: ensure github action fails in case of linter errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,6 @@ jobs:
       run: yarn
     - name: Run linter
       run: yarn lint:dry
-      # If linting fails, the workflow will stop here
     - name: Build project
       run: |
         set -e  # Exit immediately if a command exits with a non-zero status

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,9 @@ jobs:
       run: yarn
     - name: Run linter
       run: yarn lint:dry
+      # If linting fails, the workflow will stop here
     - name: Build project
-      run: yarn build
+      run: |
+        set -e  # Exit immediately if a command exits with a non-zero status
+        yarn build
+      # This ensures that if the build fails, the GitHub Action will also fail

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "scripts": {
     "test": "jest",
     "watch": "yarn prepbuild && vite build --watch",
-    "build": "yarn prepbuild && vite build",
+    "build": "yarn prepbuild && tsc && vite build",
     "analyze": "yarn prepbuild && vite build --mode development",
     "prepbuild": "yarn clean && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" | sed \"s|\\\"|'|g\" > src/services/version.ts",
     "clean": "rm -rf ./build/",
     "assets": "mkdir ./build/ && cp -R ./src/public/ ./build/public/",
     "lint": "eslint --ext .ts,.tsx -c .eslintrc.cjs src/ --fix",
-    "lint:dry": "eslint --ext .ts,.tsx -c .eslintrc.cjs --max-warnings 0 src/",
+    "lint:dry": "eslint --ext .ts,.tsx -c .eslintrc.cjs src/",
     "clean-api": "rm -rf generated-sources/api",
     "generate-api": "yarn clean-api && openapi-generator-cli generate -i https://raw.githubusercontent.com/amp-labs/openapi/main/api/api.yaml -g typescript-fetch -o generated-sources/api --additional-properties=npmName=amp-labs-generated-rest-sdk,supportsES6=true,withInterfaces=true",
     "gen": "yarn generate-api"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "clean": "rm -rf ./build/",
     "assets": "mkdir ./build/ && cp -R ./src/public/ ./build/public/",
     "lint": "eslint --ext .ts,.tsx -c .eslintrc.cjs src/ --fix",
-    "lint:dry": "eslint --ext .ts,.tsx -c .eslintrc.cjs src/",
+    "lint:dry": "eslint --ext .ts,.tsx -c .eslintrc.cjs --max-warnings 0 src/",
     "clean-api": "rm -rf generated-sources/api",
     "generate-api": "yarn clean-api && openapi-generator-cli generate -i https://raw.githubusercontent.com/amp-labs/openapi/main/api/api.yaml -g typescript-fetch -o generated-sources/api --additional-properties=npmName=amp-labs-generated-rest-sdk,supportsES6=true,withInterfaces=true",
     "gen": "yarn generate-api"


### PR DESCRIPTION
**Explicit non-zero return in case of lint errors in CI:** 

<img width="956" alt="Screenshot 2025-03-07 at 1 02 43 PM" src="https://github.com/user-attachments/assets/f2e37fa3-c0d8-4372-9d6a-9ed62fcba02e" />
