### PR TITLE
[2313] refactor: rename sync to reset

### DIFF
--- a/src/headless/config/useConfigHelper.tsx
+++ b/src/headless/config/useConfigHelper.tsx
@@ -59,17 +59,12 @@ export function useConfigHelper(
 ) {
   const [draft, setDraft] =
     useState<UpdateInstallationConfigContent>(initialConfig);
-  const [initial] = useState(initialConfig); // For reset
 
   const { getReadObject: getReadObjectFromManifest, data: manifest } =
     useManifest();
   const { installation } = useInstallation();
 
   const get = useCallback(() => draft, [draft]);
-
-  const reset = useCallback(() => {
-    setDraft(initial);
-  }, [initial]);
 
   /**
    * Initializes an object within the `_draft` configuration with default values from the manifest.
@@ -270,32 +265,26 @@ export function useConfigHelper(
     [draft.write?.objects],
   );
 
-  // add loading state
-  const [isSyncing, setIsSyncing] = useState(false);
-  const syncInstallationConfig = useCallback(() => {
+  const reset = useCallback(() => {
     // set the draft config to the installation config
-    setIsSyncing(true);
     setDraft((prev) =>
       produce(prev, (draft) => {
         Object.assign(draft, installation?.config?.content);
       }),
     );
-    setIsSyncing(false);
   }, [installation?.config?.content]);
 
   useEffect(() => {
     console.debug("Installation found", { installation });
     // sync the installation config to the local config
-    syncInstallationConfig();
-  }, [installation, syncInstallationConfig]);
+    reset();
+  }, [installation, reset]);
 
   return {
     draft,
     get,
-    syncInstallationConfig,
-    isSyncing,
-    setDraft,
     reset,
+    setDraft,
     readObject,
     writeObject,
   };


### PR DESCRIPTION
### Summary 
customer feedback said sync was a little confusing. renames sync to reset. 

- existing reset call is unused in demos. (we don't support passing in initial config yet)
- switched implementation to only use reset 