### PR TITLE
[ENG-2990] feat: add remove connection section to manage content

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -142,6 +142,7 @@ export function InstallIntegration({
         onUpdateSuccess={onUpdateSuccess}
         onUninstallSuccess={onUninstallSuccess}
         fieldMapping={fieldMapping}
+        resetComponent={reset}
       >
         <ConnectionsProvider>
           <ProtectedConnectionLayout

--- a/src/components/Configure/content/manage/ManageContent.tsx
+++ b/src/components/Configure/content/manage/ManageContent.tsx
@@ -1,3 +1,7 @@
+import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
+
+import { RemoveConnectionSection } from "components/Connect/RemoveConnectionSection";
+
 import { AuthenticationSection } from "./AuthenticationSection";
 import { UninstallSection } from "./UninstallSection";
 import { UpdateConnectionSection } from "./updateConnection/UpdateConnectionSection";
@@ -7,11 +11,18 @@ import { UpdateConnectionSection } from "./updateConnection/UpdateConnectionSect
  * @returns
  */
 export function ManageContent() {
+  const { installation, resetComponent } = useInstallIntegrationProps();
+
   return (
     <>
       <AuthenticationSection />
       <UpdateConnectionSection />
-      <UninstallSection />
+      {/* Uninstall section is only shown if the integration is installed */}
+      {installation && <UninstallSection />}
+      {/* Remove connection section is only shown if the integration is not installed */}
+      {!installation && (
+        <RemoveConnectionSection resetComponent={resetComponent} />
+      )}
     </>
   );
 }

--- a/src/components/Connect/RemoveConnectionSection.tsx
+++ b/src/components/Connect/RemoveConnectionSection.tsx
@@ -14,7 +14,7 @@ export function RemoveConnectionSection({
   onDisconnectSuccess,
 }: RemoveConnectionSectionProps) {
   return (
-    <>
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
       <FieldHeader string="Remove connection" />
       <p>Click to disconnect your connection from the provider.</p>
       <RemoveConnectionButton
@@ -22,8 +22,8 @@ export function RemoveConnectionSection({
         onDisconnectSuccess={onDisconnectSuccess}
         buttonText="Remove connection"
         buttonVariant="danger"
-        buttonStyle={{ fontSize: "13px" }}
+        buttonStyle={{ fontSize: "13px", width: "100%" }}
       />
-    </>
+    </div>
   );
 }

--- a/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
+++ b/src/context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider.tsx
@@ -39,6 +39,7 @@ interface InstallIntegrationContextValue {
   isIntegrationDeleted: boolean;
   setIntegrationDeleted: () => void;
   fieldMapping?: FieldMapping;
+  resetComponent: () => void;
 }
 // Create a context to pass down the props
 export const InstallIntegrationContext =
@@ -58,6 +59,7 @@ export const InstallIntegrationContext =
     onUninstallSuccess: undefined,
     isIntegrationDeleted: false,
     setIntegrationDeleted: () => {},
+    resetComponent: () => {},
   });
 
 // Create a custom hook to access the props
@@ -82,6 +84,7 @@ interface InstallIntegrationProviderProps {
   onUpdateSuccess?: (installationId: string, config: Config) => void;
   onUninstallSuccess?: (installationId: string) => void;
   fieldMapping?: FieldMapping;
+  resetComponent: () => void;
 }
 
 // Wrap your parent component with the context provider
@@ -96,6 +99,7 @@ export function InstallIntegrationProvider({
   onUpdateSuccess,
   onUninstallSuccess,
   fieldMapping,
+  resetComponent,
 }: InstallIntegrationProviderProps) {
   const { integrations } = useIntegrationList();
   const { setError, isError, removeError } = useErrorState();
@@ -190,6 +194,7 @@ export function InstallIntegrationProvider({
       isIntegrationDeleted,
       setIntegrationDeleted,
       fieldMapping,
+      resetComponent,
     }),
     [
       integrationObj,
@@ -206,6 +211,7 @@ export function InstallIntegrationProvider({
       isIntegrationDeleted,
       setIntegrationDeleted,
       fieldMapping,
+      resetComponent,
     ],
   );
 


### PR DESCRIPTION
### Summary 
adds remove connection section to manage content; previously could not uninstall if no installation. 
- add reset to provider context
- style: remove connection section

#### Screenshot 

![Screenshot 2025-06-05 at 4 58 40 PM](https://github.com/user-attachments/assets/0e4dcb93-b3bb-4937-b6d7-6fc1cc8e5248)
![Screenshot 2025-06-05 at 4 58 58 PM](https://github.com/user-attachments/assets/9c7d266c-c264-4ac5-998f-33925d57712e)

