### PR TITLE
feat: remove buttons save and reset on manage tab

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -73,11 +73,15 @@ export function ConfigureInstallationBase(
       : (
         <form style={{ width: '34rem' }} onSubmit={onSave}>
           <div style={{
-            display: 'flex', flexDirection: 'row-reverse', gap: '.8rem', marginBottom: '20px',
+            display: 'flex', flexDirection: 'row-reverse', gap: '.8rem', marginBottom: '20px', height: '3rem',
           }}
           >
-            {ButtonBridgeSubmit}
-            {ButtonBridgeReset}
+            {!isManageTabSelected && (
+              <>
+                {ButtonBridgeSubmit}
+                {ButtonBridgeReset}
+              </>
+            )}
           </div>
           <Box
             style={{


### PR DESCRIPTION
### Summary
There is no need for the save and reset button on the manage tab. Removes when the tab is selected. 

### Before
<img width="881" alt="Screenshot 2025-04-16 at 5 04 42 PM" src="https://github.com/user-attachments/assets/4863835e-84f8-4505-844a-c60b2e652557" />

### Now
<img width="895" alt="Screenshot 2025-04-16 at 5 01 39 PM" src="https://github.com/user-attachments/assets/cb10cbc2-ce78-4088-aedf-0911ad595e33" />
