### PR TITLE
feat: config prefill default values from manifest

### DIFF
--- a/src/headless/config/useConfigHelper.tsx
+++ b/src/headless/config/useConfigHelper.tsx
@@ -29,7 +29,17 @@ export function useConfigHelper(
     setDraft(initial);
   }, [initial]);
 
-  // Helper function to initialize object with defaults from manifest
+  /**
+   * Initializes an object within the `_draft` configuration with default values from the manifest.
+   * 
+   * @param objectName - The name of the object to initialize.
+   * @param _draft - The draft configuration object to modify. This object is updated in place.
+   * 
+   * Side Effects:
+   * - Modifies the `_draft.read.objects` property by adding or updating the specified object.
+   * - Sets default values for `schedule`, `destination`, and `selectedFields` based on the manifest.
+   * - Ensures required fields are initialized if not already set.
+   */
   const initializeObjectWithDefaults = useCallback(
     (objectName: string, _draft: UpdateInstallationConfigContent) => {
       const read = _draft.read || {};


### PR DESCRIPTION
### Summary
Currently lots of context is needed to submit a config correctly namely several fields destination, schedule, objectName, and selectedFields are required. The first 3 fields should be able to be inserted via the backend in the future, selectedFields is required by the builder may not know they must add required fields to the selected fields by default. This useConfig helper will prefill required fields. 
- prefill destination, schedule, objectName and required fields into Selected fields 
- upon setting selectedFields 
- upson setting selectedFieldMappings
- rename key to objectName for easier maintanence

### testing
note code is still in separate folder that is being tested via an export branch.