### PR TITLE
build: add source maps for debugging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,7 +70,7 @@
     "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./build",                                 /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }) => ({
       }) as PluginOption),
   ],
   build: {
+    sourcemap: true,
     outDir: "./build",
     lib: {
       entry: "./src/index.ts",


### PR DESCRIPTION
### Summary
adds source maps so chrome can see code rather than transpiled letters.

