### PR TITLE
feat: headless useConfig

### DIFF
--- a/src/headless/InstallationProvider.tsx
+++ b/src/headless/InstallationProvider.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useMemo } from "react";
 
+import { ConfigProvider } from "./config/ConfigContext";
+
 // Define the context value type
 interface InstallationContextValue {
   integrationNameOrId: string;
@@ -61,7 +63,7 @@ export function InstallationProvider({
 
   return (
     <InstallationContext.Provider value={props}>
-      {children}
+      <ConfigProvider initialConfig={{}}>{children}</ConfigProvider>
     </InstallationContext.Provider>
   );
 }

--- a/src/headless/config/ConfigContext.tsx
+++ b/src/headless/config/ConfigContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, ReactNode, useContext } from "react";
+import type { UpdateInstallationConfigContent } from "@generated/api/src";
+
+import { useConfigHelper } from "./useConfigHelper";
+
+const ConfigContext = createContext<ReturnType<typeof useConfigHelper> | null>(
+  null,
+);
+
+export function ConfigProvider({
+  children,
+  initialConfig,
+}: {
+  children: ReactNode;
+  initialConfig: UpdateInstallationConfigContent;
+}) {
+  const config = useConfigHelper(initialConfig);
+  return (
+    <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+  );
+}
+
+export function useConfig() {
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error(
+      "useConfigContext must be used within a ConfigProvider / InstallationProvider",
+    );
+  }
+  return context;
+}

--- a/src/headless/config/useConfigHelper.tsx
+++ b/src/headless/config/useConfigHelper.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react";
+import type {
+  BaseReadConfigObject,
+  UpdateInstallationConfigContent,
+} from "@generated/api/src";
+import { produce } from "immer";
+
+type ReadObjectHandlers = {
+  object: BaseReadConfigObject | undefined;
+  getSelectedField: (fieldName: string) => boolean;
+  setSelectedField: (params: { fieldName: string; selected: boolean }) => void;
+  getFieldMapping: (fieldName: string) => string | undefined;
+  setFieldMapping: (params: { fieldName: string; mapToName: string }) => void;
+};
+
+export function useConfigHelper(
+  initialConfig: UpdateInstallationConfigContent,
+) {
+  const [draft, setDraft] =
+    useState<UpdateInstallationConfigContent>(initialConfig);
+  const [initial] = useState(initialConfig); // For reset
+
+  const get = useCallback(() => draft, [draft]);
+
+  const reset = useCallback(() => {
+    setDraft(initial);
+  }, [initial]);
+
+  const readObject = useCallback(
+    (key: string): ReadObjectHandlers => ({
+      object: draft.read?.objects?.[key],
+      getSelectedField: (fieldName: string) =>
+        !!draft.read?.objects?.[key]?.selectedFields?.[fieldName],
+
+      // sets a single field selected boolean, deletes the field if selected is false
+      setSelectedField: ({ fieldName, selected }) => {
+        setDraft((prev) =>
+          produce(prev, (_draft) => {
+            // initialize read if it doesn't exist
+            const read = _draft.read || {};
+            const objects = read.objects || {};
+            const obj = objects[key] || {};
+            // initialize selectedFields if it doesn't exist
+            obj.selectedFields = obj.selectedFields || {};
+            obj.selectedFields[fieldName] = selected;
+            objects[key] = obj;
+            read.objects = objects;
+
+            // if selected is false, remove the field from selectedFields
+            if (obj.selectedFields?.[fieldName] === false) {
+              delete obj.selectedFields[fieldName];
+            }
+            _draft.read = read;
+            return _draft;
+          }),
+        );
+      },
+
+      getFieldMapping: (mapToName: string) =>
+        draft.read?.objects?.[key]?.selectedFieldMappings?.[mapToName],
+
+      setFieldMapping: ({ fieldName, mapToName }) => {
+        setDraft((prev) =>
+          produce(prev, (_draft) => {
+            // initialize read if it doesn't exist
+            const read = _draft.read || {};
+            const objects = read.objects || {};
+            const obj = objects[key] || {};
+
+            // initialize selectedFieldMappings if it doesn't exist
+            obj.selectedFieldMappings = obj.selectedFieldMappings || {};
+            obj.selectedFieldMappings[mapToName] = fieldName;
+
+            _draft.read = read;
+            return _draft;
+          }),
+        );
+      },
+    }),
+    [draft],
+  );
+
+  return {
+    draft,
+    get,
+    setDraft,
+    reset,
+    readObject,
+  };
+}


### PR DESCRIPTION
### Summary
draft for managing local state via a headless hook.
- adds getters and setters for selected fields and selected field mappings
- does not include orchestration or auto filling of fields pulled from hydrated Revision 

note this work is not exported yet and sits in the headless folder under development

### followup work
handling initializing and validating proper config 
