### PR TITLE
[ENG-2149] feat/refactor: api key connection, update api keyconnection

### DIFF
--- a/src/components/Configure/content/manage/AuthenticationSection.tsx
+++ b/src/components/Configure/content/manage/AuthenticationSection.tsx
@@ -1,3 +1,4 @@
+import { useConnections } from 'src/context/ConnectionsContextProvider';
 import { useInstallIntegrationProps } from
   'src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
 import { useConnectionQuery } from 'src/hooks/query';
@@ -16,7 +17,8 @@ function AuthenticationRow({ label, value }: { label: string; value: string | un
 }
 export function AuthenticationSection() {
   const { installation } = useInstallIntegrationProps();
-  const connectionId = installation?.connection?.id || '';
+  const { selectedConnection } = useConnections();
+  const connectionId = installation?.connection?.id || selectedConnection?.id || '';
   const { data: connection } = useConnectionQuery({ connectionId });
 
   const isSalesforce = connection?.provider === 'salesforce';

--- a/src/components/Configure/content/manage/updateConnection/UpdateConnectionSection.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateConnectionSection.tsx
@@ -2,6 +2,7 @@ import { AuthType, Oauth2OptsGrantTypeEnum } from '@generated/api/src';
 
 import { useProviderInfoQuery } from 'src/hooks/useProvider';
 
+import { UpdateApiKeyConnect } from './updateApiKeyConnect';
 import { UpdateClientCredentialsConnect } from './UpdateClientCredentialsConnect';
 import { UpdateOauthConnect } from './UpdateOauthConnect';
 
@@ -13,7 +14,7 @@ export function UpdateConnectionSection() {
   }
 
   if (providerInfo?.authType === AuthType.ApiKey) {
-    // placeholder api key
+    return <UpdateApiKeyConnect />;
   }
 
   // if oauth2 and supported grant type, oauth update connection

--- a/src/components/Configure/content/manage/updateConnection/updateApiKeyConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/updateApiKeyConnect.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+
+import { ApiKeyAuthForm } from 'src/components/auth/ApiKeyAuth/ApiKeyAuthContent';
+import { IFormType } from 'src/components/auth/ApiKeyAuth/LandingContentProps';
+import { FormErrorBox } from 'src/components/FormErrorBox';
+import { FormSuccessBox } from 'src/components/FormSuccessBox';
+import { useConnections } from 'src/context/ConnectionsContextProvider';
+import { useProject } from 'src/context/ProjectContextProvider';
+import { useUpdateConnectionMutation } from 'src/hooks/mutation/useUpdateConnectionMutation';
+import { useProvider } from 'src/hooks/useProvider';
+import { handleServerError } from 'src/utils/handleServerError';
+
+import { FieldHeader } from '../../fields/FieldHeader';
+
+export function UpdateApiKeyConnect() {
+  const { projectIdOrName } = useProject();
+  const { providerName, data: providerInfo } = useProvider();
+  const { selectedConnection, isConnectionsLoading } = useConnections();
+
+  const {
+    mutateAsync: updateConnection, isPending: isConnectionUpdating, error: updateError,
+  } = useUpdateConnectionMutation();
+
+  const [localError, setError] = useState<string | null>(null);
+  const [successConnect, setSuccessConnect] = useState<boolean>(false);
+
+  const resetSuccessConnect = () => setSuccessConnect(false);
+
+  const handleSuccessConnect = () => {
+    setSuccessConnect(true);
+    setError(null);
+  };
+
+  const error = updateError?.message || localError || null;
+  const handleSubmit = async (form: IFormType) => {
+    resetSuccessConnect();
+    setError(null);
+
+    try {
+      await updateConnection(
+        {
+          projectIdOrName: projectIdOrName || '',
+          connectionId: selectedConnection?.id || '',
+          updateConnectionRequest: {
+            updateMask: ['apiKey'],
+            connection: { apiKey: form.apiKey },
+          },
+        },
+        {
+          onError: (e) => {
+            console.error(e);
+            handleServerError(e, setError);
+          },
+          onSuccess: () => {
+            handleSuccessConnect();
+          },
+        },
+      );
+    } catch (e) {
+      console.error(e);
+      handleServerError(e, setError);
+    }
+  };
+
+  if (!providerInfo) return null;
+
+  return (
+    <>
+      <FieldHeader string="Update Connection" />
+      <div style={{
+        padding: '1rem 0', display: 'flex', flexDirection: 'column', gap: '.5rem',
+      }}
+      >
+        <p>{`Update ${providerName} API Key`}</p>
+        {successConnect && <FormSuccessBox>Connection updated successfully</FormSuccessBox>}
+        {error && <FormErrorBox>{`Error updating connection ${error}`}</FormErrorBox>}
+        <ApiKeyAuthForm
+          provider={providerInfo?.name}
+          providerInfo={providerInfo}
+          handleSubmit={handleSubmit}
+          isButtonDisabled={isConnectionUpdating || isConnectionsLoading}
+          buttonVariant="ghost"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -1,17 +1,27 @@
 import { useState } from 'react';
+import { ProviderInfo } from '@generated/api/src';
 
-import { AuthCardLayoutTemplate } from 'components/auth/AuthCardLayoutTemplate';
 import { DocsHelperText } from 'components/Docs/DocsHelperText';
+import { AuthErrorAlert } from 'src/components/auth/AuthErrorAlert/AuthErrorAlert';
 import { FormComponent } from 'src/components/form';
 import { Button } from 'src/components/ui-base/Button';
 import { useProvider } from 'src/hooks/useProvider';
+import { AuthCardLayout, AuthTitle } from 'src/layout/AuthCardLayout/AuthCardLayout';
 import { capitalize } from 'src/utils';
 
-import { LandingContentProps } from './LandingContentProps';
+import { IFormType, LandingContentProps } from './LandingContentProps';
 
-function ApiKeyAuthContentForm({
-  provider, providerInfo, handleSubmit, error, isButtonDisabled,
-}: LandingContentProps) {
+type ApiKeyAuthFormProps = {
+  provider: string;
+  providerInfo: ProviderInfo;
+  handleSubmit: (form: IFormType) => void;
+  isButtonDisabled?: boolean;
+  buttonVariant?: 'ghost';
+};
+
+export function ApiKeyAuthForm({
+  provider, providerInfo, handleSubmit, isButtonDisabled, buttonVariant,
+}: ApiKeyAuthFormProps) {
   const [show, setShow] = useState(false);
   const onToggleShowHide = () => setShow((prevShow) => !prevShow);
   const [apiKey, setApiKey] = useState('');
@@ -23,41 +33,63 @@ function ApiKeyAuthContentForm({
   const docsURL = providerInfo.apiKeyOpts?.docsURL;
 
   return (
-    <AuthCardLayoutTemplate
-      providerName={providerName}
-      handleSubmit={() => { handleSubmit({ apiKey }); }}
-      error={error}
-      isButtonDisabled={isSubmitDisabled}
+    <div style={{
+      display: 'flex', gap: '1rem', flexDirection: 'column', marginTop: '1rem',
+    }}
     >
-      <div style={{
-        display: 'flex', gap: '1rem', flexDirection: 'column', marginTop: '1rem',
-      }}
-      >
-        {docsURL && (
-        <DocsHelperText
-          url={docsURL}
-          providerDisplayName={providerName || capitalize(provider)}
-          credentialName="API key"
+      {docsURL && (
+      <DocsHelperText
+        url={docsURL}
+        providerDisplayName={providerName || capitalize(provider)}
+        credentialName="API key"
+      />
+      )}
+      <div style={{ display: 'flex', gap: '.5rem' }}>
+        <FormComponent.Input
+          id="password"
+          name="password"
+          type={show ? 'text' : 'password'}
+          placeholder="API Key"
+          onChange={(event) => handlePasswordChange(event)}
         />
-        )}
-        <div style={{ display: 'flex', gap: '.5rem' }}>
-          <FormComponent.Input
-            id="password"
-            name="password"
-            type={show ? 'text' : 'password'}
-            placeholder="API Key"
-            onChange={(event) => handlePasswordChange(event)}
-          />
-          <Button
-            type="button"
-            style={{ height: '2.5rem', width: '5rem' }}
-            onClick={onToggleShowHide}
-          >
-            {show ? 'Hide' : 'Show'}
-          </Button>
-        </div>
+        <Button
+          type="button"
+          style={{ height: '2.5rem', width: '5rem' }}
+          onClick={onToggleShowHide}
+          variant={buttonVariant}
+        >
+          {show ? 'Hide' : 'Show'}
+        </Button>
       </div>
-    </AuthCardLayoutTemplate>
+      <Button
+        style={{ marginTop: '1em', width: '100%' }}
+        disabled={isSubmitDisabled}
+        type="submit"
+        onClick={() => handleSubmit({ apiKey })}
+        variant={buttonVariant}
+      >
+        Next
+      </Button>
+    </div>
+  );
+}
+
+function ApiKeyAuthContentForm({
+  provider, providerInfo, handleSubmit, error, isButtonDisabled,
+}: LandingContentProps) {
+  const { providerName } = useProvider(provider);
+
+  return (
+    <AuthCardLayout>
+      <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
+      <AuthErrorAlert error={error} />
+      <ApiKeyAuthForm
+        provider={provider}
+        providerInfo={providerInfo}
+        handleSubmit={handleSubmit}
+        isButtonDisabled={isButtonDisabled}
+      />
+    </AuthCardLayout>
   );
 }
 

--- a/src/hooks/mutation/useUpdateConnectionMutation.ts
+++ b/src/hooks/mutation/useUpdateConnectionMutation.ts
@@ -3,7 +3,6 @@ import { UpdateConnectionOperationRequest } from '@generated/api/src';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useAPI } from 'services/api';
-import { handleServerError } from 'src/utils/handleServerError';
 
 export const useUpdateConnectionMutation = () => {
   const getAPI = useAPI();
@@ -19,10 +18,6 @@ export const useUpdateConnectionMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['amp', 'connections'] });
       setErrorMsg(null);
-    },
-    onError: (error) => {
-      console.error('Error updating connection');
-      handleServerError(error, setErrorMsg);
     },
   });
 


### PR DESCRIPTION
### Summary
- refactor api key form 
- adds update api key connection form
- adds ghost variant for update connection form
- fixes authenticate section to find connection if installation is not available

 ### Screenshot
![Screenshot 2025-04-15 at 11 59 42 AM](https://github.com/user-attachments/assets/fd38201e-2c0c-4e0c-963b-2ab43634b9dd)

### end to end
tested using monday integration (prod, connector-test-project)
![update-api-connection-request](https://github.com/user-attachments/assets/347548b1-7f58-41c7-9b7e-800afb8f5edd)

### note
If the user tries to re-authenticate and no installation exists, the component will reset and change back to the first tab.