### PR TITLE
refactor: delete connection mutation

### DIFF
--- a/src/components/Connect/RemoveConnectionButton.tsx
+++ b/src/components/Connect/RemoveConnectionButton.tsx
@@ -23,9 +23,7 @@ const useDeleteConnectionMutation = () => {
     mutationKey: ['deleteConnection'],
     mutationFn: async ({ projectIdOrName, connectionId }: any) => {
       const api = await getAPI();
-      return api.connectionApi.deleteConnection(
-        { projectIdOrName, connectionId },
-      );
+      return api.connectionApi.deleteConnection({ projectIdOrName, connectionId });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['amp', 'connections'] });


### PR DESCRIPTION
### Summary 
clean up delete connection button
- refactors to use new apiService and react-query mutation

#### tested on new connection
![delete-connection](https://github.com/user-attachments/assets/d613a9b6-78f3-445f-b251-bb84fd425d81)
