### PR TITLE
build: disable dependabot for openapi-generator-cli

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "@openapitools/openapi-generator-cli"


### PR DESCRIPTION
See https://github.com/amp-labs/react/pull/1052, updating this dependency causes Node engine requirements to get bumped, which breaks the build & prevents us from publishing to npm. 