### PR TITLE
fix: have connections query invalidate on window close

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/OAuthWindow.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/OAuthWindow.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import {
   useOpenWindowHandler,
@@ -33,6 +34,7 @@ export function OAuthWindow({
 }: OAuthWindowProps) {
   const [connectionId, setConnectionId] = useState(null);
   const [oauthWindow, setOauthWindow] = useState<Window | null>(null);
+  const queryClient = useQueryClient();
 
   const receiveMessage = useReceiveMessageEventHandler(
     setConnectionId,
@@ -84,6 +86,9 @@ export function OAuthWindow({
         } else if (connectionId) {
           onError?.(null);
         }
+
+        // invalidate the connections query to refresh the connection list
+        queryClient.invalidateQueries({ queryKey: ["amp", "connections"] });
         onWindowClose?.();
       }
     }, 500);
@@ -101,6 +106,7 @@ export function OAuthWindow({
     receiveMessage,
     onError,
     onWindowClose,
+    queryClient,
   ]);
 
   return <div>{children}</div>;

--- a/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/windowHelpers.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/windowHelpers.tsx
@@ -60,6 +60,13 @@ export function useReceiveMessageEventHandler(
         const connection = event.data.data?.connection; // connection id
         if (connection) {
           setConnectionId(connection);
+          // manually adds the connection to the query cache
+          queryClient.setQueriesData(
+            {
+              queryKey: ["amp", "connections"],
+            },
+            () => [connection],
+          );
           oauthWindow?.close(); // only close the window if connection is successful
           onSuccessConnect?.();
 


### PR DESCRIPTION
### Summary
problem: https://ampersand-company.slack.com/archives/C082KPRN4R4/p1746215768712599?thread_ts=1746117090.872019&cid=C082KPRN4R4
When the window is closed (likely from backend trigger), the auth error is triggered automatically via the window closed logic. It seems the success event may not be captured before the window is closed causing the error:

 ```onError?.("Authentication was cancelled. Please try again.");```

When the window closes we add in an extra cache invalidation to force the connection to refresh (which should trigger a re-routing to the configure component)

We also pre-emptively add a manual cache override if a success event is received. 

### Testing
Hubspot and Salesforce work as expected in mail-monkey. 

