### PR TITLE
fix: useInstallations query with integration name and group ref

### DIFF
--- a/src/headless/installation/useInstallation.ts
+++ b/src/headless/installation/useInstallation.ts
@@ -1,7 +1,13 @@
 import { useListInstallationsQuery } from "src/hooks/query";
 
+import { useInstallationProps } from "../InstallationProvider";
+
 export function useInstallation() {
-  const installationsQuery = useListInstallationsQuery();
+  const { integrationNameOrId, groupRef } = useInstallationProps();
+  const installationsQuery = useListInstallationsQuery(
+    integrationNameOrId,
+    groupRef,
+  );
   const {
     isPending, // The query has no data yet
     isFetching, //  In any state, if the query is fetching at any time (including background refetching)

--- a/src/headless/installation/useInstallation.ts
+++ b/src/headless/installation/useInstallation.ts
@@ -3,6 +3,9 @@ import { useListInstallationsQuery } from "src/hooks/query";
 import { useInstallationProps } from "../InstallationProvider";
 
 export function useInstallation() {
+  // Extracting integrationNameOrId and groupRef from useInstallationProps.
+  // These are required for the useListInstallationsQuery, especially in headless mode,
+  // where the integration and group context must be explicitly provided.
   const { integrationNameOrId, groupRef } = useInstallationProps();
   const installationsQuery = useListInstallationsQuery(
     integrationNameOrId,


### PR DESCRIPTION
### Summary
useInstallation doesn't fetch since integration and group ref were not passed in. the params are optional for the InstallIntegration component but required for headless.

#### fix found and tested in sample headless app 


