### PR TITLE
[ENG-2101] feat: add useManifest hook

### DIFF
--- a/src/headless/manifest/useHydratedRevisionQuery.ts
+++ b/src/headless/manifest/useHydratedRevisionQuery.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import {
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { useProject } from 'src/context/ProjectContextProvider';
+import { useIntegrationQuery } from 'src/hooks/query/useIntegrationQuery';
+import { useAPI } from 'src/services/api';
+
+// headless hooks
+import { useInstallationProps } from '../InstallationProvider';
+import { useConnection } from '../useConnection';
+
+/**
+ * gets hydrated revision using headless hooks to fill in details
+ * @returns
+ */
+export const useHydratedRevisionQuery = () => {
+  const queryClient = useQueryClient();
+  const getAPI = useAPI();
+  const { connection, isPending: isConnectionsPending, isFetching: isConnectionsFetching } = useConnection();
+  const { projectIdOrName } = useProject();
+  const { integrationNameOrId } = useInstallationProps();
+  const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
+
+  const connectionId = connection?.id;
+  const integrationId = integrationObj?.id;
+  const revisionId = integrationObj?.latestRevision?.id;
+  const isConnectionsLoading = isConnectionsPending || isConnectionsFetching;
+
+  useEffect(() => {
+    if (!connectionId) {
+      // clear the query cache if connectionId is not set (includes resetting cached errors)
+      queryClient.invalidateQueries({ queryKey: ['amp', 'hydratedRevision'] });
+    }
+  }, [connectionId, queryClient]);
+
+  return useQuery({
+    queryKey: ['amp', 'hydratedRevision', projectIdOrName, integrationId, revisionId, connectionId],
+    queryFn: async () => {
+      if (!projectIdOrName) throw new Error('projectIdOrName is required');
+      if (!integrationId) throw new Error('integrationId is required');
+      if (!revisionId) throw new Error('revisionId is required');
+      if (!connectionId) throw new Error('connectionId is required');
+
+      const api = await getAPI();
+      return api.revisionApi.getHydratedRevision({
+        projectIdOrName,
+        integrationId,
+        revisionId,
+        connectionId,
+      });
+    },
+    retry: 3, // retry 3 times before showing error
+    enabled: !!projectIdOrName && !!integrationId && !!revisionId && !!connectionId && !isConnectionsLoading,
+  });
+};

--- a/src/headless/manifest/useManifest.ts
+++ b/src/headless/manifest/useManifest.ts
@@ -1,0 +1,104 @@
+/**
+ * Based on sample
+ *
+  const manifest = useManifest();
+
+  // Get the required and optional fields defined in amp.yaml (allows ide flexibility)
+  const requiredFields = manifest.getReadObject(SELECTED_OBJECT_NAME).getRequiredFields();
+  const optionalFields = manifest.getReadObject(SELECTED_OBJECT_NAME).getOptionalFields();
+
+  // Get all the fields that exist in the customer's Hubspot Contact object
+  const allFields = manifest.getCustomerFieldsForObject(SELECTED_OBJECT_NAME)
+ */
+
+import { useMemo } from 'react';
+import { FieldMetadata, HydratedIntegrationField, HydratedIntegrationObject } from '@generated/api/src';
+
+import { useHydratedRevisionQuery } from './useHydratedRevisionQuery';
+
+export interface Manifest {
+  getReadObject: (objectName: string) => {
+    object: HydratedIntegrationObject | null,
+    getRequiredFields: () => HydratedIntegrationField[] | null;
+    getOptionalFields: () => HydratedIntegrationField[] | null;
+  };
+  getCustomerFieldsForObject: (objectName: string) => HydratedIntegrationField[] | null;
+  getCustomerFieldsMetadataForObject: (objectName: string) => {
+    allFieldsMetaData:{ [key: string]: FieldMetadata; } | null;
+    getField: (field: string) => FieldMetadata | null;
+  }
+}
+
+/**
+ *  useManifest retrieves data from `amp.yaml` file, plus the customer's SaaS instance.
+ * @returns Manifest object
+ *
+ * if object is not found, returns null for the object, getRequiredFields, getOptionalFields,
+ *  getCustomerFieldsForObject, getCustomerFieldsMetadataForObject
+ *
+ */
+export function useManifest() {
+  const hydratedRevisionQuery = useHydratedRevisionQuery();
+  const {
+    isPending,
+    isFetching,
+    isError,
+    isSuccess,
+    error,
+    data: hydatedRevision,
+  } = hydratedRevisionQuery;
+
+  const content = hydatedRevision?.content;
+
+  const manifest: Manifest = useMemo(() => ({
+    getReadObject: (objectName: string) => {
+      const object = content?.read?.objects?.find((obj) => obj.objectName === objectName);
+      if (!object) {
+        console.error(`Object ${objectName} not found`);
+        return { object: null, getRequiredFields: () => null, getOptionalFields: () => null };
+      }
+
+      return {
+        object,
+        getRequiredFields: (): HydratedIntegrationField[] => object.requiredFields ?? [],
+        getOptionalFields: (): HydratedIntegrationField[] => object.optionalFields ?? [],
+      };
+    },
+    getCustomerFieldsForObject: (objectName: string): HydratedIntegrationField[] | null => {
+      const object = content?.read?.objects?.find((obj) => obj.objectName === objectName);
+      if (!object) {
+        console.error(`Object ${objectName} not found`);
+        return null;
+      }
+      return object.allFields ?? [];
+    },
+    getCustomerFieldsMetadataForObject: (objectName: string) => {
+      const object = content?.read?.objects?.find((obj) => obj.objectName === objectName);
+      if (!object) {
+        console.error(`Object ${objectName} not found`);
+        return { allFieldsMetaData: null, getField: () => null };
+      }
+      return {
+        allFieldsMetaData: object.allFieldsMetadata ?? {},
+        getField: (field: string): FieldMetadata | null => {
+          const fieldMetadata = object.allFieldsMetadata?.[field];
+          if (!fieldMetadata) {
+            console.error(`Field ${field} not found`);
+            return null;
+          }
+          return fieldMetadata;
+        },
+      };
+    },
+  }), [content?.read?.objects]);
+
+  return {
+    data: hydatedRevision,
+    ...manifest,
+    isPending,
+    isFetching,
+    isError,
+    isSuccess,
+    error,
+  };
+}


### PR DESCRIPTION
### Summary
adds a useManifest hook which will help get fields from the manifest (amp.yaml)
- add useHydratedRevisionQuery in headless
- add getters in manifest

note: the headless folder is not public in the repo.

#### updated error handling
When the getters fail, we return null to allow for more graceful rendering logic and the ability for the UI to handle not found cases. The builder may need to null-check.

#### testing
We can test this inside the existing app by add an InstallationProvider at the InstallIntegration top level component and calling the use manifest hook along with destructuring inside a useEffect as follows:

```js
// InstallationContent will be wrapped by InstallationProvider
export function InstallationContent() {
  const manifest = useManifest();

  useEffect(() => {
    const { getReadObject, getCustomerFieldsForObject, getCustomerFieldsMetadataForObject } = manifest;
    const readObject = getReadObject('leads');
    const { object, getRequiredFields, getOptionalFields } = readObject;
    const requiredFields = getRequiredFields();
    const optionalFields = getReadObject('account').getOptionalFields();
    const allFields = getCustomerFieldsForObject('account');
    const allFieldsMetadata = getCustomerFieldsMetadataForObject('account');
    const field = allFieldsMetadata.getField('accountnumber');
    console.log('manifest', manifest);
    console.log('requiredFields', requiredFields);
    console.log('optionalFields', optionalFields);
    console.log('allFields', allFields);
    console.log('allFieldsMetadata', allFieldsMetadata);
    console.log('field', field);
  }, [manifest]);

return <MyComponent/>
 }
```

<img width="1470" alt="Screenshot 2025-04-07 at 2 11 28 PM" src="https://github.com/user-attachments/assets/827de80e-a3ad-4683-a4bd-688c831c4a57" />

#### IDE dev experience
![Screenshot 2025-04-07 at 1 58 27 PM](https://github.com/user-attachments/assets/a03a8afc-81ed-42d1-b632-5a7f690c01af)

#### not handled
- written tests
- write objects



