### PR TITLE
[ENG-2154] fix: oauth infinite window loop

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/OAuthWindow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/OAuthWindow.tsx
@@ -29,10 +29,12 @@ export function OAuthWindow({
 
   // open the OAuth window on mount and prop change
   useEffect(() => {
-    if (oauthUrl && !oauthWindow) {
+    // if the oauthUrl is not null, the oauthWindow is not open,
+    // the connection not successfully created, and the error is not set, open the OAuth window
+    if (oauthUrl && !oauthWindow && !connectionId && !error) {
       openOAuthWindow(); // creates new window and adds event listener
     }
-  }, [oauthUrl, oauthWindow, openOAuthWindow, receiveMessage, windowTitle]);
+  }, [oauthUrl, oauthWindow, openOAuthWindow, connectionId, error]);
 
   useEffect(() => {
     if (!oauthWindow) return;
@@ -45,7 +47,7 @@ export function OAuthWindow({
 
         if (!connectionId && !error) {
           console.error('OAuth failed. Please try again.');
-          onError?.('Something went wrong. Please try again.');
+          onError?.('Authentication was cancelled. Please try again.');
         } else if (connectionId) {
           onError?.(null);
         }

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -75,6 +75,7 @@ export function WorkspaceOauthFlow({
       windowTitle={`Connect to ${providerName}`}
       oauthUrl={oAuthPopupURL || null}
       onError={onError}
+      error={errorMessage}
     >
       {workspaceEntryComponent}
     </OAuthWindow>


### PR DESCRIPTION
### Summary 
fixes issue with oauth window re-opening even when user closes the window and there is an error 

### solution
checks if there is a successful connection or error before triggering openAuthWindow()

### demo
![fix-oauth-popup-error-loop](https://github.com/user-attachments/assets/0d0a4b4f-ca03-4fc1-905c-bcad4b011231)

