### PR TITLE
fix: no workspace oauth flow

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -55,11 +55,11 @@ export function NoWorkspaceOauthFlow({
 
   const onError = useCallback((err: string | null) => {
     setError(err);
-  }, []);
+  }, [setError]);
 
   const onSuccessConnect = useCallback(() => {
     setError(null);
-  }, []);
+  }, [setError]);
 
   return (
     <OAuthWindow

--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -57,11 +57,17 @@ export function NoWorkspaceOauthFlow({
     setError(err);
   }, []);
 
+  const onSuccessConnect = useCallback(() => {
+    setError(null);
+  }, []);
+
   return (
     <OAuthWindow
       windowTitle={`Connect to ${providerName}`}
       oauthUrl={oAuthPopupURL || null}
       onError={onError}
+      error={error}
+      onSuccessConnect={onSuccessConnect}
     >
       <NoWorkspaceEntryContent
         handleSubmit={handleSubmit}


### PR DESCRIPTION
### Summary
Hubspot integration has infinite window glitch. https://ampersand-company.slack.com/archives/C082KPRN4R4/p1746117116619159?thread_ts=1746117090.872019&cid=C082KPRN4R4

root cause: the issue lies only in noworkspace oauth flows
- pass in error to oauth window so that it does not re-open the window
- OAuthWindow will not open a window if an error is present.

#### demo
![noworkspace-oauth-fix](https://github.com/user-attachments/assets/617e4799-026b-43c8-8ef5-bbda03f2e9b3)


