### PR TITLE
fix: oauth cached url

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow.tsx
@@ -71,8 +71,10 @@ export function NoWorkspaceOauthFlow({
   const handleSubmit = async () => {
     setError(null);
     const result = await refetchOauthConnect();
+    // If the OAuth connection URL is successfully fetched, set showURL to true
+    // to display the OAuth popup. Otherwise, handle the error.
     if (result?.data) {
-      setShowURL(true); // show the OAuth popup URL after handleSubmit is called
+      setShowURL(true);
     } else {
       onError(result?.error?.message || "Authentication failed");
     }

--- a/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/OAuthWindow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/OAuthWindow.tsx
@@ -13,6 +13,7 @@ type OAuthWindowProps = {
   onError?: (err: string | null) => void;
   isSuccessConnect?: boolean; // used to check if the connection is successfully created
   onSuccessConnect?: () => void; // callback to set when connection is successfully created
+  onWindowClose?: () => void; // callback to set when window is closed
 };
 
 /**
@@ -28,6 +29,7 @@ export function OAuthWindow({
   error,
   onSuccessConnect,
   isSuccessConnect,
+  onWindowClose,
 }: OAuthWindowProps) {
   const [connectionId, setConnectionId] = useState(null);
   const [oauthWindow, setOauthWindow] = useState<Window | null>(null);
@@ -82,6 +84,7 @@ export function OAuthWindow({
         } else if (connectionId) {
           onError?.(null);
         }
+        onWindowClose?.();
       }
     }, 500);
 
@@ -91,7 +94,14 @@ export function OAuthWindow({
       clearInterval(interval);
       window.removeEventListener("message", receiveMessage);
     };
-  }, [oauthWindow, connectionId, error, receiveMessage, onError]);
+  }, [
+    oauthWindow,
+    connectionId,
+    error,
+    receiveMessage,
+    onError,
+    onWindowClose,
+  ]);
 
   return <div>{children}</div>;
 }

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -33,6 +33,7 @@ export function WorkspaceOauthFlow({
   const [workspace, setWorkspace] = useState<string>("");
   const [localError, setLocalError] = useState<string | null>(null);
   // keeps track of whether the OAuth popup URL should be passed to the OAuthWindow
+  // when this is false, then OAuthWindow component will not pop up a window.
   const [showURL, setShowURL] = useState<boolean>(false);
 
   const {

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow.tsx
@@ -32,6 +32,8 @@ export function WorkspaceOauthFlow({
 }: WorkspaceOauthFlowProps) {
   const [workspace, setWorkspace] = useState<string>("");
   const [localError, setLocalError] = useState<string | null>(null);
+  // keeps track of whether the OAuth popup URL should be passed to the OAuthWindow
+  const [showURL, setShowURL] = useState<boolean>(false);
 
   const {
     url: oAuthPopupURL,
@@ -48,6 +50,20 @@ export function WorkspaceOauthFlow({
   );
 
   const errorMessage = oAuthConnectError?.message || localError || null;
+  const onError = useCallback((err: string | null) => {
+    setLocalError(err);
+    setShowURL(false);
+  }, []);
+
+  const onSuccessConnect = useCallback(() => {
+    setLocalError(null);
+    setShowURL(false);
+  }, []);
+
+  const onWindowClose = useCallback(() => {
+    setShowURL(false);
+  }, [setShowURL]);
+
   //  fetch OAuth callback URL from connection so that oath popup can be launched
   const handleSubmit = async () => {
     setLocalError(null);
@@ -56,12 +72,13 @@ export function WorkspaceOauthFlow({
       return;
     }
 
-    refetchOauthConnect();
+    const result = await refetchOauthConnect();
+    if (result?.data) {
+      setShowURL(true);
+    } else {
+      onError(result?.error?.message || "Authentication failed");
+    }
   };
-
-  const onError = useCallback((err: string | null) => {
-    setLocalError(err);
-  }, []);
 
   // custom entry component for Salesforce provider
   const workspaceEntryComponent =
@@ -86,9 +103,11 @@ export function WorkspaceOauthFlow({
   return (
     <OAuthWindow
       windowTitle={`Connect to ${providerName}`}
-      oauthUrl={oAuthPopupURL || null}
+      oauthUrl={(showURL && oAuthPopupURL) || null} // showURL is true when handleSubmit is called
       onError={onError}
       error={errorMessage}
+      onSuccessConnect={onSuccessConnect}
+      onWindowClose={onWindowClose}
     >
       {workspaceEntryComponent}
     </OAuthWindow>

--- a/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
@@ -82,7 +82,7 @@ export const useOAuthPopupURL = (
     }
   }, [oauthConnectError]);
 
-  const refetchOauthConnect = async () => {
+  const refetchOauthConnect = async (): Promise<ReturnType<typeof refetchOauthConnectQuery> | null> => {
     if (provInfo?.authType === "oauth2") {
       if (
         provInfo?.oauth2Opts?.grantType === "authorizationCode" ||

--- a/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
@@ -82,13 +82,13 @@ export const useOAuthPopupURL = (
     }
   }, [oauthConnectError]);
 
-  const refetchOauthConnect = () => {
+  const refetchOauthConnect = async () => {
     if (provInfo?.authType === "oauth2") {
       if (
         provInfo?.oauth2Opts?.grantType === "authorizationCode" ||
         provInfo?.oauth2Opts?.grantType === "authorizationCodePKCE"
       ) {
-        refetchOauthConnectQuery();
+        return await refetchOauthConnectQuery();
       } else {
         console.error(
           "Provider does not support an OAuth2 web flow grant type.",
@@ -97,6 +97,7 @@ export const useOAuthPopupURL = (
     } else {
       console.error("Provider does not support an OAuth2 web flow.");
     }
+    return null;
   };
 
   return {


### PR DESCRIPTION
### Summary
part 2 followup to https://ampersand-company.slack.com/archives/C082KPRN4R4/p1746117090872019

problem: url can be cached by react-query which will auto popup the window even when not ready
solution: add a separate state to track whether url is active
- adds additional checks for error and oauth url
- fixes async call to refetch oauth url (will await for response, instead of autofire)

#### demo
![oauth-fix-cache](https://github.com/user-attachments/assets/f90638ba-ebe3-4c8e-93c7-f385a5f806f4)

