### PR TITLE
refactor: create installation mutation

### DIFF
--- a/src/hooks/mutation/useCreateInstallationMutation.ts
+++ b/src/hooks/mutation/useCreateInstallationMutation.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { CreateInstallationOperationRequest, useAPI } from 'services/api';
@@ -6,8 +7,9 @@ import { handleServerError } from 'src/utils/handleServerError';
 export const useCreateInstallationMutation = () => {
   const getAPI = useAPI();
   const queryClient = useQueryClient();
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  return useMutation({
+  const mutation = useMutation({
     mutationKey: ['createInstallation'],
     mutationFn: async (request: CreateInstallationOperationRequest) => {
       const api = await getAPI();
@@ -15,10 +17,16 @@ export const useCreateInstallationMutation = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['amp', 'installations'] });
+      setErrorMsg(null);
     },
     onError: (error) => {
       console.error('Error creating installation');
-      handleServerError(error);
+      handleServerError(error, setErrorMsg);
     },
   });
+
+  return {
+    ...mutation,
+    errorMsg,
+  };
 };

--- a/src/hooks/mutation/useCreateInstallationMutation.ts
+++ b/src/hooks/mutation/useCreateInstallationMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { CreateInstallationOperationRequest, useAPI } from 'services/api';
+import { handleServerError } from 'src/utils/handleServerError';
+
+export const useCreateInstallationMutation = () => {
+  const getAPI = useAPI();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['createInstallation'],
+    mutationFn: async (request: CreateInstallationOperationRequest) => {
+      const api = await getAPI();
+      return api.installationApi.createInstallation(request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['amp', 'installations'] });
+    },
+    onError: (error) => {
+      console.error('Error creating installation');
+      handleServerError(error);
+    },
+  });
+};


### PR DESCRIPTION
### Summary
followup to supporting proxy and subscribe create installation
- move create installation to a react-query mutation hook
- add support for subscribe-only installations
- refactor proxy-only installations to use the new mutation hook


