### PR TITLE
feat: add feature flag to show manage tabs

### DIFF
--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -9,10 +9,9 @@ import { Divider } from 'src/components/ui-base/Divider';
 import { UNINSTALL_INSTALLATION_CONST, WRITE_CONST } from '../../constant';
 
 import { ManageTab } from './ManageTab';
+import { SHOW_MANAGE_TABS } from './showManageTabFF';
 
 import styles from './tabs.module.css';
-
-const SHOW_MANAGE_TABS = false;
 
 type NavObjectItemProps = {
   objectName: string;

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/showManageTabFF.ts
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/showManageTabFF.ts
@@ -1,0 +1,7 @@
+import { getEnvVariable } from 'src/utils';
+
+const VITE_SHOW_MANAGE_TABS = getEnvVariable('VITE_AMP_SHOW_MANAGE_TABS', false);
+const NEXT_SHOW_MANAGE_TABS = getEnvVariable('NEXT_AMP_SHOW_MANAGE_TABS', false);
+const REACT_APP_SHOW_MANAGE_TABS = getEnvVariable('REACT_APP_AMP_SHOW_MANAGE_TABS', false);
+
+export const SHOW_MANAGE_TABS = !!VITE_SHOW_MANAGE_TABS || !!NEXT_SHOW_MANAGE_TABS || !!REACT_APP_SHOW_MANAGE_TABS;


### PR DESCRIPTION
### Summary 
adds feature flags (vite, next, create react app)

### Tested create react app
change mailmonkey prod command: 
```json
"start:prod": "PORT=3003 REACT_APP_AMP_SERVER=prod REACT_APP_AMP_SHOW_MANAGE_TABS=true npm start",
```

<img width="928" alt="Screenshot 2025-04-18 at 12 12 24 PM" src="https://github.com/user-attachments/assets/1beb78fb-ee46-48a8-b392-788010800ccc" />
