### PR TITLE
performance: useProjectWithEntitlementsQuery

### DIFF
--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -17,7 +17,7 @@ const useProjectQuery = (projectIdOrName: string) => {
     queryKey: ['project', projectIdOrName],
     queryFn: async () => {
       const api = await getAPI();
-      return api.projectApi.getProject({ projectIdOrName, includeEntitlements: true });
+      return api.projectApi.getProject({ projectIdOrName });
     },
   });
 };

--- a/src/hooks/query/useProjectWithEntitlementsQuery.ts
+++ b/src/hooks/query/useProjectWithEntitlementsQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useAPI } from 'services/api';
+import { useProject } from 'src/context/ProjectContextProvider';
+
+/**
+ * Query to get the project with entitlements
+ * entitlements is separate call additional call, a separate query is used to avoid
+ * unnecessary latency
+ * @returns
+ */
+export const useProjectWithEntitlementsQuery = () => {
+  const { project } = useProject();
+  const projectIdOrName = project?.id;
+  const getAPI = useAPI();
+
+  return useQuery({
+    queryKey: ['project', projectIdOrName, 'entitlements'],
+    queryFn: async () => {
+      if (!projectIdOrName) throw new Error('Project ID is required');
+      const api = await getAPI();
+      return api.projectApi.getProject({ projectIdOrName, includeEntitlements: true });
+    },
+    enabled: !!projectIdOrName,
+  });
+};

--- a/src/layout/AuthCardLayout/AmpersandFooter.tsx
+++ b/src/layout/AuthCardLayout/AmpersandFooter.tsx
@@ -1,12 +1,13 @@
-import { useProject } from 'context/ProjectContextProvider';
+import { useProjectWithEntitlementsQuery } from 'src/hooks/query/useProjectWithEntitlementsQuery';
+
 /**
  * Ampersand Logo in footer. Links to Ampersand website.
  * removes footer if branding removal is enabled
  * @returns
  */
 export function AmpersandFooter() {
-  const { project } = useProject();
-  const isBrandingRemoved = project?.entitlements?.brandingRemoval?.value === true;
+  const { data: projectWithEntitlements } = useProjectWithEntitlementsQuery();
+  const isBrandingRemoved = projectWithEntitlements?.entitlements?.brandingRemoval?.value === true;
 
   if (isBrandingRemoved) return null;
 


### PR DESCRIPTION
### Summary 
Creates a separate query for fetching projects with entitlements. 

Trade offs:
- fetches projects with entitlements only when Ampersand footer is rendered 
- double fetches project whenever footer is present 

notes: if performance is a concern than, we should consider entitlements as a separate endpoint.