### PR TITLE
refactor: noWorkspaceOauthFlow2

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
@@ -1,0 +1,145 @@
+/**
+ * OAuth flow for any providers that do not require the consumer to enter a workspace first.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useProject } from "src/context/ProjectContextProvider";
+import { useCreateOauthConnectionMutation } from "src/hooks/mutation/useCreateOauthConnectionMutation";
+import { useConnectionsListQuery } from "src/hooks/query/useConnectionsListQuery";
+import { AMP_SERVER } from "src/services/api";
+
+import { NoWorkspaceEntryContent } from "../NoWorkspaceEntry/NoWorkspaceEntryContent";
+const DEFAULT_WIDTH = 600; // px
+const DEFAULT_HEIGHT = 600; // px
+
+/** Payload shape we expect from the popup */
+type AuthEvent =
+  | {
+      eventType: "AUTHORIZATION_SUCCEEDED";
+      data: { connection: string };
+    }
+  | {
+      eventType: "AUTHORIZATION_FAILED";
+      data: { error: string };
+    };
+
+interface NoWorkspaceOauthFlowProps {
+  provider: string;
+  consumerRef: string;
+  consumerName?: string;
+  groupRef: string;
+  groupName?: string;
+  providerName?: string;
+}
+
+/**
+ * NoWorkspaceOauthFlow first prompts user with a next button,
+ * then launches a popup with the OAuth flow.
+ */
+export function NoWorkspaceOauthFlow2({
+  provider,
+  consumerRef,
+  consumerName,
+  groupRef,
+  groupName,
+  providerName,
+}: NoWorkspaceOauthFlowProps) {
+  const { projectId } = useProject();
+  const queryClient = useQueryClient();
+  const popupRef = useRef<Window | null>(null);
+
+  const {
+    mutateAsync: createOauthConnectionUrlAsync,
+    isPending: isCreatingOauthConnection,
+  } = useCreateOauthConnectionMutation();
+
+  const { isFetching: isConnectionsFetching, refetch: refetchConnections } =
+    useConnectionsListQuery({
+      groupRef,
+      provider,
+    });
+
+  const [error, setError] = useState<string | null>(null);
+
+  /** 2. One‑time message listener (mount‑level) */
+  useEffect(() => {
+    const onMessage = (ev: MessageEvent<AuthEvent>) => {
+      // Accept only events from *your* popup origin
+      if (ev.origin !== AMP_SERVER) return;
+
+      if (ev.data?.eventType === "AUTHORIZATION_SUCCEEDED") {
+        setError(null);
+        console.info("New connection:", ev.data.data.connection);
+        // Refresh cached list so UI shows the new connection
+        queryClient.invalidateQueries({ queryKey: ["amp", "connections"] });
+      } else if (ev.data?.eventType === "AUTHORIZATION_FAILED") {
+        console.error("OAuth failed:", ev.data.data.error);
+        setError(ev.data.data.error || "An error occurred. Please try again.");
+      }
+
+      popupRef.current?.close();
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [queryClient]);
+
+  const handleSubmit = async () => {
+    setError(null);
+
+    try {
+      const { data: connections } = await refetchConnections();
+      if (connections && connections.length > 0) {
+        // first refetch connection before attempting to re-auth
+        console.debug("connections found");
+        return;
+      }
+    } catch {
+      console.debug("no connections found");
+    }
+
+    try {
+      const url = await createOauthConnectionUrlAsync({
+        connectOAuthParams: {
+          provider,
+          consumerRef,
+          groupRef,
+          projectId,
+          consumerName,
+          groupName,
+        },
+      });
+
+      if (url) {
+        const left = window.screenX + (window.outerWidth - DEFAULT_WIDTH) / 2;
+        const top =
+          window.screenY + (window.outerHeight - DEFAULT_HEIGHT) / 2.5;
+        const windowDimensions = `width=${DEFAULT_WIDTH},height=${DEFAULT_HEIGHT},left=${left},top=${top}`;
+        popupRef.current = window.open(url, "OAuthPopup", windowDimensions);
+      }
+    } catch (error) {
+      console.error(error);
+      setError(
+        error instanceof Error
+          ? error.message
+          : String(error) || "An error occurred. Please try again."
+      );
+    }
+  };
+
+  return (
+    <div>
+      <NoWorkspaceEntryContent
+        handleSubmit={handleSubmit}
+        error={
+          // hide error message when the connections are being fetched
+          isCreatingOauthConnection ? "" : error
+        }
+        providerName={providerName}
+        // disable button when loading or fetching connections
+        isButtonDisabled={isCreatingOauthConnection || isConnectionsFetching}
+      />
+    </div>
+  );
+}

--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
@@ -96,7 +96,7 @@ export function NoWorkspaceOauthFlow2({
         return;
       }
     } catch {
-      console.debug("no connections found");
+      console.debug("error with fetching connections");
     }
 
     try {

--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
@@ -62,7 +62,7 @@ export function NoWorkspaceOauthFlow2({
 
   const [error, setError] = useState<string | null>(null);
 
-  /** 2. One‑time message listener (mount‑level) */
+  /** One‑time message listener (mount‑level) */
   useEffect(() => {
     const onMessage = (ev: MessageEvent<AuthEvent>) => {
       // Accept only events from *your* popup origin
@@ -123,7 +123,7 @@ export function NoWorkspaceOauthFlow2({
       setError(
         error instanceof Error
           ? error.message
-          : String(error) || "An error occurred. Please try again."
+          : String(error) || "An error occurred. Please try again.",
       );
     }
   };

--- a/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
+++ b/src/components/auth/Oauth/OauthFlow/OauthFlow.tsx
@@ -1,7 +1,7 @@
 import { Connection, ProviderInfo } from "services/api";
 import { useProvider } from "src/hooks/useProvider";
 
-import { NoWorkspaceOauthFlow } from "../AuthorizationCode/NoWorkspaceEntry/NoWorkspaceOauthFlow";
+import { NoWorkspaceOauthFlow2 } from "../AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2";
 import { WorkspaceOauthFlow } from "../AuthorizationCode/WorkspaceEntry/WorkspaceOauthFlow";
 import { ClientCredentials } from "../ClientCredentials/ClientCredentials";
 
@@ -57,7 +57,7 @@ export function OauthFlow({
     }
 
     // no workspace required
-    return <NoWorkspaceOauthFlow {...sharedProps} />;
+    return <NoWorkspaceOauthFlow2 {...sharedProps} />;
   }
 
   if (grantType === CLIENT_CREDENTIALS) {

--- a/src/hooks/mutation/useCreateOauthConnectionMutation.ts
+++ b/src/hooks/mutation/useCreateOauthConnectionMutation.ts
@@ -1,0 +1,18 @@
+import { OauthConnectOperationRequest } from "@generated/api/src";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAPI } from "services/api";
+
+export const useCreateOauthConnectionMutation = () => {
+  const getAPI = useAPI();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ["createOauthConnection"],
+    mutationFn: async (request: OauthConnectOperationRequest) => {
+      const api = await getAPI();
+      return api.oAuthApi.oauthConnect(request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["connections"] });
+    },
+  });
+};


### PR DESCRIPTION
### Summary
attempts to build the oauth logic from scratch in attempt to debug oauth flow

- Uses own window logic. Creates one window listener on the parent app and only removes when unmounted (no fancy intervals)
- Switches from cached url fetching to async url trigger -> less use states to track. No additional callbacks to track.
- self-contained only to NoWorkspaceOauth flow; will move forward with Workspace fix correct.
- less error handling logic
- refetches connections before submitting for new url

### notes
If this code doesn't pass in production, the likely issue is that we need to follow the standard where the client origin is passed in the callback for message broadcast. Currently now set to '*' in the backend; the message should be broadcasted to any receiver in the browser.

### demo

![hubspot-oauth](https://github.com/user-attachments/assets/7207679c-0157-47f6-81b5-0f863d3e5cf9)


