### PR TITLE
[ENG-1837] refactor: move oauth flow to useOAuthPopupURL

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -6,8 +6,8 @@ import { useCallback, useState } from 'react';
 
 import { useProject } from 'context/ProjectContextProvider';
 
-import { useOAuthPopupURL } from '../fetchOAuthPopupURL';
 import { OAuthWindow } from '../OAuthWindow/OAuthWindow';
+import { useOAuthPopupURL } from '../useOAuthPopupURL';
 
 import { NoWorkspaceEntryContent } from './NoWorkspaceEntryContent';
 

--- a/src/components/auth/Oauth/AuthorizationCode/enableCSRFprotection.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/enableCSRFprotection.ts
@@ -1,0 +1,6 @@
+import { getEnvVariable } from 'src/utils';
+
+const VITE_ENABLE_CSRF = getEnvVariable('VITE_AMP_ENABLE_CSRF', false);
+const NEXT_ENABLE_CSRF = getEnvVariable('NEXT_AMP_ENABLE_CSRF', false);
+const REACT_APP_ENABLE_CSRF = getEnvVariable('REACT_APP_AMP_ENABLE_CSRF', false);
+export const enableCSRFProtection = !!VITE_ENABLE_CSRF || !!NEXT_ENABLE_CSRF || !!REACT_APP_ENABLE_CSRF;

--- a/src/components/auth/Oauth/AuthorizationCode/fetchOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/fetchOAuthPopupURL.ts
@@ -1,18 +1,9 @@
-import { useEffect } from 'react';
-import { OauthConnectRequest } from '@generated/api/src/models';
-import { useQuery } from '@tanstack/react-query';
+import {
+  api, OauthConnectOperationRequest, ProviderApp,
+} from 'services/api';
+import { getProviderName } from 'src/utils';
 
-import { useProject } from 'context/ProjectContextProvider';
-import { useProviderInfoQuery } from 'hooks/useProvider';
-import { OauthConnectOperationRequest, ProviderApp, useAPI } from 'services/api';
-import { getEnvVariable, getProviderName } from 'src/utils';
-import { handleServerError } from 'src/utils/handleServerError';
-
-const VITE_ENABLE_CSRF = getEnvVariable('VITE_AMP_ENABLE_CSRF', false);
-const NEXT_ENABLE_CSRF = getEnvVariable('NEXT_AMP_ENABLE_CSRF', false);
-const REACT_APP_ENABLE_CSRF = getEnvVariable('REACT_APP_AMP_ENABLE_CSRF', false);
-
-const enableCSRFProtection = !!VITE_ENABLE_CSRF || !!NEXT_ENABLE_CSRF || !!REACT_APP_ENABLE_CSRF;
+import { enableCSRFProtection } from './enableCSRFprotection';
 
 /**
  * @deprecated use useOAuthPopupURL instead
@@ -72,121 +63,4 @@ export const fetchOAuthPopupURL = async (
   }
 
   throw new Error(`Provider ${provider} does not support an OAuth2 web flow.`);
-};
-
-export const useListProviderAppsQuery = () => {
-  const getAPI = useAPI();
-  const { projectIdOrName } = useProject();
-
-  return useQuery({
-    queryKey: ['amp', 'providerApps', projectIdOrName],
-    queryFn: async () => {
-      if (!projectIdOrName) throw new Error('Project ID is required');
-      const api = await getAPI();
-      return api.providerAppApi.listProviderApps({ projectIdOrName });
-    },
-    enabled: !!projectIdOrName,
-  });
-};
-
-const useOauthConnectQuery = (request: OauthConnectRequest) => {
-  const getAPI = useAPI();
-
-  const operationRequest: OauthConnectOperationRequest = {
-    connectOAuthParams: request,
-  };
-
-  return useQuery({
-    queryKey: ['amp', 'oauthConnect', request.projectId, request.groupRef, request.consumerRef, request.provider],
-    queryFn: async () => {
-      if (!request.projectId) throw new Error('Project ID is required');
-      if (!request?.providerAppId) throw new Error('Provider App ID is required');
-      if (!request?.provider) throw new Error('Provider is required');
-      if (!request?.consumerRef) throw new Error('Consumer Ref is required');
-      if (!request?.groupRef) throw new Error('Group Ref is required');
-      if (!request?.projectId) throw new Error('Project ID is required');
-      const api = await getAPI();
-      return api.oAuthApi.oauthConnect(operationRequest);
-    },
-    enabled: false, // do not auto-fetch
-  });
-};
-
-export const useOAuthPopupURL = (
-  projectId: string,
-  consumerRef: string,
-  groupRef: string,
-  provider: string,
-  workspace?: string,
-  consumerName?: string,
-  groupName?: string,
-) => {
-  const { data: provInfo, isLoading: isProvInfoLoading, error: provInfoError } = useProviderInfoQuery(provider);
-  const { data: providerApps, isLoading: isProviderAppsLoading, error: providerAppsError } = useListProviderAppsQuery();
-
-  const app = providerApps?.find((a: ProviderApp) => a.provider === provider);
-  const providerName = provInfo ? getProviderName(provider, provInfo) : null;
-
-  const request: OauthConnectRequest = {
-    providerWorkspaceRef: workspace,
-    projectId,
-    groupRef,
-    groupName,
-    consumerRef,
-    consumerName,
-    providerAppId: app?.id,
-    provider,
-    enableCSRFProtection,
-  };
-
-  const {
-    data: url, error: oauthConnectError, isLoading: isOauthConnectLoading, refetch: refetchOauthConnectQuery,
-  } = useOauthConnectQuery(request);
-
-  useEffect(() => {
-    if (provInfo && provider && !app) {
-      console.error(`You must first set up a ${providerName} Provider App using the Ampersand Console.`);
-    }
-  }, [app, providerName, provInfo, provider]);
-
-  useEffect(() => {
-    if (provInfoError) {
-      console.error('Error fetching provider info:', provInfoError);
-      handleServerError(provInfoError);
-    }
-  }, [provInfoError]);
-
-  useEffect(() => {
-    if (providerAppsError) {
-      console.error('Error fetching provider apps:', providerAppsError);
-      handleServerError(providerAppsError);
-    }
-  }, [providerAppsError]);
-
-  useEffect(() => {
-    if (oauthConnectError) {
-      console.error('Error fetching OAuth connect:', oauthConnectError);
-      handleServerError(oauthConnectError);
-    }
-  }, [oauthConnectError]);
-
-  const refetchOauthConnect = () => {
-    if (provInfo?.authType === 'oauth2') {
-      if (provInfo?.oauth2Opts?.grantType === 'authorizationCode'
-        || provInfo?.oauth2Opts?.grantType === 'authorizationCodePKCE') {
-        refetchOauthConnectQuery();
-      } else {
-        console.error('Provider does not support an OAuth2 web flow grant type.');
-      }
-    } else {
-      console.error('Provider does not support an OAuth2 web flow.');
-    }
-  };
-
-  return {
-    url,
-    error: provInfoError || providerAppsError || oauthConnectError,
-    isLoading: isProvInfoLoading || isProviderAppsLoading || isOauthConnectLoading,
-    refetchOauthConnect,
-  };
 };

--- a/src/components/auth/Oauth/AuthorizationCode/fetchOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/fetchOAuthPopupURL.ts
@@ -1,5 +1,12 @@
-import { api, OauthConnectOperationRequest, ProviderApp } from 'services/api';
+import { useEffect } from 'react';
+import { OauthConnectRequest } from '@generated/api/src/models';
+import { useQuery } from '@tanstack/react-query';
+
+import { useProject } from 'context/ProjectContextProvider';
+import { useProviderInfoQuery } from 'hooks/useProvider';
+import { OauthConnectOperationRequest, ProviderApp, useAPI } from 'services/api';
 import { getEnvVariable, getProviderName } from 'src/utils';
+import { handleServerError } from 'src/utils/handleServerError';
 
 const VITE_ENABLE_CSRF = getEnvVariable('VITE_AMP_ENABLE_CSRF', false);
 const NEXT_ENABLE_CSRF = getEnvVariable('NEXT_AMP_ENABLE_CSRF', false);
@@ -7,6 +14,10 @@ const REACT_APP_ENABLE_CSRF = getEnvVariable('REACT_APP_AMP_ENABLE_CSRF', false)
 
 const enableCSRFProtection = !!VITE_ENABLE_CSRF || !!NEXT_ENABLE_CSRF || !!REACT_APP_ENABLE_CSRF;
 
+/**
+ * @deprecated use useOAuthPopupURL instead
+ * @returns
+ */
 export const fetchOAuthPopupURL = async (
   projectId: string,
   consumerRef: string,
@@ -61,4 +72,121 @@ export const fetchOAuthPopupURL = async (
   }
 
   throw new Error(`Provider ${provider} does not support an OAuth2 web flow.`);
+};
+
+export const useListProviderAppsQuery = () => {
+  const getAPI = useAPI();
+  const { projectIdOrName } = useProject();
+
+  return useQuery({
+    queryKey: ['amp', 'providerApps', projectIdOrName],
+    queryFn: async () => {
+      if (!projectIdOrName) throw new Error('Project ID is required');
+      const api = await getAPI();
+      return api.providerAppApi.listProviderApps({ projectIdOrName });
+    },
+    enabled: !!projectIdOrName,
+  });
+};
+
+const useOauthConnectQuery = (request: OauthConnectRequest) => {
+  const getAPI = useAPI();
+
+  const operationRequest: OauthConnectOperationRequest = {
+    connectOAuthParams: request,
+  };
+
+  return useQuery({
+    queryKey: ['amp', 'oauthConnect', request.projectId, request.groupRef, request.consumerRef, request.provider],
+    queryFn: async () => {
+      if (!request.projectId) throw new Error('Project ID is required');
+      if (!request?.providerAppId) throw new Error('Provider App ID is required');
+      if (!request?.provider) throw new Error('Provider is required');
+      if (!request?.consumerRef) throw new Error('Consumer Ref is required');
+      if (!request?.groupRef) throw new Error('Group Ref is required');
+      if (!request?.projectId) throw new Error('Project ID is required');
+      const api = await getAPI();
+      return api.oAuthApi.oauthConnect(operationRequest);
+    },
+    enabled: false, // do not auto-fetch
+  });
+};
+
+export const useOAuthPopupURL = (
+  projectId: string,
+  consumerRef: string,
+  groupRef: string,
+  provider: string,
+  workspace?: string,
+  consumerName?: string,
+  groupName?: string,
+) => {
+  const { data: provInfo, isLoading: isProvInfoLoading, error: provInfoError } = useProviderInfoQuery(provider);
+  const { data: providerApps, isLoading: isProviderAppsLoading, error: providerAppsError } = useListProviderAppsQuery();
+
+  const app = providerApps?.find((a: ProviderApp) => a.provider === provider);
+  const providerName = provInfo ? getProviderName(provider, provInfo) : null;
+
+  const request: OauthConnectRequest = {
+    providerWorkspaceRef: workspace,
+    projectId,
+    groupRef,
+    groupName,
+    consumerRef,
+    consumerName,
+    providerAppId: app?.id,
+    provider,
+    enableCSRFProtection,
+  };
+
+  const {
+    data: url, error: oauthConnectError, isLoading: isOauthConnectLoading, refetch: refetchOauthConnectQuery,
+  } = useOauthConnectQuery(request);
+
+  useEffect(() => {
+    if (provInfo && provider && !app) {
+      console.error(`You must first set up a ${providerName} Provider App using the Ampersand Console.`);
+    }
+  }, [app, providerName, provInfo, provider]);
+
+  useEffect(() => {
+    if (provInfoError) {
+      console.error('Error fetching provider info:', provInfoError);
+      handleServerError(provInfoError);
+    }
+  }, [provInfoError]);
+
+  useEffect(() => {
+    if (providerAppsError) {
+      console.error('Error fetching provider apps:', providerAppsError);
+      handleServerError(providerAppsError);
+    }
+  }, [providerAppsError]);
+
+  useEffect(() => {
+    if (oauthConnectError) {
+      console.error('Error fetching OAuth connect:', oauthConnectError);
+      handleServerError(oauthConnectError);
+    }
+  }, [oauthConnectError]);
+
+  const refetchOauthConnect = () => {
+    if (provInfo?.authType === 'oauth2') {
+      if (provInfo?.oauth2Opts?.grantType === 'authorizationCode'
+        || provInfo?.oauth2Opts?.grantType === 'authorizationCodePKCE') {
+        refetchOauthConnectQuery();
+      } else {
+        console.error('Provider does not support an OAuth2 web flow grant type.');
+      }
+    } else {
+      console.error('Provider does not support an OAuth2 web flow.');
+    }
+  };
+
+  return {
+    url,
+    error: provInfoError || providerAppsError || oauthConnectError,
+    isLoading: isProvInfoLoading || isProviderAppsLoading || isOauthConnectLoading,
+    refetchOauthConnect,
+  };
 };

--- a/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
@@ -1,0 +1,88 @@
+import { useEffect } from 'react';
+import { OauthConnectRequest, ProviderApp } from '@generated/api/src';
+
+import { useListProviderAppsQuery, useOauthConnectQuery } from 'src/hooks/query';
+import { useProviderInfoQuery } from 'src/hooks/useProvider';
+import { getProviderName } from 'src/utils';
+import { handleServerError } from 'src/utils/handleServerError';
+
+import { enableCSRFProtection } from './enableCSRFprotection';
+
+export const useOAuthPopupURL = (
+  projectId: string,
+  consumerRef: string,
+  groupRef: string,
+  provider: string,
+  workspace?: string,
+  consumerName?: string,
+  groupName?: string,
+) => {
+  const { data: provInfo, isLoading: isProvInfoLoading, error: provInfoError } = useProviderInfoQuery(provider);
+  const { data: providerApps, isLoading: isProviderAppsLoading, error: providerAppsError } = useListProviderAppsQuery();
+
+  const app = providerApps?.find((a: ProviderApp) => a.provider === provider);
+  const providerName = provInfo ? getProviderName(provider, provInfo) : null;
+
+  const request: OauthConnectRequest = {
+    providerWorkspaceRef: workspace,
+    projectId,
+    groupRef,
+    groupName,
+    consumerRef,
+    consumerName,
+    providerAppId: app?.id,
+    provider,
+    enableCSRFProtection,
+  };
+
+  const {
+    data: url, error: oauthConnectError, isLoading: isOauthConnectLoading, refetch: refetchOauthConnectQuery,
+  } = useOauthConnectQuery(request);
+
+  useEffect(() => {
+    if (provInfo && provider && !app) {
+      console.error(`You must first set up a ${providerName} Provider App using the Ampersand Console.`);
+    }
+  }, [app, providerName, provInfo, provider]);
+
+  useEffect(() => {
+    if (provInfoError) {
+      console.error('Error fetching provider info:', provInfoError);
+      handleServerError(provInfoError);
+    }
+  }, [provInfoError]);
+
+  useEffect(() => {
+    if (providerAppsError) {
+      console.error('Error fetching provider apps:', providerAppsError);
+      handleServerError(providerAppsError);
+    }
+  }, [providerAppsError]);
+
+  useEffect(() => {
+    if (oauthConnectError) {
+      console.error('Error fetching OAuth connect:', oauthConnectError);
+      handleServerError(oauthConnectError);
+    }
+  }, [oauthConnectError]);
+
+  const refetchOauthConnect = () => {
+    if (provInfo?.authType === 'oauth2') {
+      if (provInfo?.oauth2Opts?.grantType === 'authorizationCode'
+        || provInfo?.oauth2Opts?.grantType === 'authorizationCodePKCE') {
+        refetchOauthConnectQuery();
+      } else {
+        console.error('Provider does not support an OAuth2 web flow grant type.');
+      }
+    } else {
+      console.error('Provider does not support an OAuth2 web flow.');
+    }
+  };
+
+  return {
+    url,
+    error: provInfoError || providerAppsError || oauthConnectError,
+    isLoading: isProvInfoLoading || isProviderAppsLoading || isOauthConnectLoading,
+    refetchOauthConnect,
+  };
+};

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,0 +1,9 @@
+import { useListInstallationsQuery } from './useListInstallationsQuery';
+import { useListProviderAppsQuery } from './useListProviderAppsQuery';
+import { useOauthConnectQuery } from './useOauthConnectQuery';
+
+export {
+  useListInstallationsQuery,
+  useListProviderAppsQuery,
+  useOauthConnectQuery,
+};

--- a/src/hooks/query/useListProviderAppsQuery.ts
+++ b/src/hooks/query/useListProviderAppsQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useProject } from 'context/ProjectContextProvider';
+import { useAPI } from 'services/api';
+
+export const useListProviderAppsQuery = () => {
+  const getAPI = useAPI();
+  const { projectIdOrName } = useProject();
+
+  return useQuery({
+    queryKey: ['amp', 'providerApps', projectIdOrName],
+    queryFn: async () => {
+      if (!projectIdOrName) throw new Error('Project ID is required');
+      const api = await getAPI();
+      return api.providerAppApi.listProviderApps({ projectIdOrName });
+    },
+    enabled: !!projectIdOrName,
+  });
+};

--- a/src/hooks/query/useOauthConnectQuery.ts
+++ b/src/hooks/query/useOauthConnectQuery.ts
@@ -1,0 +1,26 @@
+import { OauthConnectRequest } from '@generated/api/src/models';
+import { useQuery } from '@tanstack/react-query';
+
+import { OauthConnectOperationRequest, useAPI } from 'services/api';
+
+export const useOauthConnectQuery = (request: OauthConnectRequest) => {
+  const getAPI = useAPI();
+
+  const operationRequest: OauthConnectOperationRequest = {
+    connectOAuthParams: request,
+  };
+
+  return useQuery({
+    queryKey: ['amp', 'oauthConnect', request.projectId, request.groupRef, request.consumerRef, request.provider],
+    queryFn: async () => {
+      if (!request.projectId) throw new Error('Project ID is required');
+      if (!request?.providerAppId) throw new Error('Provider App ID is required');
+      if (!request?.provider) throw new Error('Provider is required');
+      if (!request?.consumerRef) throw new Error('Consumer Ref is required');
+      if (!request?.groupRef) throw new Error('Group Ref is required');
+      const api = await getAPI();
+      return api.oAuthApi.oauthConnect(operationRequest);
+    },
+    enabled: false, // do not auto-fetch
+  });
+};

--- a/src/hooks/useProvider.tsx
+++ b/src/hooks/useProvider.tsx
@@ -5,7 +5,7 @@ import { useInstallIntegrationProps } from
   'src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { getProviderName } from 'src/utils';
 
-const useProviderInfoQuery = (provider?: string) => {
+export const useProviderInfoQuery = (provider?: string) => {
   const getAPI = useAPI();
   const { provider: providerFromProps } = useInstallIntegrationProps();
   const selectedProvider = provider || providerFromProps;


### PR DESCRIPTION
### Summary 
This PR refactors the OAuth flow by migrating from fetchOAuthPopupURL to a new hook, useOAuthPopupURL, and integrating react-query to manage API calls and error handling.

- migrate to useQuery
- add error handling
- add refetch function
- add useEffect to handle errors
- add useEffect to handle provider info
- add useEffect to handle provider apps
- add useEffect to handle oauth connect

#### followup
does not migrate workspace oauth entries
part 2: https://github.com/amp-labs/react/pull/947

#### demo (no workspace)
![refactor-oauth-flow](https://github.com/user-attachments/assets/eef52868-942b-4129-869f-2013ddc51243)

