### PR TITLE
feat: add useConnectionQuery hook

### DIFF
--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,3 +1,4 @@
+import { useConnectionQuery } from './useConnectionQuery';
 import { useConnectionsListQuery } from './useConnectionsListQuery';
 import { useListIntegrationsQuery } from './useIntegrationListQuery';
 import { useListInstallationsQuery } from './useListInstallationsQuery';
@@ -5,6 +6,7 @@ import { useListProviderAppsQuery } from './useListProviderAppsQuery';
 import { useOauthConnectQuery } from './useOauthConnectQuery';
 
 export {
+  useConnectionQuery,
   useConnectionsListQuery,
   useListIntegrationsQuery,
   useListInstallationsQuery,

--- a/src/hooks/query/useConnectionQuery.ts
+++ b/src/hooks/query/useConnectionQuery.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useProject } from 'src/context/ProjectContextProvider';
+import { useAPI } from 'src/services/api';
+
+type ConnectionQueryProps = {
+  connectionId: string;
+};
+
+export const useConnectionQuery = ({ connectionId }: ConnectionQueryProps) => {
+  const getAPI = useAPI();
+  const { projectIdOrName } = useProject();
+
+  return useQuery({
+    queryKey: ['connection', connectionId, projectIdOrName],
+    queryFn: async () => {
+      if (!projectIdOrName) {
+        throw new Error('Project ID or name not found. Please wrap this component inside of AmpersandProvider');
+      }
+      if (!connectionId) throw new Error('Connection ID not found.');
+
+      const api = await getAPI();
+      return api.connectionApi.getConnection({ projectIdOrName, connectionId });
+    },
+    enabled: !!projectIdOrName && !!connectionId,
+  });
+};


### PR DESCRIPTION
### Summary 
Part 1 in Update Connection in InstallIntegration 
- adds useConnectionQuery in hooks/query folder

#### Tested the hook in the following
```js
import { useEffect } from 'react';
import { useConnectionQuery } from 'src/hooks/query';

export function UninstallContent() {
  const { installation } = useInstallIntegrationProps();
  const connectionId = installation?.connection?.id || '';
  const { data: connection } = useConnectionQuery({ connectionId });

  useEffect(() => {
    if (connection) {
      console.log('connection', connection);
    }
  }, [connection]);

  return (
    // smth
  );
}

```
#### console log connection
<img width="1474" alt="Screenshot 2025-04-08 at 4 21 33 PM" src="https://github.com/user-attachments/assets/f41725e3-525b-4252-9425-b3a208b55b03" />


