### PR TITLE
[ENG-2419] refactor: useProjectQuery hook

### DIFF
--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -106,7 +106,7 @@ export function InstallIntegration({
     return <ComponentContainerLoading />;
   }
 
-  if (projectIdOrName && isError(ErrorBoundary.PROJECT, projectIdOrName)) {
+  if (isError(ErrorBoundary.PROJECT, projectIdOrName)) {
     // set in ProjectContextProvider (AmpersandProvider)
     return (
       <ComponentContainerError
@@ -116,10 +116,7 @@ export function InstallIntegration({
   }
 
   // set in IntegrationListContextProvider (AmpersandProvider)
-  if (
-    projectIdOrName &&
-    isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
-  ) {
+  if (isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)) {
     return (
       <ComponentContainerError message="Error retrieving integrations for the project, double check the API key" />
     );

--- a/src/components/Configure/InstallIntegration.tsx
+++ b/src/components/Configure/InstallIntegration.tsx
@@ -1,9 +1,9 @@
 import { ConnectionsProvider } from "context/ConnectionsContextProvider";
 import { ErrorBoundary, useErrorState } from "context/ErrorContextProvider";
 import { InstallIntegrationProvider } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import { useProject } from "context/ProjectContextProvider";
 import { Config } from "services/api";
 import { useIntegrationList } from "src/context/IntegrationListContextProvider";
+import { useProjectQuery } from "src/hooks/query";
 import { useForceUpdate } from "src/hooks/useForceUpdate";
 
 import {
@@ -97,7 +97,7 @@ export function InstallIntegration({
   onUninstallSuccess,
   fieldMapping,
 }: InstallIntegrationProps) {
-  const { projectIdOrName, isLoading: isProjectLoading } = useProject();
+  const { projectIdOrName, isLoading: isProjectLoading } = useProjectQuery();
   const { isLoading: isIntegrationListLoading } = useIntegrationList();
   const { isError, errorState } = useErrorState();
   const { seed, reset } = useForceUpdate();
@@ -106,7 +106,7 @@ export function InstallIntegration({
     return <ComponentContainerLoading />;
   }
 
-  if (isError(ErrorBoundary.PROJECT, projectIdOrName)) {
+  if (projectIdOrName && isError(ErrorBoundary.PROJECT, projectIdOrName)) {
     // set in ProjectContextProvider (AmpersandProvider)
     return (
       <ComponentContainerError
@@ -116,7 +116,10 @@ export function InstallIntegration({
   }
 
   // set in IntegrationListContextProvider (AmpersandProvider)
-  if (isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)) {
+  if (
+    projectIdOrName &&
+    isError(ErrorBoundary.INTEGRATION_LIST, projectIdOrName)
+  ) {
     return (
       <ComponentContainerError message="Error retrieving integrations for the project, double check the API key" />
     );

--- a/src/components/Configure/content/fields/ObjectMapping.tsx
+++ b/src/components/Configure/content/fields/ObjectMapping.tsx
@@ -1,5 +1,5 @@
 import { FormCalloutBox } from "src/components/FormCalloutBox";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useProjectQuery } from "src/hooks/query";
 import { useProvider } from "src/hooks/useProvider";
 import { capitalize } from "src/utils";
 
@@ -11,7 +11,7 @@ import { useSelectedConfigureState } from "../useSelectedConfigureState";
  * @returns
  */
 export function ReadObjectMapping() {
-  const { project } = useProject();
+  const { data: project } = useProjectQuery();
   const { hydratedRevision } = useHydratedRevision();
   const { selectedObjectName } = useSelectedConfigureState();
 

--- a/src/components/Configure/content/fields/RequiredFields.tsx
+++ b/src/components/Configure/content/fields/RequiredFields.tsx
@@ -1,4 +1,4 @@
-import { useProject } from "context/ProjectContextProvider";
+import { useProjectQuery } from "src/hooks/query";
 
 import { Tag } from "components/ui-base/Tag";
 
@@ -9,7 +9,7 @@ import { FieldHeader } from "./FieldHeader";
 
 export function RequiredFields() {
   const { configureState } = useSelectedConfigureState();
-  const { appName } = useProject();
+  const { appName } = useProjectQuery();
 
   return (
     <>

--- a/src/components/Configure/content/useSelectedConfigureState.tsx
+++ b/src/components/Configure/content/useSelectedConfigureState.tsx
@@ -1,4 +1,4 @@
-import { useProject } from "context/ProjectContextProvider";
+import { useProjectQuery } from "src/hooks/query";
 
 import { useSelectedObjectName } from "../nav/ObjectManagementNav/ObjectManagementNavContext";
 import { useObjectsConfigureState } from "../state/ConfigurationStateProvider";
@@ -9,7 +9,7 @@ import { getConfigureState } from "../state/utils";
  * @returns {object} configureState for the selected object in nav
  */
 export const useSelectedConfigureState = () => {
-  const { appName } = useProject();
+  const { appName } = useProjectQuery();
   const { objectConfigurationsState, setConfigureState } =
     useObjectsConfigureState();
   const { selectedObjectName } = useSelectedObjectName();

--- a/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/index.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import { useProject } from "context/ProjectContextProvider";
 import { VerticalTabs } from "src/components/Configure/nav/ObjectManagementNav/v2/Tabs";
 import { NavObject } from "src/components/Configure/types";
+import { useProjectQuery } from "src/hooks/query";
 import { useProvider } from "src/hooks/useProvider";
 import { AmpersandFooter } from "src/layout/AuthCardLayout/AmpersandFooter";
 
@@ -37,7 +37,7 @@ type ObjectManagementNavProps = {
 
 // note: when the object key exists in the config; the user has already completed the object before
 export function ObjectManagementNavV2({ children }: ObjectManagementNavProps) {
-  const { project } = useProject();
+  const { data: project } = useProjectQuery();
   const { installation } = useInstallIntegrationProps();
   const { providerName } = useProvider();
   const { hydratedRevision } = useHydratedRevision();

--- a/src/components/Connect/ConnectedSuccessBox.tsx
+++ b/src/components/Connect/ConnectedSuccessBox.tsx
@@ -1,4 +1,4 @@
-import { useProject } from "context/ProjectContextProvider";
+import { useProjectQuery } from "src/hooks/query";
 import { useProvider } from "src/hooks/useProvider";
 import { Connection } from "src/services/api";
 
@@ -16,7 +16,7 @@ export function ConnectedSuccessBox({
   onDisconnectSuccess,
   resetComponent,
 }: ConnectedSuccessBoxProps) {
-  const { appName } = useProject();
+  const { appName } = useProjectQuery();
   const { providerName } = useProvider(provider);
 
   const text = `You have successfully connected your ${providerName} account to ${appName}.`;

--- a/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/NoWorkspaceOauthFlow2/NoWorkspaceOauthFlow2.tsx
@@ -4,8 +4,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useProject } from "src/context/ProjectContextProvider";
 import { useCreateOauthConnectionMutation } from "src/hooks/mutation/useCreateOauthConnectionMutation";
+import { useProjectQuery } from "src/hooks/query";
 import { useConnectionsListQuery } from "src/hooks/query/useConnectionsListQuery";
 import { AMP_SERVER } from "src/services/api";
 
@@ -45,7 +45,7 @@ export function NoWorkspaceOauthFlow2({
   groupName,
   providerName,
 }: NoWorkspaceOauthFlowProps) {
-  const { projectId } = useProject();
+  const { projectId } = useProjectQuery();
   const queryClient = useQueryClient();
   const popupRef = useRef<Window | null>(null);
 
@@ -105,7 +105,7 @@ export function NoWorkspaceOauthFlow2({
           provider,
           consumerRef,
           groupRef,
-          projectId,
+          projectId: projectId || "", // todo - update to use projectIdOrName
           consumerName,
           groupName,
         },

--- a/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
@@ -9,8 +9,8 @@ import {
   isProviderMetadataValid,
   ProviderMetadata,
 } from "src/components/auth/providerMetadata";
-import { useProject } from "src/context/ProjectContextProvider";
 import { useCreateOauthConnectionMutation } from "src/hooks/mutation/useCreateOauthConnectionMutation";
+import { useProjectQuery } from "src/hooks/query";
 import { useConnectionsListQuery } from "src/hooks/query/useConnectionsListQuery";
 import { useProviderInfoQuery } from "src/hooks/useProvider";
 import { AMP_SERVER } from "src/services/api";
@@ -56,7 +56,7 @@ export function OauthFlow2({
   groupName,
   providerName,
 }: OauthFlowProps) {
-  const { projectId } = useProject();
+  const { projectId } = useProjectQuery();
   const queryClient = useQueryClient();
   const popupRef = useRef<Window | null>(null);
 
@@ -148,7 +148,7 @@ export function OauthFlow2({
           provider,
           consumerRef,
           groupRef,
-          projectId,
+          projectId: projectId || "", // todo - update to use projectIdOrName
           consumerName,
           groupName,
           providerWorkspaceRef:

--- a/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
+++ b/src/components/auth/Oauth/AuthorizationCode/useOAuthPopupURL.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { OauthConnectRequest, ProviderApp } from "@generated/api/src";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useProjectQuery } from "src/hooks/query";
 import {
   useListProviderAppsQuery,
   useOauthConnectQuery,
@@ -22,7 +22,7 @@ export const useOAuthPopupURL = (
   workspace?: string,
   providerMetadata?: ProviderMetadata,
 ) => {
-  const { projectId } = useProject();
+  const { projectId } = useProjectQuery();
   const {
     data: provInfo,
     isLoading: isProvInfoLoading,
@@ -39,7 +39,7 @@ export const useOAuthPopupURL = (
 
   const request: OauthConnectRequest = {
     providerWorkspaceRef: workspace || providerMetadata?.workspace?.value,
-    projectId,
+    projectId: projectId || "", // todo - update to use projectIdOrName
     groupRef,
     groupName,
     consumerRef,

--- a/src/context/ProjectContextProvider.tsx
+++ b/src/context/ProjectContextProvider.tsx
@@ -1,21 +1,9 @@
 import { createContext, useContext, useEffect, useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Project, useAPI } from "services/api";
+import { Project } from "services/api";
+
+import { useProjectQuery } from "../hooks/query";
 
 import { ErrorBoundary, useErrorState } from "./ErrorContextProvider";
-
-// use react query hook
-const useProjectQuery = (projectIdOrName: string) => {
-  const getAPI = useAPI();
-
-  return useQuery({
-    queryKey: ["project", projectIdOrName],
-    queryFn: async () => {
-      const api = await getAPI();
-      return api.projectApi.getProject({ projectIdOrName });
-    },
-  });
-};
 
 interface ProjectContextValue {
   project: Project | null;
@@ -53,11 +41,7 @@ export function ProjectProvider({
   children,
 }: ProjectProviderProps) {
   const { setError } = useErrorState();
-  const {
-    data: project,
-    isLoading,
-    isError,
-  } = useProjectQuery(projectIdOrName);
+  const { data: project, isLoading, isError } = useProjectQuery();
 
   useEffect(() => {
     if (isError) setError(ErrorBoundary.PROJECT, projectIdOrName);

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -4,6 +4,7 @@ import { useListIntegrationsQuery } from "./useIntegrationListQuery";
 import { useListInstallationsQuery } from "./useListInstallationsQuery";
 import { useListProviderAppsQuery } from "./useListProviderAppsQuery";
 import { useOauthConnectQuery } from "./useOauthConnectQuery";
+import { useProjectQuery } from "./useProjectQuery";
 
 export {
   useConnectionQuery,
@@ -12,4 +13,5 @@ export {
   useListInstallationsQuery,
   useListProviderAppsQuery,
   useOauthConnectQuery,
+  useProjectQuery,
 };

--- a/src/hooks/query/useProjectQuery.ts
+++ b/src/hooks/query/useProjectQuery.ts
@@ -2,7 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 import { useAPI } from "services/api";
 import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider/AmpersandContextProvider";
 
-// use react query hook
+/**
+ * Custom hook to fetch project data using React Query.
+ * 
+ * This hook retrieves project information based on the `projectIdOrName` provided
+ * by the Ampersand context. It uses the `getProject` method from the API service
+ * to fetch the data and returns an enhanced query object with additional properties
+ * such as `appName` and `projectId`.
+ * 
+ * @returns {Object} An object containing:
+ *   - All properties from the React Query result (`data`, `error`, `isLoading`, etc.).
+ *   - `projectIdOrName`: The identifier for the project.
+ *   - `appName`: The name of the project (if available).
+ *   - `projectId`: The ID of the project (if available).
+ */
 const useProjectQuery = () => {
   const getAPI = useAPI();
   const { projectIdOrName } = useAmpersandProviderProps();

--- a/src/hooks/query/useProjectQuery.ts
+++ b/src/hooks/query/useProjectQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAPI } from "services/api";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider/AmpersandContextProvider";
+
+// use react query hook
+const useProjectQuery = () => {
+  const getAPI = useAPI();
+  const { projectIdOrName } = useAmpersandProviderProps();
+
+  const query = useQuery({
+    queryKey: ["project", projectIdOrName],
+    queryFn: async () => {
+      const api = await getAPI();
+      return api.projectApi.getProject({ projectIdOrName });
+    },
+  });
+
+  return {
+    ...query,
+    projectIdOrName,
+    appName: query.data?.name,
+    projectId: query.data?.id,
+  };
+};
+
+export { useProjectQuery };

--- a/src/hooks/query/useProjectWithEntitlementsQuery.ts
+++ b/src/hooks/query/useProjectWithEntitlementsQuery.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAPI } from "services/api";
-import { useProject } from "src/context/ProjectContextProvider";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider/AmpersandContextProvider";
 
 /**
  * Query to get the project with entitlements
@@ -9,8 +9,7 @@ import { useProject } from "src/context/ProjectContextProvider";
  * @returns
  */
 export const useProjectWithEntitlementsQuery = () => {
-  const { project } = useProject();
-  const projectIdOrName = project?.id;
+  const { projectIdOrName } = useAmpersandProviderProps();
   const getAPI = useAPI();
 
   return useQuery({


### PR DESCRIPTION
### Summary 
Part 2 - We need to refactor the projectProvider since AmpersandProvider will no longer be able to make an API call without a groupRef/consumerRef. 

Previously we had calls for projectId go to useAmpersandProviderProps(). For instances needing appName, project (object), and other react query data, we make calls to useProjectQuery.
- replace useProject with useProjectQuery

#### note
refactor in progress for ProjectProvider
part 1: https://github.com/amp-labs/react/pull/1224

~~1. add props provider to AmpersandProvider~~
~~2. refactor basic uses of projectId~~
**3. refactor uses of Project, isProjectLoading, appName (to use projectListQuery)**
4. remove ProjectProvider from AmpersandProvider
5. do steps 1 - 4 with IntegrationList provider 

#### Testing 
No visual changes in app expected for InstallIntegration, ConnectProvider, or headless


