### PR TITLE
[ENG-1974] style: remove button outline

### DIFF
--- a/src/components/form/Input/input.module.css
+++ b/src/components/form/Input/input.module.css
@@ -29,7 +29,7 @@
 }
 
 .input:focus:enabled {
-    border: 2px solid var(--amp-colors-input-border-focus);
+    border: 1px solid var(--amp-colors-input-border-focus);
     outline: none;
     background-color: var(--amp-colors-input-surface-focus);
 }

--- a/src/components/ui-base/Button/button.module.css
+++ b/src/components/ui-base/Button/button.module.css
@@ -17,12 +17,20 @@
     opacity: .8;
 }
 
+.button:focus {
+    outline: none;
+}
+
+.button:focus-visible {
+    outline: none;
+}
+
 .buttonError {
     border: 1px solid var(--amp-colors-status-critical);
 }
 
 .button:focus:enabled {
-    border: 2px solid var(--amp-colors-input-border-focus);
+    /* border: 1px solid var(--amp-colors-input-border-focus); */
     outline: none;
 }
 


### PR DESCRIPTION
### Summary 
address button feedback
- removes active selected state from basic button
- removes 2px outline from input to match

![remove-button-outline](https://github.com/user-attachments/assets/6416c97d-a998-4f22-b69b-fa287ba350ca)

