### PR TITLE
[ENG- 2114] refactor: change integrationId param to integrationName in Installati…

### DIFF
--- a/src/headless/InstallationProvider.tsx
+++ b/src/headless/InstallationProvider.tsx
@@ -8,7 +8,7 @@ import {
 
 // Define the context value type
 interface InstallationContextValue {
-  integrationId: string;
+  integrationName: string;
   consumerRef: string;
   consumerName?: string;
   groupRef: string;
@@ -16,7 +16,7 @@ interface InstallationContextValue {
 }
 // Create a context to pass down the props
 const InstallationContext = createContext<InstallationContextValue>({
-  integrationId: '',
+  integrationName: '',
   consumerRef: '',
   consumerName: undefined,
   groupRef: '',
@@ -33,7 +33,7 @@ export function useInstallationProps() {
 }
 
 interface InstallationProviderProps {
-  integrationId: string,
+  integrationName: string;
   consumerRef: string,
   consumerName?: string,
   groupRef: string,
@@ -43,15 +43,15 @@ interface InstallationProviderProps {
 
 // Wrap your parent component with the context provider
 export function InstallationProvider({
-  children, integrationId, consumerRef, consumerName, groupRef, groupName,
+  children, integrationName, consumerRef, consumerName, groupRef, groupName,
 }: InstallationProviderProps) {
   const props = useMemo(() => ({
-    integrationId,
+    integrationName,
     consumerRef,
     consumerName,
     groupRef,
     groupName,
-  }), [integrationId, consumerRef, consumerName, groupRef, groupName]);
+  }), [integrationName, consumerRef, consumerName, groupRef, groupName]);
 
   return (
     <InstallationContext.Provider value={props}>

--- a/src/headless/useConnections.ts
+++ b/src/headless/useConnections.ts
@@ -8,8 +8,8 @@ import { useInstallationProps } from './InstallationProvider';
  * Loading and error states are also returned.
  */
 export const useConnection = () => {
-  const { groupRef, integrationId } = useInstallationProps();
-  const { provider } = useIntegrationQuery(integrationId);
+  const { groupRef, integrationName } = useInstallationProps();
+  const { provider } = useIntegrationQuery(integrationName);
 
   const query = useConnectionsListQuery({ groupRef, provider });
 

--- a/src/hooks/query/useIntegrationQuery.ts
+++ b/src/hooks/query/useIntegrationQuery.ts
@@ -1,16 +1,19 @@
 import { useListIntegrationsQuery } from './useIntegrationListQuery';
 
 /**
- * get integration by id
- * @param integrationId
+ * get integration by name or id
+ * @param integrationNameOrId
  * @returns
  */
-export const useIntegrationQuery = (integrationId: string) => {
+export const useIntegrationQuery = (integrationNameOrId: string) => {
   // TODO: replace with getIntegration endpoint
   const integrationsQuery = useListIntegrationsQuery();
   const integrations = integrationsQuery.data;
 
-  const integration = integrations?.find((_integration) => _integration.id === integrationId);
+  const integration = integrations?.find(
+    (_integration) => _integration.name === integrationNameOrId // find by name
+      || _integration.id === integrationNameOrId, // find by id
+  );
 
   return {
     ...integrationsQuery,


### PR DESCRIPTION
### Summary
change integration id to integration name
- update useIntegrationQuery to use either integrationName or id
- note: InstallIntegration use `integration` to represent integrationName (internally inconsistent)


