### PR TITLE
[ENG-2291] feat: add syncInstallationConfig to useConfigHelper

### DIFF
--- a/src/headless/config/useConfigHelper.tsx
+++ b/src/headless/config/useConfigHelper.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@generated/api/src";
 import { produce } from "immer";
 
+import { useInstallation } from "../installation/useInstallation";
 import { useManifest } from "../manifest/useManifest";
 
 type ReadObjectHandlers = {
@@ -61,6 +62,7 @@ export function useConfigHelper(
   const [initial] = useState(initialConfig); // For reset
 
   const { getReadObject: getReadObjectFromManifest } = useManifest();
+  const { installation } = useInstallation();
 
   const get = useCallback(() => draft, [draft]);
 
@@ -265,9 +267,19 @@ export function useConfigHelper(
     [draft.write?.objects],
   );
 
+  const syncInstallationConfig = useCallback(() => {
+    // set the draft config to the installation config
+    setDraft((prev) =>
+      produce(prev, (draft) => {
+        Object.assign(draft, installation?.config?.content);
+      }),
+    );
+  }, [installation?.config?.content]);
+
   return {
     draft,
     get,
+    syncInstallationConfig,
     setDraft,
     reset,
     readObject,

--- a/src/headless/installation/useCreateInstallation.ts
+++ b/src/headless/installation/useCreateInstallation.ts
@@ -3,6 +3,7 @@ import {
   CreateInstallationOperationRequest,
   Installation,
 } from "@generated/api/src";
+import { useQueryClient } from "@tanstack/react-query";
 import { useProject } from "src/context/ProjectContextProvider";
 import { useCreateInstallationMutation } from "src/hooks/mutation/useCreateInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
@@ -27,7 +28,7 @@ export function useCreateInstallation() {
   const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
   const { connection } = useConnection();
   const { installation } = useInstallation();
-
+  const queryClient = useQueryClient();
   const {
     mutate: createInstallationMutation,
     isIdle,
@@ -60,7 +61,11 @@ export function useCreateInstallation() {
       installation: {
         groupRef,
         connectionId: connection?.id,
-        config: { content: config },
+        config: {
+          content: {
+            ...config,
+          },
+        },
       },
     };
 
@@ -73,6 +78,9 @@ export function useCreateInstallation() {
       },
       onSettled: () => {
         onSettled?.();
+        queryClient.invalidateQueries({
+          queryKey: ["amp", "installations"],
+        });
       },
     });
   };

--- a/src/headless/installation/useDeleteInstallation.ts
+++ b/src/headless/installation/useDeleteInstallation.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useProject } from "src/context/ProjectContextProvider";
 import { useDeleteInstallationMutation } from "src/hooks/mutation/useDeleteInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
@@ -20,7 +21,7 @@ export function useDeleteInstallation() {
   const { integrationNameOrId } = useInstallationProps();
   const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
   const { installation } = useInstallation();
-
+  const queryClient = useQueryClient();
   const {
     mutate: deleteInstallationMutation,
     isIdle,
@@ -59,6 +60,13 @@ export function useDeleteInstallation() {
         },
         onSettled: () => {
           onSettled?.();
+          // invalidate installations and connections queries
+          queryClient.invalidateQueries({
+            queryKey: ["amp", "installations"],
+          });
+          queryClient.invalidateQueries({
+            queryKey: ["amp", "connections"],
+          });
         },
       },
     );


### PR DESCRIPTION
### Summary 
adds ability for config hook to sync with server state
- adds cache invalidation for CRUD installations so that queries will re-fetch upon mutations
- adds useEffect to track when to sync config state with server state (when new installation is available)
- adds side effect support for CRUD installation options.

#### notes
still hidden behind export folder. note to rebase on main instead of headless-export

test here: https://github.com/amp-labs/headless-sample-app/pull/1

![headless-demo-app](https://github.com/user-attachments/assets/1b4cc493-f6b4-44eb-b765-262032aed1d3)
