### PR TITLE
fix: reloading connection

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceEntry/NoWorkspaceEntryContent.tsx
@@ -28,7 +28,7 @@ export function NoWorkspaceEntryContent({
         type="submit"
         onClick={handleSubmit}
       >
-        Next
+        {isButtonDisabled ? "Loading..." : "Next"}
       </Button>
     </AuthCardLayout>
   );


### PR DESCRIPTION
### Summary
From the reported bug, it seems the connection is failing to connect from 
1 ) success event is not being captured by the client when the backend closes the window (difficult to duplicate)
2) when the window closes, the connection list is not being refetched 

#### Solution
This PR adds more refetching redundancy to No Workspace Auth flow, adds a loading/refetching state, asks for a refetch before submitting the oauth url. 
- add loading message when fetching connections
- hide error message when fetching connections
- disable button when fetching connections
- add refetching connections on window close and on success connect

note: this solution has not been applied to workspace workflows as the amount of overfetching can be a bit much without confirming this works as a solution.

#### demo

![loading-fetching-connection](https://github.com/user-attachments/assets/cd2c774c-6292-4694-b474-f63f52fb0866)
