### PR TITLE
[ENG-2419] refactor: use ampersand provider props for projectIdOrName

### DIFF
--- a/src/components/Configure/actions/mutateAndSetState/createInstallationAndSetState.ts
+++ b/src/components/Configure/actions/mutateAndSetState/createInstallationAndSetState.ts
@@ -8,7 +8,7 @@ import {
 import { handleServerError } from "src/utils/handleServerError";
 
 export type CreateInstallationSharedProps = {
-  projectId: string;
+  projectIdOrName: string;
   integrationId: string;
   groupRef: string;
   connectionId: string;
@@ -24,7 +24,7 @@ type CreateInstallationAndSetStateProps = CreateInstallationSharedProps & {
 
 export async function createInstallationAndSetState({
   createConfig,
-  projectId,
+  projectIdOrName,
   integrationId,
   groupRef,
   connectionId,
@@ -34,7 +34,7 @@ export async function createInstallationAndSetState({
   onInstallSuccess,
 }: CreateInstallationAndSetStateProps) {
   const createInstallationRequest: CreateInstallationOperationRequest = {
-    projectIdOrName: projectId,
+    projectIdOrName,
     integrationId,
     installation: {
       groupRef,

--- a/src/components/Configure/actions/mutateAndSetState/updateInstallationAndSetState.ts
+++ b/src/components/Configure/actions/mutateAndSetState/updateInstallationAndSetState.ts
@@ -9,7 +9,7 @@ import { escapeObjectName } from "src/utils";
 import { handleServerError } from "src/utils/handleServerError";
 
 type UpdateInstallationSharedProps = {
-  projectId: string;
+  projectIdOrName: string;
   integrationId: string;
   installationId: string;
   apiKey: string;
@@ -23,7 +23,7 @@ type UpdateInstallationAndSetStateProps = UpdateInstallationSharedProps & {
 };
 export function updateInstallationAndSetState({
   updateConfig,
-  projectId,
+  projectIdOrName,
   integrationId,
   installationId,
   apiKey,
@@ -33,7 +33,7 @@ export function updateInstallationAndSetState({
   setError,
 }: UpdateInstallationAndSetStateProps) {
   const updateInstallationRequest: UpdateInstallationOperationRequest = {
-    projectIdOrName: projectId,
+    projectIdOrName,
     installationId,
     integrationId,
     installationUpdate: {

--- a/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
@@ -96,7 +96,7 @@ const generateCreateReadConfigFromConfigureState = (
 };
 
 export const onSaveReadCreateInstallation = (
-  projectId: string,
+  projectIdOrName: string,
   integrationId: string,
   groupRef: string,
   consumerRef: string,
@@ -122,7 +122,7 @@ export const onSaveReadCreateInstallation = (
 
   return createInstallationAndSetState({
     createConfig,
-    projectId,
+    projectIdOrName,
     integrationId,
     groupRef,
     connectionId,

--- a/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadUpdateInstallation.ts
@@ -79,7 +79,7 @@ const generateUpdateReadConfigFromConfigureState = (
 };
 
 export const onSaveReadUpdateInstallation = (
-  projectId: string,
+  projectIdOrName: string,
   integrationId: string,
   installationId: string,
   selectedObjectName: string,
@@ -109,7 +109,7 @@ export const onSaveReadUpdateInstallation = (
 
   return updateInstallationAndSetState({
     updateConfig,
-    projectId,
+    projectIdOrName,
     integrationId,
     installationId,
     apiKey,

--- a/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteCreateInstallation.ts
@@ -79,7 +79,7 @@ const generateCreateWriteConfigFromConfigureState = (
 };
 
 export const onSaveWriteCreateInstallation = (
-  projectId: string,
+  projectIdOrName: string,
   integrationId: string,
   groupRef: string,
   consumerRef: string,
@@ -103,7 +103,7 @@ export const onSaveWriteCreateInstallation = (
 
   return createInstallationAndSetState({
     createConfig,
-    projectId,
+    projectIdOrName,
     integrationId,
     groupRef,
     connectionId,

--- a/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
+++ b/src/components/Configure/actions/write/onSaveWriteUpdateInstallation.ts
@@ -46,7 +46,7 @@ const generateUpdateWriteConfigFromConfigureState = (
 };
 
 export const onSaveWriteUpdateInstallation = (
-  projectId: string,
+  projectIdOrName: string,
   integrationId: string,
   installationId: string,
   apiKey: string,
@@ -71,7 +71,7 @@ export const onSaveWriteUpdateInstallation = (
   }
 
   const updateInstallationRequest: UpdateInstallationOperationRequest = {
-    projectIdOrName: projectId,
+    projectIdOrName,
     installationId,
     integrationId,
     installationUpdate: {

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -28,7 +28,7 @@ export function CreateInstallation() {
     selectedObjectName,
     selectedConnection,
     apiKey,
-    projectId,
+    projectIdOrName,
     resetBoundary,
     setErrors,
     setMutateInstallationError,
@@ -97,7 +97,7 @@ export function CreateInstallation() {
       selectedObjectName &&
       selectedConnection?.id &&
       apiKey &&
-      projectId &&
+      projectIdOrName &&
       integrationId &&
       groupRef &&
       consumerRef &&
@@ -105,7 +105,7 @@ export function CreateInstallation() {
     ) {
       setLoadingState(true);
       const res = onSaveReadCreateInstallation(
-        projectId,
+        projectIdOrName,
         integrationId,
         groupRef,
         consumerRef,
@@ -139,7 +139,7 @@ export function CreateInstallation() {
       selectedObjectName &&
       selectedConnection?.id &&
       apiKey &&
-      projectId &&
+      projectIdOrName &&
       integrationId &&
       groupRef &&
       consumerRef &&
@@ -147,7 +147,7 @@ export function CreateInstallation() {
     ) {
       setLoadingState(true);
       const res = onSaveWriteCreateInstallation(
-        projectId,
+        projectIdOrName,
         integrationId,
         groupRef,
         consumerRef,

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -27,7 +27,7 @@ export function UpdateInstallation({
     loading,
     selectedObjectName,
     apiKey,
-    projectId,
+    projectIdOrName,
     resetBoundary,
     setErrors,
     setMutateInstallationError,
@@ -103,12 +103,12 @@ export function UpdateInstallation({
       installation &&
       selectedObjectName &&
       apiKey &&
-      projectId &&
+      projectIdOrName &&
       hydratedObject
     ) {
       setLoadingState(true);
       const res = onSaveReadUpdateInstallation(
-        projectId,
+        projectIdOrName,
         integrationObj.id,
         installation.id,
         selectedObjectName,
@@ -136,12 +136,12 @@ export function UpdateInstallation({
       installation &&
       selectedObjectName &&
       apiKey &&
-      projectId &&
+      projectIdOrName &&
       hydratedRevision
     ) {
       setLoadingState(true);
       const res = onSaveWriteUpdateInstallation(
-        projectId,
+        projectIdOrName,
         integrationObj.id,
         installation.id,
         apiKey,

--- a/src/components/Configure/content/manage/updateConnection/UpdateApiKeyConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateApiKeyConnect.tsx
@@ -3,8 +3,8 @@ import { ApiKeyAuthForm } from "src/components/auth/ApiKeyAuth/ApiKeyAuthContent
 import { IFormType } from "src/components/auth/ApiKeyAuth/LandingContentProps";
 import { FormErrorBox } from "src/components/FormErrorBox";
 import { FormSuccessBox } from "src/components/FormSuccessBox";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useConnections } from "src/context/ConnectionsContextProvider";
-import { useProject } from "src/context/ProjectContextProvider";
 import { useUpdateConnectionMutation } from "src/hooks/mutation/useUpdateConnectionMutation";
 import { useProvider } from "src/hooks/useProvider";
 import { handleServerError } from "src/utils/handleServerError";
@@ -17,7 +17,7 @@ import { FieldHeader } from "../../fields/FieldHeader";
  * @returns
  */
 export function UpdateApiKeyConnect({ provider }: { provider?: string }) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { providerName, data: providerInfo } = useProvider(provider);
   const { selectedConnection, isConnectionsLoading } = useConnections();
 

--- a/src/components/Configure/content/manage/updateConnection/UpdateBasicAuthConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateBasicAuthConnect.tsx
@@ -3,8 +3,8 @@ import { BasicAuthForm } from "src/components/auth/BasicAuth/BasicAuthContent";
 import { BasicCreds } from "src/components/auth/BasicAuth/LandingContentProps";
 import { FormErrorBox } from "src/components/FormErrorBox";
 import { FormSuccessBox } from "src/components/FormSuccessBox";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useConnections } from "src/context/ConnectionsContextProvider";
-import { useProject } from "src/context/ProjectContextProvider";
 import { useUpdateConnectionMutation } from "src/hooks/mutation/useUpdateConnectionMutation";
 import { useProvider } from "src/hooks/useProvider";
 import { handleServerError } from "src/utils/handleServerError";
@@ -17,7 +17,7 @@ import { FieldHeader } from "../../fields/FieldHeader";
  * @returns
  */
 export function UpdateBasicAuthConnect({ provider }: { provider?: string }) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { providerName, data: providerInfo } = useProvider(provider);
   const { selectedConnection, isConnectionsLoading } = useConnections();
 

--- a/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
+++ b/src/components/Configure/content/manage/updateConnection/UpdateClientCredentialsConnect.tsx
@@ -3,8 +3,8 @@ import { ClientCredentialsForm } from "src/components/auth/Oauth/ClientCredentia
 import { ClientCredentialsCredsContent } from "src/components/auth/Oauth/ClientCredentials/ClientCredentialsCredsContent";
 import { FormErrorBox } from "src/components/FormErrorBox";
 import { FormSuccessBox } from "src/components/FormSuccessBox";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useConnections } from "src/context/ConnectionsContextProvider";
-import { useProject } from "src/context/ProjectContextProvider";
 import { useUpdateConnectionMutation } from "src/hooks/mutation/useUpdateConnectionMutation";
 import { useProvider } from "src/hooks/useProvider";
 import { handleServerError } from "src/utils/handleServerError";
@@ -21,7 +21,7 @@ export function UpdateClientCredentialsConnect({
 }: {
   provider?: string;
 }) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { selectedConnection, isConnectionsLoading } = useConnections();
   const { providerName, data: providerInfo } = useProvider(provider);
   const {

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -3,7 +3,7 @@ import { useApiKey } from "context/ApiKeyContextProvider";
 import { useConnections } from "context/ConnectionsContextProvider";
 import { ErrorBoundary, useErrorState } from "context/ErrorContextProvider";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import { useProject } from "context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 
 import {
   useNextIncompleteTabIndex,
@@ -29,7 +29,7 @@ export const useMutateInstallation = () => {
   const { selectedObjectName } = useSelectedObjectName();
   const { selectedConnection } = useConnections();
   const apiKey = useApiKey();
-  const { projectId } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { resetBoundary, setErrors, setError, getError } = useErrorState();
   const {
     resetConfigureState,
@@ -93,7 +93,7 @@ export const useMutateInstallation = () => {
     selectedObjectName,
     selectedConnection,
     apiKey,
-    projectId,
+    projectIdOrName,
     resetBoundary,
     setErrors,
     setMutateInstallationError,

--- a/src/components/Configure/layout/ConditionalHasConfigurationLayout/ConditionalHasConfigurationLayout.tsx
+++ b/src/components/Configure/layout/ConditionalHasConfigurationLayout/ConditionalHasConfigurationLayout.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
 import { useConnections } from "context/ConnectionsContextProvider";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import { useProject } from "context/ProjectContextProvider";
 import {
   CreateInstallationOperationRequest,
   HydratedRevision,
 } from "services/api";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useCreateInstallationMutation } from "src/hooks/mutation/useCreateInstallationMutation";
 
 import { getIsProxyEnabled } from "../../actions/proxy/isProxyEnabled";
@@ -39,7 +39,7 @@ export function ConditionalHasConfigurationLayout({
   children,
 }: ConditionalHasConfigurationLayoutProps) {
   const hasFiredMutationRef = useRef(false);
-  const { projectId } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { hydratedRevision, loading: hydratedRevisionLoading } =
     useHydratedRevision();
   const {
@@ -81,7 +81,7 @@ export function ConditionalHasConfigurationLayout({
       provider
     ) {
       const createInstallationRequest: CreateInstallationOperationRequest = {
-        projectIdOrName: projectId,
+        projectIdOrName,
         integrationId: integrationObj?.id,
         installation: {
           groupRef,
@@ -110,7 +110,7 @@ export function ConditionalHasConfigurationLayout({
     isConfigurationNotRequired,
     installation,
     selectedConnection,
-    projectId,
+    projectIdOrName,
     integrationObj?.id,
     groupRef,
     consumerRef,

--- a/src/components/Configure/layout/UninstallButton.tsx
+++ b/src/components/Configure/layout/UninstallButton.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import { useProject } from "context/ProjectContextProvider";
 import { useAPI } from "services/api";
 import { Button } from "src/components/ui-base/Button";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { handleServerError } from "src/utils/handleServerError";
 
 interface UninstallButtonProps {
@@ -44,7 +44,7 @@ export function UninstallButton({
   buttonVariant = "secondary",
   buttonStyle = {},
 }: UninstallButtonProps) {
-  const { projectId } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const {
     integrationId,
     installation,
@@ -53,7 +53,7 @@ export function UninstallButton({
   } = useInstallIntegrationProps();
   const [loading, setLoading] = useState<boolean>(false);
   const isDisabled =
-    !projectId || !integrationId || !installation?.id || loading;
+    !projectIdOrName || !integrationId || !installation?.id || loading;
 
   const deleteInstallationMutation = useDeleteInstallationMutation();
 
@@ -61,14 +61,14 @@ export function UninstallButton({
     if (!isDisabled) {
       setLoading(true);
       console.warn("uninstalling installation", {
-        projectId,
+        projectIdOrName,
         integrationId,
         installationId: installation.id,
       });
 
       deleteInstallationMutation.mutate(
         {
-          projectIdOrName: projectId,
+          projectIdOrName,
           integrationId,
           installationId: installation.id,
         },

--- a/src/components/Configure/state/HydratedRevisionContext.tsx
+++ b/src/components/Configure/state/HydratedRevisionContext.tsx
@@ -9,7 +9,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useConnections } from "context/ConnectionsContextProvider";
 import { ErrorBoundary, useErrorState } from "context/ErrorContextProvider";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import { useProject } from "context/ProjectContextProvider";
 import {
   HydratedIntegrationRead,
   HydratedIntegrationWriteObject,
@@ -23,6 +22,7 @@ import {
 import { UpdateConnectionSection } from "src/components/Configure/content/manage/updateConnection/UpdateConnectionSection";
 import { RemoveConnectionButton } from "src/components/Connect/RemoveConnectionButton";
 import { InnerErrorTextBox } from "src/components/ErrorTextBox/ErrorTextBox";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { handleServerError } from "src/utils/handleServerError";
 
 interface HydratedRevisionContextValue {
@@ -56,7 +56,7 @@ const useHydratedRevisionQuery = () => {
   const queryClient = useQueryClient();
   const getAPI = useAPI();
   const { selectedConnection, isConnectionsLoading } = useConnections();
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { integrationId, integrationObj } = useInstallIntegrationProps();
 
   const connectionId = selectedConnection?.id;

--- a/src/components/Connect/RemoveConnectionButton.tsx
+++ b/src/components/Connect/RemoveConnectionButton.tsx
@@ -1,6 +1,6 @@
-import { useProject } from "context/ProjectContextProvider";
 import { Connection } from "services/api";
 import { Button } from "src/components/ui-base/Button";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useConnections } from "src/context/ConnectionsContextProvider";
 import { useDeleteConnectionMutation } from "src/hooks/mutation/useDeleteConnectionMutation";
 import { handleServerError } from "src/utils/handleServerError";
@@ -22,13 +22,13 @@ export function RemoveConnectionButton({
   resetComponent,
   onDisconnectError,
 }: RemoveConnectionButtonProps) {
-  const { projectId } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { selectedConnection } = useConnections();
   const { mutate: deleteConnection, isPending: isDeletePending } =
     useDeleteConnectionMutation();
 
   const isDisabled =
-    !projectId ||
+    !projectIdOrName ||
     !selectedConnection ||
     !selectedConnection.id ||
     isDeletePending;
@@ -36,13 +36,13 @@ export function RemoveConnectionButton({
   const onDelete = async () => {
     if (!isDisabled) {
       console.warn("deleting connection", {
-        projectId,
+        projectIdOrName,
         connectionId: selectedConnection?.id,
       });
 
       deleteConnection(
         {
-          projectIdOrName: projectId,
+          projectIdOrName,
           connectionId: selectedConnection?.id,
         },
         {

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthFlow.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthFlow.tsx
@@ -3,8 +3,8 @@ import {
   GenerateConnectionOperationRequest,
   ProviderInfo,
 } from "@generated/api/src";
-import { useProject } from "context/ProjectContextProvider";
 import { Connection } from "services/api";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 
 import { useCreateConnectionMutation } from "../useCreateConnectionMutation";
 
@@ -32,7 +32,7 @@ export function ApiKeyAuthFlow({
   children,
   selectedConnection,
 }: ApiKeyAuthFlowProps) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const createConnectionMutation = useCreateConnectionMutation();
 
   const onNext = useCallback(

--- a/src/components/auth/BasicAuth/BasicAuthFlow.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthFlow.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { GenerateConnectionOperationRequest } from "@generated/api/src";
-import { useProject } from "context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 
 import { useCreateConnectionMutation } from "../useCreateConnectionMutation";
 
@@ -18,7 +18,7 @@ export function BasicAuthFlow({
   children,
   selectedConnection,
 }: BasicAuthFlowProps) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const createConnectionMutation = useCreateConnectionMutation();
 
   const onNext = useCallback(

--- a/src/components/auth/CustomAuth/CustomAuthFlow.tsx
+++ b/src/components/auth/CustomAuth/CustomAuthFlow.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { GenerateConnectionOperationRequest } from "@generated/api/src";
-import { useProject } from "context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { handleServerError } from "src/utils/handleServerError";
 
 import { useCreateConnectionMutation } from "../useCreateConnectionMutation";
@@ -18,7 +18,7 @@ export function CustomAuthFlow({
   children,
   selectedConnection,
 }: CustomAuthFlowProps) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const createConnectionMutation = useCreateConnectionMutation();
   const [error, setError] = useState<string | null>(null);
 

--- a/src/components/auth/NoAuth/NoAuthFlow.tsx
+++ b/src/components/auth/NoAuth/NoAuthFlow.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { GenerateConnectionOperationRequest } from "@generated/api/src";
-import { useProject } from "context/ProjectContextProvider";
 import { Connection } from "services/api";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 
 import { useCreateConnectionMutation } from "../useCreateConnectionMutation";
 
@@ -33,7 +33,7 @@ export function NoAuthFlow({
   selectedConnection,
   providerName,
 }: NoAuthFlowProps) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const createConnectionMutation = useCreateConnectionMutation();
 
   const onNext = useCallback(() => {

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContainer.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContainer.tsx
@@ -7,7 +7,7 @@ import {
   Connection,
   GenerateConnectionOperationRequest,
 } from "@generated/api/src";
-import { useProject } from "context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 
 import { LoadingCentered } from "components/Loading";
 
@@ -41,7 +41,7 @@ export function ClientCredsContainer({
   explicitScopesRequired,
   selectedConnection,
 }: OauthClientCredsContainerProps) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const createConnectionMutation = useCreateConnectionMutation();
   const [error, setError] = useState<string | null>(null);
 

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -30,6 +30,26 @@ interface AmpersandProviderProps {
   children: React.ReactNode;
 }
 
+interface AmpersandContextValue {
+  options: AmpersandProviderProps["options"];
+  projectIdOrName: string;
+}
+
+export const AmpersandContext = createContext<AmpersandContextValue | null>(
+  null,
+);
+
+export function useAmpersandProviderProps(): AmpersandContextValue {
+  const ampersandContext = useContext(AmpersandContext);
+
+  if (!ampersandContext) {
+    throw new Error(`Cannot call useAmpersandProvider unless your 
+        component is wrapped with AmpersandProvider`);
+  }
+
+  return ampersandContext;
+}
+
 const queryClient = new QueryClient();
 
 export function AmpersandProvider(props: AmpersandProviderProps) {
@@ -53,27 +73,22 @@ export function AmpersandProvider(props: AmpersandProviderProps) {
     throw new Error("Cannot use AmpersandProvider without an apiKey.");
   }
 
+  const contextValue: AmpersandContextValue = {
+    options: props.options,
+    projectIdOrName,
+  };
+
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorStateProvider>
-        <ApiKeyProvider value={apiKey}>
-          <ProjectProvider projectIdOrName={projectIdOrName}>
-            <IntegrationListProvider>{children}</IntegrationListProvider>
-          </ProjectProvider>
-        </ApiKeyProvider>
-      </ErrorStateProvider>
+      <AmpersandContext.Provider value={contextValue}>
+        <ErrorStateProvider>
+          <ApiKeyProvider value={apiKey}>
+            <ProjectProvider projectIdOrName={projectIdOrName}>
+              <IntegrationListProvider>{children}</IntegrationListProvider>
+            </ProjectProvider>
+          </ApiKeyProvider>
+        </ErrorStateProvider>
+      </AmpersandContext.Provider>
     </QueryClientProvider>
   );
-}
-
-export const AmpersandContext = createContext(null);
-export function useAmpersandProvider() {
-  const ampersandContext = useContext(AmpersandContext);
-
-  if (!ampersandContext) {
-    throw new Error(`Cannot call useAmpersandProvider unless your 
-        component is wrapped with AmpersandProvider`);
-  }
-
-  return ampersandContext;
 }

--- a/src/context/IntegrationListContextProvider.tsx
+++ b/src/context/IntegrationListContextProvider.tsx
@@ -3,8 +3,8 @@ import { useListIntegrationsQuery } from "hooks/query/useIntegrationListQuery";
 import { Integration } from "services/api";
 import { handleServerError } from "src/utils/handleServerError";
 
+import { useAmpersandProviderProps } from "./AmpersandContextProvider/AmpersandContextProvider";
 import { ErrorBoundary, useErrorState } from "./ErrorContextProvider";
-import { useProject } from "./ProjectContextProvider";
 
 interface IntegrationListContextValue {
   integrations: Integration[] | null;
@@ -36,7 +36,7 @@ type IntegrationListContextProviderProps = {
 export function IntegrationListProvider({
   children,
 }: IntegrationListContextProviderProps) {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { setError, removeError } = useErrorState();
   const { data: integrations, isLoading, isError } = useListIntegrationsQuery();
 

--- a/src/headless/installation/useCreateInstallation.ts
+++ b/src/headless/installation/useCreateInstallation.ts
@@ -3,7 +3,7 @@ import {
   Installation,
 } from "@generated/api/src";
 import { useQueryClient } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useCreateInstallationMutation } from "src/hooks/mutation/useCreateInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
 
@@ -24,7 +24,7 @@ import { useInstallation } from "./useInstallation";
  *   - `errorMsg` (string | null): The error message, if any.
  */
 export function useCreateInstallation() {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { groupRef, integrationNameOrId } = useInstallationProps();
   const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
   const { connection } = useConnection();

--- a/src/headless/installation/useDeleteInstallation.ts
+++ b/src/headless/installation/useDeleteInstallation.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useDeleteInstallationMutation } from "src/hooks/mutation/useDeleteInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
 
@@ -17,7 +17,7 @@ import { useInstallation } from "./useInstallation";
  *   - `errorMsg` (string | null): The error message, if any.
  */
 export function useDeleteInstallation() {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { integrationNameOrId } = useInstallationProps();
   const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
   const { installation } = useInstallation();

--- a/src/headless/installation/useUpdateInstallation.ts
+++ b/src/headless/installation/useUpdateInstallation.ts
@@ -3,7 +3,7 @@ import {
   UpdateInstallationOperationRequest,
 } from "@generated/api/src";
 import { useQueryClient } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useUpdateInstallationMutation } from "src/hooks/mutation/useUpdateInstallationMutation";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
 
@@ -23,7 +23,7 @@ import { useInstallation } from "./useInstallation";
  *   - `errorMsg` (string | null): The error message, if any.
  */
 export function useUpdateInstallation() {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { integrationNameOrId } = useInstallationProps();
   const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
   const { installation } = useInstallation();

--- a/src/headless/manifest/useHydratedRevisionQuery.ts
+++ b/src/headless/manifest/useHydratedRevisionQuery.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useIntegrationQuery } from "src/hooks/query/useIntegrationQuery";
 import { useAPI } from "src/services/api";
 
@@ -20,7 +20,7 @@ export const useHydratedRevisionQuery = () => {
     isPending: isConnectionsPending,
     isFetching: isConnectionsFetching,
   } = useConnection();
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const { integrationNameOrId } = useInstallationProps();
   const { data: integrationObj } = useIntegrationQuery(integrationNameOrId);
 

--- a/src/hooks/query/useConnectionQuery.ts
+++ b/src/hooks/query/useConnectionQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useAPI } from "src/services/api";
 
 type ConnectionQueryProps = {
@@ -8,7 +8,7 @@ type ConnectionQueryProps = {
 
 export const useConnectionQuery = ({ connectionId }: ConnectionQueryProps) => {
   const getAPI = useAPI();
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
 
   return useQuery({
     queryKey: ["connection", connectionId, projectIdOrName],

--- a/src/hooks/query/useConnectionsListQuery.ts
+++ b/src/hooks/query/useConnectionsListQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useAPI } from "src/services/api";
 
 type ConnectionsListQueryProps = {
@@ -11,7 +11,7 @@ export const useConnectionsListQuery = ({
   groupRef,
   provider,
 }: ConnectionsListQueryProps) => {
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
 
   const getAPI = useAPI();
   return useQuery({

--- a/src/hooks/query/useIntegrationListQuery.ts
+++ b/src/hooks/query/useIntegrationListQuery.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useAPI } from "src/services/api";
 
 export function useListIntegrationsQuery() {
   const getAPI = useAPI();
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
 
   return useQuery({
     queryKey: ["amp", "integrations", projectIdOrName],

--- a/src/hooks/query/useListInstallationsQuery.ts
+++ b/src/hooks/query/useListInstallationsQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useProject } from "context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useIntegrationList } from "src/context/IntegrationListContextProvider";
 import { useAPI } from "src/services/api";
 
@@ -8,7 +8,7 @@ export const useListInstallationsQuery = (
   groupRef?: string,
 ) => {
   const getAPI = useAPI();
-  const { projectIdOrName } = useProject(); // in AmpersandProvider
+  const { projectIdOrName } = useAmpersandProviderProps(); // in AmpersandProvider
   const { integrations } = useIntegrationList(); // in AmpersandProvider
 
   const integrationId = integrations?.find(

--- a/src/hooks/query/useListProviderAppsQuery.ts
+++ b/src/hooks/query/useListProviderAppsQuery.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { useProject } from "context/ProjectContextProvider";
 import { useAPI } from "services/api";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 
 export const useListProviderAppsQuery = () => {
   const getAPI = useAPI();
-  const { projectIdOrName } = useProject();
+  const { projectIdOrName } = useAmpersandProviderProps();
 
   return useQuery({
     queryKey: ["amp", "providerApps", projectIdOrName],


### PR DESCRIPTION
### Summary
We need to refactor the projectProvider since AmpersandProvider will no longer be able to make an API call without a groupRef/consumerRef

- adds AmpersandProvider to share props (options and projectIdOrName)
- refactor instances of projectId or projectIdOrName to use the hook `useAmpersandProviderProps`

#### note
refactor in progress for ProjectProvider
**1. add props provider to AmpersandProvider (this pr)
2. refactor basic uses of projectId (this PR)**
3. refactor uses of Project, isProjectLoading, appName (to use projectListQuery)
4. remove ProjectProvider from AmpersandProvider
5. do steps 1 - 4 with IntegrationList provider 

#### Testing 
No visual changes in app expected for InstallIntegration, ConnectProvider, or headless