### PR TITLE
[ENG-2026] fix: ConnectProvider list connections query

### DIFF
--- a/src/components/Connect/ConnectProvider.tsx
+++ b/src/components/Connect/ConnectProvider.tsx
@@ -56,7 +56,7 @@ export function ConnectProvider({
 
   return (
     <div className={resetStyles.resetContainer} key={seed}>
-      <ConnectionsProvider>
+      <ConnectionsProvider groupRef={groupRef} provider={provider}>
         <ProtectedConnectionLayout
           resetComponent={reset}
           provider={provider}


### PR DESCRIPTION
### Summary
#### problem: 
`<ConnectProvider/>` was infinite loading. `<ConnectProvider/>` uses components coupled to InstallIntegration (uses installIntegration props).
- adds ability to pass in groupRef and provider to ConnectProvider
- overloads check to InstallIntegration hook

#### followup: 
- remove connection button doesn't work. 
- should also consider decoupling <ConnectProvider/> and <InstallIntegration/> shared components.

### demo
listConnections call is now made (first row)
<img width="1394" alt="Screenshot 2025-03-10 at 2 02 32 PM" src="https://github.com/user-attachments/assets/94310b03-d018-4009-a62e-4ea89f95483e" />

![Screenshot 2025-03-10 at 2 02 35 PM](https://github.com/user-attachments/assets/f85d8702-83b8-45e2-a9b4-4aaa9cb03276)



