### PR TITLE
type: add config bridge types

### DIFF
--- a/src/headless/config/ConfigContext.tsx
+++ b/src/headless/config/ConfigContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext } from "react";
-import type { UpdateInstallationConfigContent } from "@generated/api/src";
 
+import type { InstallationConfigContent } from "./types";
 import { useConfigHelper } from "./useConfigHelper";
 
 const ConfigContext = createContext<ReturnType<typeof useConfigHelper> | null>(
@@ -12,7 +12,7 @@ export function ConfigProvider({
   initialConfig,
 }: {
   children: ReactNode;
-  initialConfig: UpdateInstallationConfigContent;
+  initialConfig: InstallationConfigContent;
 }) {
   const config = useConfigHelper(initialConfig);
   return (

--- a/src/headless/config/types.ts
+++ b/src/headless/config/types.ts
@@ -1,0 +1,44 @@
+import type {
+  ConfigContent,
+  UpdateInstallationConfigContent,
+} from "@generated/api/src";
+
+/**
+ * Bridge type for config content that can be used for both creation and updates.
+ * This type makes all fields optional to match UpdateInstallationConfigContent,
+ * but when used for creation, the provider field should be provided.
+ */
+type InstallationConfigContent = Partial<ConfigContent>;
+
+/**
+ * Type guard to check if a config content has the required fields for creation
+ */
+export function isValidCreateConfig(
+  config: InstallationConfigContent,
+): config is ConfigContent {
+  return typeof config.provider === "string";
+}
+
+/**
+ * Helper to convert InstallationConfigContent to UpdateInstallationConfigContent
+ */
+export function toUpdateConfigContent(
+  config: InstallationConfigContent,
+): UpdateInstallationConfigContent {
+  return config;
+}
+
+/**
+ * Helper to convert InstallationConfigContent to ConfigContent
+ * Throws error if required fields are missing
+ */
+export function toCreateConfigContent(
+  config: InstallationConfigContent,
+): ConfigContent {
+  if (!isValidCreateConfig(config)) {
+    throw new Error("Config must have a provider field for creation");
+  }
+  return config;
+}
+
+export type { InstallationConfigContent };

--- a/src/headless/config/useConfigHelper.tsx
+++ b/src/headless/config/useConfigHelper.tsx
@@ -6,12 +6,13 @@ import type {
   FieldSettingDefault,
   FieldSettingWriteOnCreateEnum,
   FieldSettingWriteOnUpdateEnum,
-  UpdateInstallationConfigContent,
 } from "@generated/api/src";
 import { produce } from "immer";
 
 import { useInstallation } from "../installation/useInstallation";
 import { useManifest } from "../manifest/useManifest";
+
+import type { InstallationConfigContent } from "./types";
 
 type ReadObjectHandlers = {
   object: BaseReadConfigObject | undefined;
@@ -54,11 +55,8 @@ type WriteObjectHandlers = {
   }) => void;
 };
 
-export function useConfigHelper(
-  initialConfig: UpdateInstallationConfigContent,
-) {
-  const [draft, setDraft] =
-    useState<UpdateInstallationConfigContent>(initialConfig);
+export function useConfigHelper(initialConfig: InstallationConfigContent) {
+  const [draft, setDraft] = useState<InstallationConfigContent>(initialConfig);
 
   const { getReadObject: getReadObjectFromManifest, data: manifest } =
     useManifest();
@@ -78,10 +76,10 @@ export function useConfigHelper(
    * - Ensures required fields are initialized if not already set.
    */
   const initializeObjectWithDefaults = useCallback(
-    (objectName: string, _draft: UpdateInstallationConfigContent) => {
+    (objectName: string, _draft: InstallationConfigContent) => {
       // initialize provider if not set
       _draft.provider = _draft.provider || manifest?.content?.provider || "";
-      const read = _draft.read || {};
+      const read = _draft.read || { objects: {} };
       const objects = read.objects || {};
       const obj = objects[objectName] || {};
 
@@ -100,8 +98,8 @@ export function useConfigHelper(
 
       // Initialize required fields for object from manifest if not set
       obj.objectName = obj.objectName || objectName;
-      obj.schedule = obj.schedule || defaultSchedule;
-      obj.destination = obj.destination || defaultDestination;
+      obj.schedule = obj.schedule || defaultSchedule || "";
+      obj.destination = obj.destination || defaultDestination || "";
       obj.selectedFields = obj.selectedFields || defaultSelectedFields;
 
       objects[objectName] = obj;
@@ -158,9 +156,7 @@ export function useConfigHelper(
     (objectName: string): WriteObjectHandlers => {
       const object = draft.write?.objects?.[objectName];
 
-      const initializeWriteObject = (
-        _draft: UpdateInstallationConfigContent,
-      ) => {
+      const initializeWriteObject = (_draft: InstallationConfigContent) => {
         // initialize write if it doesn't exist
         const write = _draft.write || {};
         // initialize object if it doesn't exist

--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -19,3 +19,6 @@ export { useHydratedRevisionQuery } from "./manifest/useHydratedRevisionQuery";
 
 // Config Hooks
 export { useConfig } from "./config/ConfigContext";
+
+// Config Bridge Types
+export type { InstallationConfigContent } from "./config/types";

--- a/src/headless/installation/useCreateInstallation.ts
+++ b/src/headless/installation/useCreateInstallation.ts
@@ -1,5 +1,4 @@
 import {
-  ConfigContent,
   CreateInstallationOperationRequest,
   Installation,
 } from "@generated/api/src";
@@ -8,6 +7,8 @@ import { useProject } from "src/context/ProjectContextProvider";
 import { useCreateInstallationMutation } from "src/hooks/mutation/useCreateInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
 
+import type { InstallationConfigContent } from "../config/types";
+import { toCreateConfigContent } from "../config/types";
 import { useInstallationProps } from "../InstallationProvider";
 import { useConnection } from "../useConnection";
 
@@ -43,7 +44,7 @@ export function useCreateInstallation() {
     onError,
     onSettled,
   }: {
-    config: ConfigContent;
+    config: InstallationConfigContent;
     onSuccess?: (data: Installation) => void;
     onError?: (error: Error) => void;
     onSettled?: () => void;
@@ -62,9 +63,7 @@ export function useCreateInstallation() {
         groupRef,
         connectionId: connection?.id,
         config: {
-          content: {
-            ...config,
-          },
+          content: toCreateConfigContent(config),
         },
       },
     };

--- a/src/headless/installation/useUpdateInstallation.ts
+++ b/src/headless/installation/useUpdateInstallation.ts
@@ -1,5 +1,4 @@
 import {
-  ConfigContent,
   Installation,
   UpdateInstallationOperationRequest,
 } from "@generated/api/src";
@@ -8,6 +7,8 @@ import { useProject } from "src/context/ProjectContextProvider";
 import { useUpdateInstallationMutation } from "src/hooks/mutation/useUpdateInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
 
+import type { InstallationConfigContent } from "../config/types";
+import { toUpdateConfigContent } from "../config/types";
 import { useInstallationProps } from "../InstallationProvider";
 
 import { useInstallation } from "./useInstallation";
@@ -41,7 +42,7 @@ export function useUpdateInstallation() {
     onError,
     onSettled,
   }: {
-    config: ConfigContent;
+    config: InstallationConfigContent;
     onSuccess?: (data: Installation) => void;
     onError?: (error: Error) => void;
     onSettled?: () => void;
@@ -83,7 +84,7 @@ export function useUpdateInstallation() {
         updateMask,
         installation: {
           config: {
-            content: config,
+            content: toUpdateConfigContent(config),
           },
         },
       },

--- a/src/public/index.ts
+++ b/src/public/index.ts
@@ -11,12 +11,8 @@ export * from "../context/AmpersandContextProvider";
 export * from "../components/Configure";
 export * from "../components/Connect/ConnectProvider";
 export * from "../hooks/useIsIntegrationInstalled";
-// export * from "../headless";
 
-/**
- * Generated API types and models
- */
-export * from "@generated/api/src";
+// Headless exported in index.ts
 
 /**
  *  Exported types which are helpful for builders


### PR DESCRIPTION
### Summary 
ConfigContent and UpdateInstallationContent types are being managed by the openAPI spec which causes confusion to the builder. This PR 
- adds a bridge type to merge the types and simplify the types needed by the builder. 
- remove generated types so that we selectively expose types as needed

