### PR TITLE
[ENG-2100]: [headless] useConnection 

### DIFF
--- a/src/headless/useConnections.ts
+++ b/src/headless/useConnections.ts
@@ -1,0 +1,34 @@
+import { useConnectionsListQuery } from 'hooks/query/useConnectionsListQuery';
+import { useIntegrationQuery } from 'hooks/query/useIntegrationQuery';
+
+import { useInstallationProps } from './InstallationProvider';
+
+/**
+ * Connection manager that gives a connection if one is available.
+ * Loading and error states are also returned.
+ */
+export const useConnection = () => {
+  const { groupRef, integrationId } = useInstallationProps();
+  const { provider } = useIntegrationQuery(integrationId);
+
+  const query = useConnectionsListQuery({ groupRef, provider });
+
+  const {
+    isPending, // The query has no data yet
+    isFetching, //  In any state, if the query is fetching at any time (including background refetching)
+    isError, // The query encountered an error
+    isSuccess, // The query was successful and data is available
+    error, // If the query is in an isError state, the error is available via the error property.
+    data: connections, // If the query is in an isSuccess state, the data is available via the data property.
+  } = query;
+
+  const connection = connections?.[0]; // a single connection if any
+
+  return {
+    connection, // first connection in connections array
+    error,
+    isLoading: isPending || isFetching,
+    isError,
+    isSuccess,
+  };
+};

--- a/src/headless/useConnections.ts
+++ b/src/headless/useConnections.ts
@@ -27,7 +27,8 @@ export const useConnection = () => {
   return {
     connection, // first connection in connections array
     error,
-    isLoading: isPending || isFetching,
+    isPending,
+    isFetching,
     isError,
     isSuccess,
   };


### PR DESCRIPTION
### Summary 
This PR adds useConnection hook. The hook returns the following: 

 ```
  return {
    connection, // first connection in connections array
    error,
    isLoading: isPending || isFetching,
    isError,
    isSuccess,
  };
```

note: isLoading is overloaded with isPending (no data yet) and isFetching (query is fetching). Note that react-query does this to allow optimistic updates (you can have data and still be fetching), overriding with isLoading will take away this feature in exchange for simplicity.