### PR TITLE
[ENG-2157] feat: update client credentials

### DIFF
--- a/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
@@ -1,7 +1,72 @@
+import { useState } from 'react';
+
+import { ClientCredentialsContent } from 'src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent';
+import { ClientCredentialsCredsContent } from 'src/components/auth/Oauth/ClientCredentials/ClientCredentialsCredsContent';
+import { FormSuccessBox } from 'src/components/FormSuccessBox';
+import { useConnections } from 'src/context/ConnectionsContextProvider';
+import { useProject } from 'src/context/ProjectContextProvider';
+import { useUpdateConnectionMutation } from 'src/hooks/mutation/useUpdateConnectionMutation';
+import { useProvider } from 'src/hooks/useProvider';
+import { handleServerError } from 'src/utils/handleServerError';
+
+import { FieldHeader } from '../../fields/FieldHeader';
+
 export function UpdateClientCredentialsConnect() {
+  const { projectIdOrName } = useProject();
+  const { selectedConnection, isConnectionsLoading } = useConnections();
+  const { providerName, data: providerInfo } = useProvider();
+  const {
+    mutateAsync: updateConnection, isPending: isConnectionUpdating, error: updateError,
+  } = useUpdateConnectionMutation();
+
+  const [localError, setError] = useState<string | null>(null);
+  const [successConnect, setSuccessConnect] = useState<boolean>(false);
+
+  const resetSuccessConnect = () => {
+    setSuccessConnect(false);
+  };
+
+  const handleSuccessConnect = () => {
+    setSuccessConnect(true);
+    setError(null);
+  };
+
+  const explicitScopesRequired = providerInfo?.oauth2Opts?.explicitScopesRequired;
+  const error = updateError?.message || localError || null;
+  const handleSubmit = async (formData: ClientCredentialsCredsContent) => {
+    resetSuccessConnect();
+    setError(null);
+
+    try {
+      await updateConnection({
+        projectIdOrName: projectIdOrName || '',
+        connectionId: selectedConnection?.id || '',
+        updateConnectionRequest: {
+          oauth2ClientCredentials: {
+            clientId: formData.clientId,
+            clientSecret: formData.clientSecret,
+            scopes: formData.scopes,
+          },
+        },
+      });
+      handleSuccessConnect();
+    } catch (e) {
+      handleServerError(e, setError);
+    }
+  };
+
   return (
-    <div>
-      placeholder client credentials
-    </div>
+    <>
+      <FieldHeader string="Update Connection" />
+      {successConnect && <FormSuccessBox>Connection updated successfully</FormSuccessBox>}
+      <ClientCredentialsContent
+        handleSubmit={handleSubmit}
+        error={error}
+        isButtonDisabled={isConnectionUpdating || isConnectionsLoading}
+        providerName={providerName}
+        explicitScopesRequired={explicitScopesRequired} // todo: add scopes to update connection
+        explicitWorkspaceRequired={false} // workspace is not updated so do not show
+      />
+    </>
   );
 }

--- a/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
@@ -43,10 +43,13 @@ export function UpdateClientCredentialsConnect() {
         projectIdOrName: projectIdOrName || '',
         connectionId: selectedConnection?.id || '',
         updateConnectionRequest: {
-          oauth2ClientCredentials: {
-            clientId: formData.clientId,
-            clientSecret: formData.clientSecret,
-            scopes: formData.scopes,
+          updateMask: ['oauth2ClientCredentials'],
+          connection: {
+            oauth2ClientCredentials: {
+              clientId: formData.clientId,
+              clientSecret: formData.clientSecret,
+              scopes: formData.scopes,
+            },
           },
         },
       });
@@ -65,7 +68,7 @@ export function UpdateClientCredentialsConnect() {
       >
         <p>{`Re-authenticate to ${providerName}`}</p>
         {successConnect && <FormSuccessBox>Connection updated successfully</FormSuccessBox>}
-        {error && <FormErrorBox>Error updating connection {error}</FormErrorBox>}
+        {error && <FormErrorBox>{`Error updating connection ${error}`}</FormErrorBox>}
 
         <ClientCredentialsForm
           handleSubmit={handleSubmit}

--- a/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 
-import { ClientCredentialsContent } from 'src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent';
+import { ClientCredentialsForm } from 'src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent';
 import { ClientCredentialsCredsContent } from 'src/components/auth/Oauth/ClientCredentials/ClientCredentialsCredsContent';
+import { FormErrorBox } from 'src/components/FormErrorBox';
 import { FormSuccessBox } from 'src/components/FormSuccessBox';
 import { useConnections } from 'src/context/ConnectionsContextProvider';
 import { useProject } from 'src/context/ProjectContextProvider';
@@ -58,15 +59,22 @@ export function UpdateClientCredentialsConnect() {
   return (
     <>
       <FieldHeader string="Update Connection" />
-      {successConnect && <FormSuccessBox>Connection updated successfully</FormSuccessBox>}
-      <ClientCredentialsContent
-        handleSubmit={handleSubmit}
-        error={error}
-        isButtonDisabled={isConnectionUpdating || isConnectionsLoading}
-        providerName={providerName}
-        explicitScopesRequired={explicitScopesRequired} // todo: add scopes to update connection
-        explicitWorkspaceRequired={false} // workspace is not updated so do not show
-      />
+      <div style={{
+        padding: '1rem 0', display: 'flex', flexDirection: 'column', gap: '.5rem',
+      }}
+      >
+        <p>{`Re-authenticate to ${providerName}`}</p>
+        {successConnect && <FormSuccessBox>Connection updated successfully</FormSuccessBox>}
+        {error && <FormErrorBox>Error updating connection {error}</FormErrorBox>}
+
+        <ClientCredentialsForm
+          handleSubmit={handleSubmit}
+          isButtonDisabled={isConnectionUpdating || isConnectionsLoading}
+          explicitScopesRequired={explicitScopesRequired}
+          explicitWorkspaceRequired={false}
+          buttonVariant="ghost"
+        />
+      </div>
     </>
   );
 }

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContainer.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContainer.tsx
@@ -10,7 +10,8 @@ import { useProject } from 'context/ProjectContextProvider';
 
 import { useCreateConnectionMutation } from '../../useCreateConnectionMutation';
 
-import { ClientCredentialsContent, ClientCredentialsCredsContent } from './ClientCredentialsContent';
+import { ClientCredentialsContent } from './ClientCredentialsContent';
+import { ClientCredentialsCredsContent } from './ClientCredentialsCredsContent';
 
 interface OauthClientCredsContainerProps {
   provider: string;

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
@@ -6,12 +6,7 @@ import { Button } from 'src/components/ui-base/Button';
 import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
 import { convertTextareaToArray } from 'src/utils';
 
-export type ClientCredentialsCredsContent = {
-  workspace?: string;
-  clientId: string;
-  clientSecret: string;
-  scopes?: string[];
-};
+import { ClientCredentialsCredsContent } from './ClientCredentialsCredsContent';
 
 type ClientCredentialsContentProps = {
   handleSubmit: (creds: ClientCredentialsCredsContent) => void;

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
@@ -8,19 +8,18 @@ import { convertTextareaToArray } from 'src/utils';
 
 import { ClientCredentialsCredsContent } from './ClientCredentialsCredsContent';
 
-type ClientCredentialsContentProps = {
+type ClientCredentialsFormProps = {
   handleSubmit: (creds: ClientCredentialsCredsContent) => void;
-  error: string | null;
+  isButtonDisabled?: boolean;
   explicitScopesRequired?: boolean;
   explicitWorkspaceRequired?: boolean;
-  isButtonDisabled?: boolean;
-  providerName?: string;
+  buttonVariant?: 'ghost';
 };
 
-export function ClientCredentialsContent({
-  handleSubmit, error, isButtonDisabled, providerName,
-  explicitScopesRequired, explicitWorkspaceRequired,
-}: ClientCredentialsContentProps) {
+export function ClientCredentialsForm({
+  handleSubmit, isButtonDisabled, explicitScopesRequired, explicitWorkspaceRequired,
+  buttonVariant,
+}: ClientCredentialsFormProps) {
   const [show, setShow] = useState(false);
 
   const [formData, setFormData] = useState({
@@ -67,10 +66,7 @@ export function ClientCredentialsContent({
   };
 
   return (
-    <AuthCardLayout>
-      <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
-      <AuthErrorAlert error={error} />
-      <br />
+    <>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '1.2rem' }}>
         {explicitWorkspaceRequired && (
         <FormComponent.Input
@@ -100,6 +96,7 @@ export function ClientCredentialsContent({
             type="button"
             style={{ height: '2.5rem', width: '5rem' }}
             onClick={onToggleShowHide}
+            variant={buttonVariant}
           >
             {show ? 'Hide' : 'Show'}
           </Button>
@@ -114,14 +111,42 @@ export function ClientCredentialsContent({
       </div>
       <br />
       <Button
-        style={{ marginTop: '1em', width: '100%' }}
+        style={{ width: '100%' }}
         disabled={isSubmitDisabled}
         type="submit"
         onClick={onHandleSubmit}
+        variant={buttonVariant}
       >
         Next
       </Button>
+    </>
+  );
+}
 
+type ClientCredentialsContentProps = {
+  handleSubmit: (creds: ClientCredentialsCredsContent) => void;
+  error: string | null;
+  explicitScopesRequired?: boolean;
+  explicitWorkspaceRequired?: boolean;
+  isButtonDisabled?: boolean;
+  providerName?: string;
+};
+
+export function ClientCredentialsContent({
+  handleSubmit, error, isButtonDisabled, providerName,
+  explicitScopesRequired, explicitWorkspaceRequired,
+}: ClientCredentialsContentProps) {
+  return (
+    <AuthCardLayout>
+      <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
+      <AuthErrorAlert error={error} />
+      <br />
+      <ClientCredentialsForm
+        handleSubmit={handleSubmit}
+        isButtonDisabled={isButtonDisabled}
+        explicitScopesRequired={explicitScopesRequired}
+        explicitWorkspaceRequired={explicitWorkspaceRequired}
+      />
     </AuthCardLayout>
   );
 }

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
@@ -113,7 +113,7 @@ export function ClientCredentialsForm({
       <Button
         style={{ width: '100%' }}
         disabled={isSubmitDisabled}
-        type="submit"
+        type="button"
         onClick={onHandleSubmit}
         variant={buttonVariant}
       >

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsCredsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsCredsContent.tsx
@@ -1,0 +1,6 @@
+export type ClientCredentialsCredsContent = {
+  workspace?: string;
+  clientId: string;
+  clientSecret: string;
+  scopes?: string[];
+};


### PR DESCRIPTION
### Summary
update client credentials
- refactors client credentials form to use without border in the update connections flow

note: we'll waive end to end testing for this feat. will just show the UI as intended. (updateConnection endpoint works for apiKey)

#### Testing
To test the Update Connections tab, you'll need to switch the hard coded feature flag to: `SHOW_MANAGE_TAB = true`

1. Deploy Marketo Integration Amp.Yaml with some configuration
2. Setup Provider App and destination in console
3. InstallIntegration via mailmonkey/demo-app and use Marketo projectId and integrationName
4. Login with Client Credentials to Marketo
5. Click install after configuring.
6. Click on placeholder manage tab (may be hidden if SHOW_MANAGE_TAB is not turned on)
7. Fill out the client credentials in Update Connection section of Manage tab
8. Click Button -> should see success or fail dialog.

### Screenshot
![Screenshot 2025-04-14 at 2 38 04 PM](https://github.com/user-attachments/assets/0ca67b33-e71f-402d-bdeb-e1c40e45b0b3)

![Screenshot 2025-04-14 at 2 41 19 PM](https://github.com/user-attachments/assets/af4d91ae-8864-4126-8e69-0d42c4f0885d)

