### PR TITLE
[ENG-1980] feat: add hydrated revision error ui, disconnect button + error

### DIFF
--- a/src/components/Configure/ComponentContainer.tsx
+++ b/src/components/Configure/ComponentContainer.tsx
@@ -27,10 +27,17 @@ export function ComponentContainerLoading() {
   );
 }
 
-export function ComponentContainerError({ message }: { message: string; }) {
+/**
+ * Container for error messages. Usually used when a component cannot be rendered due to an error.
+ * @param param0
+ * @returns
+ */
+export function ComponentContainerError({ message, children }: { message: string; children?: React.ReactNode; }) {
   return (
     <ComponentContainer>
-      <ErrorTextBox message={message} />
+      <ErrorTextBox message={message}>
+        {children}
+      </ErrorTextBox>
     </ComponentContainer>
   );
 }

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -137,7 +137,7 @@ export function InstallIntegration(
             groupName={groupName}
             resetComponent={reset}
           >
-            <HydratedRevisionProvider>
+            <HydratedRevisionProvider resetComponent={reset}>
               <ConditionalProxyLayout>
                 <ConfigurationProvider>
                   <ObjectManagementNav>

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -1,5 +1,5 @@
 import React, {
-  createContext, useContext, useEffect, useMemo,
+  createContext, useContext, useEffect, useMemo, useState,
 } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -87,6 +87,7 @@ export function HydratedRevisionProvider({
   const { integrationId, integrationObj } = useInstallIntegrationProps();
   const { isError, removeError, setError } = useErrorState();
   const errorIntegrationIdentifier = integrationObj?.name || integrationId;
+  const [readeableErrorMsg, setReadableErrorMsg] = useState<string | null>(null);
 
   const {
     data: hydratedRevision,
@@ -97,11 +98,13 @@ export function HydratedRevisionProvider({
   useEffect(() => {
     if (isHydratedRevisionError) {
       setError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier);
-      handleServerError(hydrateRevisionError);
+      handleServerError(hydrateRevisionError, setReadableErrorMsg);
     } else {
       removeError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier);
+      setReadableErrorMsg(null);
     }
-  }, [isHydratedRevisionError, errorIntegrationIdentifier, setError, removeError, hydrateRevisionError]);
+  }, [isHydratedRevisionError, errorIntegrationIdentifier,
+    setError, removeError, hydrateRevisionError, setReadableErrorMsg]);
 
   const contextValue = useMemo(() => ({
     hydratedRevision: hydratedRevision || null,
@@ -117,7 +120,8 @@ export function HydratedRevisionProvider({
   if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {
     const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';
     const errorMsg = `Error retrieving integration details for '${intNameOrId
-    }. This is sometimes caused by insufficient permissions with your credentials'`;
+    }. This is sometimes caused by insufficient permissions with your credentials. ' + 
+    ${readeableErrorMsg ? `: ${readeableErrorMsg}` : ''}`;
 
     return <ComponentContainerError message={errorMsg} />;
   }

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -122,10 +122,12 @@ export function HydratedRevisionProvider({
     return <ComponentContainerLoading />;
   }
 
+  const providerName = integrationObj?.provider || 'provider';
+
   if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {
     const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';
     const errorMsg = `${readableErrorMsg ? `: ${readableErrorMsg}`
-      : `Error loading hydrated revision for integration ${intNameOrId}.`}`;
+      : `Error retrieving objects from ${providerName} or integration details for ${intNameOrId}`}`;
 
     return (
       <ComponentContainerError message={errorMsg}>

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -90,7 +90,7 @@ export function HydratedRevisionProvider({
   const { integrationId, integrationObj } = useInstallIntegrationProps();
   const { isError, removeError, setError } = useErrorState();
   const errorIntegrationIdentifier = integrationObj?.name || integrationId;
-  const [readeableErrorMsg, setReadableErrorMsg] = useState<string | null>(null);
+  const [readableErrorMsg, setReadableErrorMsg] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
   const {

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -126,7 +126,7 @@ export function HydratedRevisionProvider({
     const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';
     const errorMsg = `Error retrieving integration details for '${intNameOrId
     }. This is sometimes caused by insufficient permissions with your credentials. ' 
-    ${readeableErrorMsg ? `: ${readeableErrorMsg}` : ''}`;
+    ${readableErrorMsg ? `: ${readableErrorMsg}` : ''}`;
 
     return (
       <ComponentContainerError message={errorMsg}>

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -124,9 +124,8 @@ export function HydratedRevisionProvider({
 
   if (isError(ErrorBoundary.HYDRATED_REVISION, errorIntegrationIdentifier)) {
     const intNameOrId = integrationObj?.name || integrationId || 'unknown integration';
-    const errorMsg = `Error retrieving integration details for '${intNameOrId
-    }. This is sometimes caused by insufficient permissions with your credentials. ' 
-    ${readableErrorMsg ? `: ${readableErrorMsg}` : ''}`;
+    const errorMsg = `${readableErrorMsg ? `: ${readableErrorMsg}`
+      : `Error loading hydrated revision for integration ${intNameOrId}.`}`;
 
     return (
       <ComponentContainerError message={errorMsg}>
@@ -136,7 +135,7 @@ export function HydratedRevisionProvider({
         >
           {connectionError && <InnerErrorTextBox message={connectionError} />}
           <RemoveConnectionButton
-            buttonText="Remove Connection"
+            buttonText="Try again"
             resetComponent={resetComponent}
             buttonVariant="danger"
             onDisconnectError={(error: string) => setConnectionError(error)}

--- a/src/components/Connect/RemoveConnectionButton.tsx
+++ b/src/components/Connect/RemoveConnectionButton.tsx
@@ -13,6 +13,7 @@ interface RemoveConnectionButtonProps {
   buttonVariant?: string;
   buttonStyle?: React.CSSProperties;
   onDisconnectSuccess?: (connection: Connection) => void;
+  onDisconnectError?: (errorMsg: string) => void;
 }
 
 const useDeleteConnectionMutation = () => {
@@ -29,8 +30,7 @@ const useDeleteConnectionMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['amp', 'connections'] });
     },
     onError: (error) => {
-      console.error('Error deleting connection.');
-      handleServerError(error);
+      console.error('Error deleting connection.', { error });
     },
   });
 };
@@ -41,6 +41,7 @@ export function RemoveConnectionButton({
   buttonStyle = {},
   onDisconnectSuccess,
   resetComponent,
+  onDisconnectError,
 }: RemoveConnectionButtonProps) {
   const { projectId } = useProject();
   const { selectedConnection } = useConnections();
@@ -67,6 +68,9 @@ export function RemoveConnectionButton({
             // Trigger builder-provided callback if it exists
             onDisconnectSuccess?.(selectedConnection);
             resetComponent(); // reset / refresh the Connect Provider component
+          },
+          onError: (error) => {
+            handleServerError(error, onDisconnectError);
           },
           onSettled: () => setLoading(false),
         },

--- a/src/components/ErrorTextBox/ErrorTextBox.tsx
+++ b/src/components/ErrorTextBox/ErrorTextBox.tsx
@@ -7,15 +7,17 @@ import classes from './errorTextBox.module.css';
 
 interface ErrorTextBoxProps {
   message: string,
+  children?: React.ReactNode
 }
 
-export function ErrorTextBox({ message }: ErrorTextBoxProps) {
+export function ErrorTextBox({ message, children }: ErrorTextBoxProps) {
   return (
     <Container className={classes.errorBoxContainer}>
       <ErrorIcon />
       <Box className={classes.errorBox}>
         <p className={classes.errorText}>{message}</p>
       </Box>
+      {children}
     </Container>
   );
 }

--- a/src/components/ErrorTextBox/ErrorTextBox.tsx
+++ b/src/components/ErrorTextBox/ErrorTextBox.tsx
@@ -10,13 +10,19 @@ interface ErrorTextBoxProps {
   children?: React.ReactNode
 }
 
+export function InnerErrorTextBox({ message }: { message: string }) {
+  return (
+    <Box className={classes.errorBox}>
+      <p className={classes.errorText}>{message}</p>
+    </Box>
+  );
+}
+
 export function ErrorTextBox({ message, children }: ErrorTextBoxProps) {
   return (
     <Container className={classes.errorBoxContainer}>
       <ErrorIcon />
-      <Box className={classes.errorBox}>
-        <p className={classes.errorText}>{message}</p>
-      </Box>
+      <InnerErrorTextBox message={message} />
       {children}
     </Container>
   );

--- a/src/utils/handleServerError.ts
+++ b/src/utils/handleServerError.ts
@@ -32,8 +32,9 @@ export const handleServerError = async (error: any, setError?: (error: string) =
         if (errorBody?.remedy) { console.error('[Remedy]', errorBody.remedy); }
       }
 
+      const combinedErrorMessage = errorMsg + (errorBody?.remedy ? `\n\n${errorBody.remedy}` : '');
       if (setError) {
-        setError(errorMsg + (errorBody?.remedy ? `\n\n${errorBody.remedy}` : ''));
+        setError(combinedErrorMessage);
       }
     } catch (e) {
       console.error('Error parsing error response body:', e); // the response body could already be parsed

--- a/src/utils/handleServerError.ts
+++ b/src/utils/handleServerError.ts
@@ -32,7 +32,8 @@ export const handleServerError = async (error: any, setError?: (error: string) =
         if (errorBody?.remedy) { console.error('[Remedy]', errorBody.remedy); }
       }
 
-      const combinedErrorMessage = errorMsg + (errorBody?.remedy ? `\n\n${errorBody.remedy}` : '');
+      const combinedErrorMessage = `[Error Message] ${errorMsg} 
+      ${errorBody?.remedy ? `\n\n[Remedy] ${errorBody.remedy}` : ''}`;
       if (setError) {
         setError(combinedErrorMessage);
       }

--- a/src/utils/handleServerError.ts
+++ b/src/utils/handleServerError.ts
@@ -32,11 +32,8 @@ export const handleServerError = async (error: any, setError?: (error: string) =
         if (errorBody?.remedy) { console.error('[Remedy]', errorBody.remedy); }
       }
 
-      const combinedErrorMessage = `[Error Message] ${errorMsg} 
-      ${errorBody?.remedy ? `\n\n[Remedy] ${errorBody.remedy}` : ''}`;
-      if (setError) {
-        setError(combinedErrorMessage);
-      }
+      const combinedErrorMessage = `${errorMsg} ${errorBody?.remedy ? `\n\n[Remedy] ${errorBody.remedy}` : ''}`;
+      if (setError) setError(combinedErrorMessage);
     } catch (e) {
       console.error('Error parsing error response body:', e); // the response body could already be parsed
     }


### PR DESCRIPTION
### Summary 
Hydrated error state console logs error, but does not add detail to UI error. 
- adds UI causes error for hydrated revision
- adds disconnect button 
- adds disconnect error UI 

#### demo
note demo does not show causes arrary in UI since hydrated revision error is triggered by react-query error; does not recreate hydrated revision error from our amperand server endpoint. similiar logic is used in the disconnect button however.

![hydrated-revision-error-state](https://github.com/user-attachments/assets/f874e919-820d-459d-b53e-ce82ff9876e9)
