### PR TITLE
feat: support headless advanced write 

### DIFF
--- a/src/headless/config/useConfigHelper.tsx
+++ b/src/headless/config/useConfigHelper.tsx
@@ -219,7 +219,7 @@ export function useConfigHelper(
           setDraft((prev) =>
             produce(prev, (_draft) => {
               const { objects } = initializeWriteObject(_draft);
-              delete objects.objectName;
+              delete objects[objectName];
             }),
           );
         },


### PR DESCRIPTION
### Summary
This PR adds support for updating the write features in the config. 
- support enable /disable write per objectName
- support value defaults
- support field settings

use `_default` for value defaults in field settings

#### testing
code is in headless folder non public, to be tested in sample app