### PR TITLE
fix: form submission/re-render issue

### DIFF
--- a/src/components/Configure/content/manage/AuthenticationSection.tsx
+++ b/src/components/Configure/content/manage/AuthenticationSection.tsx
@@ -1,7 +1,4 @@
 import { useConnections } from 'src/context/ConnectionsContextProvider';
-import { useInstallIntegrationProps } from
-  'src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider';
-import { useConnectionQuery } from 'src/hooks/query';
 
 import { FieldHeader } from '../fields/FieldHeader';
 
@@ -16,20 +13,16 @@ function AuthenticationRow({ label, value }: { label: string; value: string | un
   );
 }
 export function AuthenticationSection() {
-  const { installation } = useInstallIntegrationProps();
   const { selectedConnection } = useConnections();
-  const connectionId = installation?.connection?.id || selectedConnection?.id || '';
-  const { data: connection } = useConnectionQuery({ connectionId });
-
-  const isSalesforce = connection?.provider === 'salesforce';
+  const isSalesforce = selectedConnection?.provider === 'salesforce';
   const workspaceString = isSalesforce ? 'Subdomain' : 'Workspace';
 
   return (
     <>
       <FieldHeader string="Authentication" />
       <div style={{ paddingBottom: '1rem' }}>
-        <AuthenticationRow label={workspaceString} value={connection?.providerWorkspaceRef} />
-        <AuthenticationRow label="Connection Status" value={connection?.status} />
+        <AuthenticationRow label={workspaceString} value={selectedConnection?.providerWorkspaceRef} />
+        <AuthenticationRow label="Connection Status" value={selectedConnection?.status} />
       </div>
     </>
   );

--- a/src/components/Configure/content/manage/updateConnection/updateApiKeyConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/updateApiKeyConnect.tsx
@@ -48,7 +48,7 @@ export function UpdateApiKeyConnect() {
         },
         {
           onError: (e) => {
-            console.error(e);
+            console.error('Update connection error:', e);
             handleServerError(e, setError);
           },
           onSuccess: () => {
@@ -57,7 +57,7 @@ export function UpdateApiKeyConnect() {
         },
       );
     } catch (e) {
-      console.error(e);
+      console.error('Update connection caught error:', e);
       handleServerError(e, setError);
     }
   };
@@ -80,6 +80,7 @@ export function UpdateApiKeyConnect() {
           handleSubmit={handleSubmit}
           isButtonDisabled={isConnectionUpdating || isConnectionsLoading}
           buttonVariant="ghost"
+          submitButtonType="button"
         />
       </div>
     </>

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -17,10 +17,11 @@ type ApiKeyAuthFormProps = {
   handleSubmit: (form: IFormType) => void;
   isButtonDisabled?: boolean;
   buttonVariant?: 'ghost';
+  submitButtonType?: 'submit' | 'button';
 };
 
 export function ApiKeyAuthForm({
-  provider, providerInfo, handleSubmit, isButtonDisabled, buttonVariant,
+  provider, providerInfo, handleSubmit, isButtonDisabled, buttonVariant, submitButtonType,
 }: ApiKeyAuthFormProps) {
   const [show, setShow] = useState(false);
   const onToggleShowHide = () => setShow((prevShow) => !prevShow);
@@ -64,7 +65,7 @@ export function ApiKeyAuthForm({
       <Button
         style={{ marginTop: '1em', width: '100%' }}
         disabled={isSubmitDisabled}
-        type="submit"
+        type={submitButtonType || 'submit'}
         onClick={() => handleSubmit({ apiKey })}
         variant={buttonVariant}
       >


### PR DESCRIPTION
### Summary
#### problem: 
clicking submit on the update connection flow was causing the app to reload and re-render. 

#### root cause
This bug is caused by an underlying implementation that nests the borrowed `AuthKeyAuthForm` submit button in the `ConfigureBase` save/create installation form. 

#### solution
This PR does a quick fix and turns off the submit type button, however the bug shows a tech debt issue with the current tab structure.

- make submit button exception
- extra: removes extra calls to connection in the auth tab 

### todo
will need to also fix this in the other auth flows. 

### demo
![update-api-key-fixed](https://github.com/user-attachments/assets/d85dff36-ec8e-485e-81db-1151460c467a)


