### PR TITLE
build: bump peer deps to allow React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "vite-plugin-dts": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "x.x.x"
+    "react": ">=18.0.0 <20.0.0",
+    "react-dom": ">=18.0.0 <20.0.0"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.1.2",


### PR DESCRIPTION
### Summary
allow builder projects to use app with react 19. currently being tested in preview

https://storage.googleapis.com/ampersand/react/amp-labs-react-19.tgz