### PR TITLE
feat: add callbacks and docs to CRUD installation hook

### DIFF
--- a/src/headless/installation/useCreateInstallation.ts
+++ b/src/headless/installation/useCreateInstallation.ts
@@ -1,6 +1,7 @@
 import {
   ConfigContent,
   CreateInstallationOperationRequest,
+  Installation,
 } from "@generated/api/src";
 import { useProject } from "src/context/ProjectContextProvider";
 import { useCreateInstallationMutation } from "src/hooks/mutation/useCreateInstallationMutation";
@@ -30,7 +31,17 @@ export function useCreateInstallation() {
     errorMsg,
   } = useCreateInstallationMutation();
 
-  const createInstallation = (config: ConfigContent) => {
+  const createInstallation = ({
+    config,
+    onSuccess,
+    onError,
+    onSettled,
+  }: {
+    config: ConfigContent;
+    onSuccess?: (data: Installation) => void;
+    onError?: (error: Error) => void;
+    onSettled?: () => void;
+  }) => {
     if (installation) {
       throw Error("Installation already created. Try updating instead.");
     }
@@ -48,7 +59,17 @@ export function useCreateInstallation() {
       },
     };
 
-    return createInstallationMutation(createInstallationRequest);
+    return createInstallationMutation(createInstallationRequest, {
+      onSuccess: (data) => {
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        onError?.(error);
+      },
+      onSettled: () => {
+        onSettled?.();
+      },
+    });
   };
 
   return {

--- a/src/headless/installation/useCreateInstallation.ts
+++ b/src/headless/installation/useCreateInstallation.ts
@@ -14,7 +14,12 @@ import { useInstallation } from "./useInstallation";
 
 /**
  * create installation hook
- * @returns
+ * @returns {Object} An object containing:
+ *   - `createInstallation` (function): A function to create the installation.
+ *   - `isIdle` (boolean): Whether the mutation is idle.
+ *   - `isPending` (boolean): Whether the mutation is pending.
+ *   - `error` (Error | null): The error object, if any.
+ *   - `errorMsg` (string | null): The error message, if any.
  */
 export function useCreateInstallation() {
   const { projectIdOrName } = useProject();

--- a/src/headless/installation/useDeleteInstallation.ts
+++ b/src/headless/installation/useDeleteInstallation.ts
@@ -6,6 +6,15 @@ import { useInstallationProps } from "../InstallationProvider";
 
 import { useInstallation } from "./useInstallation";
 
+/**
+ * delete installation hook
+ * @returns {Object} An object containing:
+ *   - `deleteInstallation` (function): A function to delete the installation.
+ *   - `isIdle` (boolean): Whether the mutation is idle.
+ *   - `isPending` (boolean): Whether the mutation is pending.
+ *   - `error` (Error | null): The error object, if any.
+ *   - `errorMsg` (string | null): The error message, if any.
+ */
 export function useDeleteInstallation() {
   const { projectIdOrName } = useProject();
   const { integrationNameOrId } = useInstallationProps();

--- a/src/headless/installation/useDeleteInstallation.ts
+++ b/src/headless/installation/useDeleteInstallation.ts
@@ -20,18 +20,39 @@ export function useDeleteInstallation() {
     errorMsg,
   } = useDeleteInstallationMutation();
 
-  const deleteInstallation = () => {
+  const deleteInstallation = ({
+    onSuccess,
+    onError,
+    onSettled,
+  }: {
+    onSuccess?: () => void;
+    onError?: (error: Error) => void;
+    onSettled?: () => void;
+  }) => {
     if (!installation) {
       throw Error("Installation not found. Not able to delete installation.");
     }
     if (!integrationObj) {
       throw Error("No integration found");
     }
-    return deleteInstallationMutation({
-      projectIdOrName,
-      integrationId: integrationObj?.id,
-      installationId: installation.id,
-    });
+    return deleteInstallationMutation(
+      {
+        projectIdOrName,
+        integrationId: integrationObj?.id,
+        installationId: installation.id,
+      },
+      {
+        onSuccess: () => {
+          onSuccess?.();
+        },
+        onError: (error) => {
+          onError?.(error);
+        },
+        onSettled: () => {
+          onSettled?.();
+        },
+      },
+    );
   };
 
   return {

--- a/src/headless/installation/useInstallation.ts
+++ b/src/headless/installation/useInstallation.ts
@@ -2,6 +2,17 @@ import { useListInstallationsQuery } from "src/hooks/query";
 
 import { useInstallationProps } from "../InstallationProvider";
 
+/**
+ * useInstallation hook
+ * @returns {Object} An object containing:
+ *   - `installation` (Installation | undefined): The installation object.
+ *   - `isPending` (boolean): Whether the query is pending.
+ *   - `isFetching` (boolean): Whether the query is fetching.
+ *   - `isError` (boolean): Whether the query is in an error state.
+ *   - `isSuccess` (boolean): Whether the query is in a success state.
+ *   - `error` (Error | null): The error object, if any.
+ *   - `errorMsg` (string | null): The error message, if any.
+ */
 export function useInstallation() {
   // Extracting integrationNameOrId and groupRef from useInstallationProps.
   // These are required for the useListInstallationsQuery, especially in headless mode,

--- a/src/headless/installation/useUpdateInstallation.ts
+++ b/src/headless/installation/useUpdateInstallation.ts
@@ -1,5 +1,6 @@
 import {
   ConfigContent,
+  Installation,
   UpdateInstallationOperationRequest,
 } from "@generated/api/src";
 import { useProject } from "src/context/ProjectContextProvider";
@@ -12,7 +13,12 @@ import { useInstallation } from "./useInstallation";
 
 /**
  * update installation hook
- * @returns
+ * @returns {Object} An object containing:
+ *   - `updateInstallation` (function): A function to update the installation.
+ *   - `isIdle` (boolean): Whether the mutation is idle.
+ *   - `isPending` (boolean): Whether the mutation is pending.
+ *   - `error` (Error | null): The error object, if any.
+ *   - `errorMsg` (string | null): The error message, if any.
  */
 export function useUpdateInstallation() {
   const { projectIdOrName } = useProject();
@@ -28,7 +34,17 @@ export function useUpdateInstallation() {
     errorMsg,
   } = useUpdateInstallationMutation();
 
-  const updateInstallation = (config: ConfigContent) => {
+  const updateInstallation = ({
+    config,
+    onSuccess,
+    onError,
+    onSettled,
+  }: {
+    config: ConfigContent;
+    onSuccess?: (data: Installation) => void;
+    onError?: (error: Error) => void;
+    onSettled?: () => void;
+  }) => {
     if (!installation) {
       throw Error(
         "Installation not created yet. Try creating the installation first.",
@@ -53,7 +69,17 @@ export function useUpdateInstallation() {
       },
     };
 
-    return updateInstallationMutation(updateInstallationRequest);
+    return updateInstallationMutation(updateInstallationRequest, {
+      onSuccess: (data) => {
+        onSuccess?.(data);
+      },
+      onError: (error) => {
+        onError?.(error);
+      },
+      onSettled: () => {
+        onSettled?.();
+      },
+    });
   };
 
   return {


### PR DESCRIPTION
### Summary 
adds callbacks so that the builder has access to the success, error, and settled state given by tanstack-query. 

### notes:
headless folder is not exposed yet. 

