### PR TITLE
fix: connections not being detected

### DIFF
--- a/src/context/ConnectionsContextProvider.tsx
+++ b/src/context/ConnectionsContextProvider.tsx
@@ -49,12 +49,12 @@ export function ConnectionsProvider({ groupRef, provider, children }: Connection
   const queryClient = useQueryClient();
   const { setError, isError } = useErrorState();
   const { projectId, isLoading: isProjectLoading } = useProject();
-  const { integrationId } = useInstallIntegrationProps();
+  const { integrationId, groupRef: groupRefProp } = useInstallIntegrationProps();
   const { provider: integrationProvider } = useIntegrationQuery(integrationId);
 
   const {
     data: connections, isLoading: isConnectionsLoading, isError: isConnectionsError, error: connectionError,
-  } = useConnectionsListQuery({ groupRef, provider: integrationProvider || provider });
+  } = useConnectionsListQuery({ groupRef: groupRef || groupRefProp, provider: integrationProvider || provider });
 
   // simplify connections logic to be derived from the first connection
   const selectedConnection = connections?.[0];


### PR DESCRIPTION
### Summary
connections was not being detected.
root cause: group ref was missing (overloaded in a few components), easy to miss.
Oauth connections should work as expected.

#### Considerations
 - may need to consider adding oauth simple integration tests to make sure components load. 
- decouple headless and install components to use different hooks when context dependent.



