### PR TITLE
feat: add jwt token provider to ampersand context

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.0.0",
     "immer": "^10.0.3",
+    "jose": "^6.0.12",
     "lodash.isequal": "^4.5.0",
     "react-tooltip": "^5.28.0"
   },

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -11,11 +11,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ApiKeyProvider } from "../ApiKeyContextProvider";
 import { ErrorStateProvider } from "../ErrorContextProvider";
 import { IntegrationListProvider } from "../IntegrationListContextProvider";
+import { JwtTokenProvider } from "../JwtTokenContextProvider";
 import { ProjectProvider } from "../ProjectContextProvider";
 
 interface AmpersandProviderProps {
   options: {
-    apiKey: string;
+    apiKey?: string;
     /**
      * Use `project` instead of `projectId`.
      * @deprecated
@@ -26,6 +27,11 @@ interface AmpersandProviderProps {
      */
     project?: string;
     styles?: object;
+    /**
+     * Callback function to get a JWT token for authorization.
+     * This function should return a Promise that resolves to a JWT token string.
+     */
+    getToken?: (consumerRef: string, groupRef: string) => Promise<string>;
   };
   children: React.ReactNode;
 }
@@ -34,7 +40,7 @@ const queryClient = new QueryClient();
 
 export function AmpersandProvider(props: AmpersandProviderProps) {
   const {
-    options: { apiKey, projectId, project },
+    options: { apiKey, projectId, project, getToken },
     children,
   } = props;
   const projectIdOrName = project || projectId;
@@ -49,18 +55,28 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
     );
   }
 
-  if (!apiKey) {
-    throw new Error("Cannot use AmpersandProvider without an apiKey.");
+  if (!apiKey && !getToken) {
+    throw new Error(
+      "Cannot use AmpersandProvider without an apiKey or getToken.",
+    );
+  }
+
+  if (apiKey && getToken) {
+    throw new Error(
+      "Cannot use AmpersandProvider with both apiKey and getToken.",
+    );
   }
 
   return (
     <QueryClientProvider client={queryClient}>
       <ErrorStateProvider>
-        <ApiKeyProvider value={apiKey}>
-          <ProjectProvider projectIdOrName={projectIdOrName}>
-            <IntegrationListProvider>{children}</IntegrationListProvider>
-          </ProjectProvider>
-        </ApiKeyProvider>
+        <JwtTokenProvider getTokenCallback={getToken || null}>
+          <ApiKeyProvider value={null}>
+            <ProjectProvider projectIdOrName={projectIdOrName}>
+              <IntegrationListProvider>{children}</IntegrationListProvider>
+            </ProjectProvider>
+          </ApiKeyProvider>
+        </JwtTokenProvider>
       </ErrorStateProvider>
     </QueryClientProvider>
   );

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -71,7 +71,7 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
     <QueryClientProvider client={queryClient}>
       <ErrorStateProvider>
         <JwtTokenProvider getTokenCallback={getToken || null}>
-          <ApiKeyProvider value={null}>
+          <ApiKeyProvider value={apiKey || null}>
             <ProjectProvider projectIdOrName={projectIdOrName}>
               <IntegrationListProvider>{children}</IntegrationListProvider>
             </ProjectProvider>

--- a/src/context/AmpersandContextProvider/README.md
+++ b/src/context/AmpersandContextProvider/README.md
@@ -1,0 +1,93 @@
+# AmpersandProvider with JWT Token Support
+
+The `AmpersandProvider` now supports both API key and JWT token authentication methods.
+
+## Usage
+
+### API Key Authentication (Existing)
+
+```tsx
+import { AmpersandProvider } from './AmpersandContextProvider';
+
+function App() {
+  return (
+    <AmpersandProvider
+      options={{
+        apiKey: "your-api-key-here",
+        project: "your-project-id"
+      }}
+    >
+      {/* Your app components */}
+    </AmpersandProvider>
+  );
+}
+```
+
+### JWT Token Authentication (New)
+
+```tsx
+import { AmpersandProvider } from './AmpersandContextProvider';
+
+function App() {
+  const getToken = async (consumerRef: string, groupRef: string): Promise<string> => {
+    // Your custom token retrieval logic here
+    // This could involve calling your auth service, checking localStorage, etc.
+    const response = await fetch('/api/auth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ consumerRef, groupRef }),
+    });
+    
+    const data = await response.json();
+    return data.token;
+  };
+
+  return (
+    <AmpersandProvider
+      options={{
+        getToken,
+        project: "your-project-id"
+      }}
+    >
+      {/* Your app components */}
+    </AmpersandProvider>
+  );
+}
+```
+
+## Features
+
+### JWT Token Caching
+
+The JWT token provider automatically caches tokens in both memory and localStorage:
+
+- **Memory Cache**: Fast access for the current session
+- **localStorage**: Persistence across browser sessions
+- **Automatic Expiration**: Tokens are automatically refreshed when they expire
+- **Cache Key**: Tokens are cached using the pattern `{consumerRef}:{groupRef}`
+
+### Authentication Methods
+
+The provider supports two mutually exclusive authentication methods:
+
+1. **API Key**: Traditional API key authentication
+2. **JWT Token**: Dynamic token retrieval with caching
+
+You cannot use both methods simultaneously - the provider will throw an error if both `apiKey` and `getToken` are provided.
+
+### Error Handling
+
+- If neither `apiKey` nor `getToken` is provided, the provider will throw an error
+- If both are provided, the provider will throw an error
+- JWT token retrieval failures are properly handled and logged
+
+## API Service Integration
+
+The `useAPI` hook automatically detects which authentication method is available and configures the API service accordingly:
+
+- **API Key**: Uses `X-Api-Key` header
+- **JWT Token**: Uses `Authorization: Bearer {token}` header
+
+The API service will automatically retrieve fresh tokens when needed, handling the caching and refresh logic transparently. 

--- a/src/context/ApiKeyContextProvider.tsx
+++ b/src/context/ApiKeyContextProvider.tsx
@@ -1,14 +1,19 @@
 import { createContext, useContext } from "react";
 
+import { JwtTokenContext } from "./JwtTokenContextProvider";
+
 export const ApiKeyContext = createContext<string | null>(null);
 
 export const ApiKeyProvider = ApiKeyContext.Provider;
 
 export const useApiKey = () => {
   const apiKey = useContext(ApiKeyContext);
+  const jwtToken = useContext(JwtTokenContext);
 
-  if (apiKey === null) {
-    throw new Error("useApiKey must be used within an ApiKeyProvider");
+  if (apiKey === null && jwtToken === null) {
+    console.error(
+      "useApiKey must be used within an ApiKeyProvider, or there is no JWT token callback",
+    );
   }
 
   return apiKey;

--- a/src/context/JwtTokenContextProvider.tsx
+++ b/src/context/JwtTokenContextProvider.tsx
@@ -13,6 +13,9 @@ interface TokenCacheEntry {
   expiresAt: number;
 }
 
+const createCacheKey = (consumerRef: string, groupRef: string) =>
+  `${consumerRef}:${groupRef}`;
+
 type TokenCache = Map<string, TokenCacheEntry>;
 
 interface JwtTokenContextValue {
@@ -61,7 +64,7 @@ export function JwtTokenProvider({
 
   const getCachedToken = useCallback(
     (consumerRef: string, groupRef: string): string | null => {
-      const cacheKey = `${consumerRef}:${groupRef}`;
+      const cacheKey = createCacheKey(consumerRef, groupRef);
       const cached = tokenCache.get(cacheKey);
 
       if (cached && cached.expiresAt > Date.now()) {
@@ -84,7 +87,7 @@ export function JwtTokenProvider({
 
   const setCachedToken = useCallback(
     async (consumerRef: string, groupRef: string, token: string) => {
-      const cacheKey = `${consumerRef}:${groupRef}`;
+      const cacheKey = createCacheKey(consumerRef, groupRef);
 
       // Extract actual expiration time from JWT token using jose library
       const tokenExpiration = await getTokenExpirationTime(token);

--- a/src/context/JwtTokenContextProvider.tsx
+++ b/src/context/JwtTokenContextProvider.tsx
@@ -1,0 +1,202 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { jwtVerify } from "jose";
+
+// Token cache types
+interface TokenCacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+type TokenCache = Map<string, TokenCacheEntry>;
+
+interface JwtTokenContextValue {
+  getToken: (consumerRef: string, groupRef: string) => Promise<string>;
+  clearToken: () => void;
+}
+
+export const JwtTokenContext = createContext<JwtTokenContextValue | null>(null);
+
+interface JwtTokenProviderProps {
+  getTokenCallback:
+    | ((consumerRef: string, groupRef: string) => Promise<string>)
+    | null;
+  children: React.ReactNode;
+}
+
+// JWT token expiration extraction using jose library
+const getTokenExpirationTime = async (
+  token: string,
+): Promise<number | null> => {
+  try {
+    // Use jose library to decode and verify the JWT token
+    // We're not verifying the signature since we just want to extract the payload
+    const decoded = await jwtVerify(token, new Uint8Array(0), {
+      algorithms: [], // Skip signature verification
+    });
+
+    const payload = decoded.payload;
+    if (payload.exp && typeof payload.exp === "number") {
+      // JWT exp is in seconds, convert to milliseconds
+      return payload.exp * 1000;
+    }
+
+    return null;
+  } catch (error) {
+    console.warn("Failed to decode JWT token:", error);
+    return null;
+  }
+};
+
+export function JwtTokenProvider({
+  getTokenCallback,
+  children,
+}: JwtTokenProviderProps) {
+  const [tokenCache, setTokenCache] = useState<TokenCache>(new Map());
+
+  const getCachedToken = useCallback(
+    (consumerRef: string, groupRef: string): string | null => {
+      const cacheKey = `${consumerRef}:${groupRef}`;
+      const cached = tokenCache.get(cacheKey);
+
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.token;
+      }
+
+      // Remove expired token from cache
+      if (cached && cached.expiresAt < Date.now()) {
+        setTokenCache((prev) => {
+          const newCache = new Map(prev);
+          newCache.delete(cacheKey);
+          return newCache;
+        });
+      }
+
+      return null;
+    },
+    [tokenCache],
+  );
+
+  const setCachedToken = useCallback(
+    async (consumerRef: string, groupRef: string, token: string) => {
+      const cacheKey = `${consumerRef}:${groupRef}`;
+
+      // Extract actual expiration time from JWT token using jose library
+      const tokenExpiration = await getTokenExpirationTime(token);
+      const expiresAt = tokenExpiration || Date.now() + 3600 * 1000; // fallback to 1 hour
+
+      const cacheEntry: TokenCacheEntry = { token, expiresAt };
+
+      setTokenCache((prev) => new Map(prev).set(cacheKey, cacheEntry));
+
+      // Also store in localStorage for persistence
+      try {
+        localStorage.setItem(
+          `amp-labs_jwt_${cacheKey}`,
+          JSON.stringify(cacheEntry),
+        );
+      } catch {
+        console.warn("Failed to store JWT token in localStorage");
+      }
+    },
+    [],
+  );
+
+  const clearToken = useCallback(() => {
+    setTokenCache(new Map());
+    // Clear from localStorage
+    try {
+      const keys = Object.keys(localStorage);
+      keys.forEach((key) => {
+        if (key.startsWith("amp-labs_jwt_")) {
+          localStorage.removeItem(key);
+        }
+      });
+    } catch {
+      console.warn("Failed to clear JWT tokens from localStorage");
+    }
+  }, []);
+
+  // Load cached tokens from localStorage on mount
+  useEffect(() => {
+    try {
+      const newCache: TokenCache = new Map();
+      const keys = Object.keys(localStorage);
+
+      keys.forEach((key) => {
+        if (key.startsWith("amp-labs_jwt_")) {
+          const cacheKey = key.replace("amp-labs_jwt_", "");
+          const stored = localStorage.getItem(key);
+          if (stored) {
+            try {
+              const cacheEntry: TokenCacheEntry = JSON.parse(stored);
+              if (cacheEntry.expiresAt > Date.now()) {
+                newCache.set(cacheKey, cacheEntry);
+              } else {
+                localStorage.removeItem(key);
+              }
+            } catch {
+              localStorage.removeItem(key);
+            }
+          }
+        }
+      });
+
+      if (newCache.size > 0) {
+        setTokenCache(newCache);
+      }
+    } catch {
+      console.warn("Failed to load JWT tokens from localStorage");
+    }
+  }, []);
+
+  const getToken = useCallback(
+    async (consumerRef: string, groupRef: string): Promise<string> => {
+      // First try to get from cache
+      const cachedToken = getCachedToken(consumerRef, groupRef);
+      if (cachedToken) return cachedToken;
+
+      if (!getTokenCallback) {
+        console.error("getTokenCallback is not set");
+        throw new Error("getTokenCallback is not set");
+      }
+
+      // If not cached, fetch new token
+      try {
+        const token = await getTokenCallback(consumerRef, groupRef);
+        await setCachedToken(consumerRef, groupRef, token);
+        return token;
+      } catch {
+        console.error("Failed to get JWT token");
+        throw new Error("Failed to get JWT token");
+      }
+    },
+    [getTokenCallback, getCachedToken, setCachedToken],
+  );
+
+  const contextValue: JwtTokenContextValue = {
+    getToken,
+    clearToken,
+  };
+
+  return (
+    <JwtTokenContext.Provider value={contextValue}>
+      {children}
+    </JwtTokenContext.Provider>
+  );
+}
+
+export const useJwtToken = () => {
+  const context = useContext(JwtTokenContext);
+
+  if (!context) {
+    throw new Error("useJwtToken must be used within a JwtTokenProvider");
+  }
+
+  return context;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5243,6 +5243,11 @@ jju@~1.4.0:
   resolved "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
+jose@^6.0.12:
+  version "6.0.12"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.0.12.tgz#56253d94d46bd784addc4bde3691c323552fe7e4"
+  integrity sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"


### PR DESCRIPTION
### Summary
This PR adds the ability for the builder to give a callback `getToken` to get a JWT. Our API service will smart detect either an API key or a `getToken` option and use if only one is provided.
- adds `jose` library to handle jwt token expiration / decoding
- adds jwt token provider to ampersand context
- refactor api service to use jwt token provider 
- refactors api service to use API key and JWT headers. 

#### JWT Logic
1. `getToken` gets token from builder's backend
2. `amp-labs/react` api service will look in localstorage for a cached jwt token or call getToken to use / set in cache
3. cached jwt will be loaded into JWT provider to be used in the API service
4. expired JWT will be removed from local storage upon mount


