### PR TITLE
[ENG-2258] feat: add update auth flow to hydrated revision

### DIFF
--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -20,6 +20,7 @@ import {
   ComponentContainerError,
   ComponentContainerLoading,
 } from "src/components/Configure/ComponentContainer";
+import { UpdateConnectionSection } from "src/components/Configure/content/manage/updateConnection/UpdateConnectionSection";
 import { RemoveConnectionButton } from "src/components/Connect/RemoveConnectionButton";
 import { InnerErrorTextBox } from "src/components/ErrorTextBox/ErrorTextBox";
 import { handleServerError } from "src/utils/handleServerError";
@@ -174,11 +175,18 @@ export function HydratedRevisionProvider({
             flexDirection: "column",
             gap: "1rem",
             paddingTop: "1rem",
+            width: "100%",
           }}
         >
+          <UpdateConnectionSection provider={providerName} />
+          <p>
+            If the authentication is not working, you attempt to delete and
+            create a new connection, but reauthentication should be attempted
+            above first.
+          </p>
           {connectionError && <InnerErrorTextBox message={connectionError} />}
           <RemoveConnectionButton
-            buttonText="Try again"
+            buttonText="Delete Connection"
             resetComponent={resetComponent}
             buttonVariant="danger"
             onDisconnectError={(error: string) => setConnectionError(error)}

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -180,9 +180,8 @@ export function HydratedRevisionProvider({
         >
           <UpdateConnectionSection provider={providerName} />
           <p>
-            If the authentication is not working, you attempt to delete and
-            create a new connection, but reauthentication should be attempted
-            above first.
+            If authentication is failing, please try reauthenticating using the
+            section above before deleting and recreating the connection.
           </p>
           {connectionError && <InnerErrorTextBox message={connectionError} />}
           <RemoveConnectionButton


### PR DESCRIPTION
### Summary 
problem: when the user tries to connect via InstallProvider, the component may error out because the token needs to be refreshed. The ability to update the authentication does not show up since the revision is not available.

solution: the hydrated revision error screen adds the ability to re-authenticate as well as delete connection. 

#### Screenshot
<img width="926" alt="Screenshot 2025-05-20 at 2 13 14 PM" src="https://github.com/user-attachments/assets/088c81e2-e89c-40e4-8f59-b586b7303b7b" />
