### PR TITLE
[ENG-2476] feat: checkbox search

### DIFF
--- a/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
+++ b/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
@@ -24,21 +24,6 @@ export function OptionalFieldsV2() {
     }
   };
 
-  const onSelectAllCheckboxChange = (checked: boolean) => {
-    if (selectedObjectName && readOptionalFields) {
-      readOptionalFields.forEach((field) => {
-        if (!isIntegrationFieldMapping(field)) {
-          setOptionalField(
-            selectedObjectName,
-            setConfigureState,
-            field.fieldName,
-            checked,
-          );
-        }
-      });
-    }
-  };
-
   const checkboxItems = useMemo<CheckboxItem[]>(
     () =>
       // optional fields should all be pre-defined
@@ -59,11 +44,6 @@ export function OptionalFieldsV2() {
   );
 
   const shouldRender = !!(readOptionalFields && readOptionalFields.length > 0);
-  const isAllChecked = checkboxItems.every(
-    (item) => selectedOptionalFields?.[item.id] === true,
-  );
-  const isIndeterminate =
-    !isAllChecked && Object.keys(selectedOptionalFields || {}).length > 0;
 
   return (
     shouldRender && (
@@ -76,9 +56,6 @@ export function OptionalFieldsV2() {
           key={`${selectedObjectName}-${readOptionalFields?.length}`}
           items={checkboxItems}
           onItemChange={onCheckboxChange}
-          onSelectAllChange={onSelectAllCheckboxChange}
-          isAllChecked={isAllChecked}
-          isIndeterminate={isIndeterminate}
           showSelectAll={checkboxItems.length >= 2}
         />
       </>

--- a/src/components/Configure/content/fields/WriteFields/WriteFieldsV2.tsx
+++ b/src/components/Configure/content/fields/WriteFields/WriteFieldsV2.tsx
@@ -25,25 +25,7 @@ export function WriteFieldsV2() {
     }
   };
 
-  const onSelectAllChange = (checked: boolean) => {
-    if (selectedObjectName && configureState) {
-      configureState?.write?.writeObjects?.forEach((field) => {
-        setNonConfigurableWriteField(
-          selectedObjectName,
-          setConfigureState,
-          field.objectName,
-          checked,
-        );
-      });
-    }
-  };
-
   const shouldRender = !!writeObjects;
-  const isAllChecked =
-    Object.keys(selectedWriteFields || {}).length ===
-    configureState?.write?.writeObjects?.length;
-  const isIndeterminate =
-    !isAllChecked && Object.keys(selectedWriteFields || {}).length > 0;
 
   const checkboxItems: CheckboxItem[] =
     writeObjects?.map((field) => ({
@@ -59,9 +41,6 @@ export function WriteFieldsV2() {
         <CheckboxPagination
           items={checkboxItems}
           onItemChange={onItemChange}
-          onSelectAllChange={onSelectAllChange}
-          isAllChecked={isAllChecked}
-          isIndeterminate={isIndeterminate}
           showSelectAll={writeObjects.length >= 2}
         />
       </>

--- a/src/components/ui-base/Checkbox/CheckboxPagination.tsx
+++ b/src/components/ui-base/Checkbox/CheckboxPagination.tsx
@@ -93,7 +93,7 @@ export function CheckboxPagination({
         <SelectAllCheckbox
           id="select-all-fields"
           isChecked={areAllFilteredItemsChecked}
-          label={`Select all ${filteredItems.length} fields`}
+          label={`Select all ${filteredItems.length} ${searchTerm ? 'matching ' : ''}fields`}
           onCheckedChange={handleSelectAllChange}
           isIndeterminate={
             areSomeFilteredItemsChecked && !areAllFilteredItemsChecked

--- a/src/components/ui-base/Checkbox/CheckboxPagination.tsx
+++ b/src/components/ui-base/Checkbox/CheckboxPagination.tsx
@@ -21,9 +21,6 @@ export interface CheckboxItem {
 interface CheckboxPaginationProps {
   items: CheckboxItem[];
   onItemChange: (id: string, checked: boolean) => void;
-  onSelectAllChange: (checked: boolean) => void;
-  isAllChecked?: boolean;
-  isIndeterminate?: boolean;
   itemsPerPage?: number;
   showSelectAll?: boolean;
   showSearch?: boolean;
@@ -33,9 +30,6 @@ interface CheckboxPaginationProps {
 export function CheckboxPagination({
   items,
   onItemChange,
-  onSelectAllChange,
-  isAllChecked = false,
-  isIndeterminate = false,
   itemsPerPage = 8,
   showSelectAll = true,
   showSearch = true,
@@ -60,6 +54,23 @@ export function CheckboxPagination({
     setSearchTerm(value);
     setCurrentPage(1);
   };
+
+  // Handle select all for filtered items only
+  const handleSelectAllChange = (checked: boolean) => {
+    // Only change the checked state of filtered items
+    filteredItems.forEach((item) => {
+      onItemChange(item.id, checked);
+    });
+  };
+
+  // Calculate if all filtered items are checked
+  const areAllFilteredItemsChecked =
+    filteredItems.length > 0 && filteredItems.every((item) => item.isChecked);
+
+  // Calculate if some filtered items are checked (for indeterminate state)
+  const areSomeFilteredItemsChecked = filteredItems.some(
+    (item) => item.isChecked,
+  );
 
   return (
     <CheckboxGroup>
@@ -107,10 +118,12 @@ export function CheckboxPagination({
       {showSelectAll && filteredItems.length >= 2 && (
         <SelectAllCheckbox
           id="select-all-fields"
-          isChecked={isAllChecked}
+          isChecked={areAllFilteredItemsChecked}
           label={`Select all ${filteredItems.length} fields`}
-          onCheckedChange={onSelectAllChange}
-          isIndeterminate={isIndeterminate}
+          onCheckedChange={handleSelectAllChange}
+          isIndeterminate={
+            areSomeFilteredItemsChecked && !areAllFilteredItemsChecked
+          }
         />
       )}
 

--- a/src/components/ui-base/Checkbox/CheckboxPagination.tsx
+++ b/src/components/ui-base/Checkbox/CheckboxPagination.tsx
@@ -89,7 +89,7 @@ export function CheckboxPagination({
         </div>
       )}
 
-      {showSelectAll && filteredItems.length >= 2 && (
+      {showSelectAll && items.length >= 2 && (
         <SelectAllCheckbox
           id="select-all-fields"
           isChecked={areAllFilteredItemsChecked}

--- a/src/components/ui-base/Checkbox/CheckboxPagination.tsx
+++ b/src/components/ui-base/Checkbox/CheckboxPagination.tsx
@@ -89,32 +89,6 @@ export function CheckboxPagination({
         </div>
       )}
 
-      {totalPages > 1 && (
-        <div className={styles.paginationContainer}>
-          <Button
-            type="button"
-            onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
-            disabled={currentPage === 1}
-            variant="ghost"
-          >
-            &lt;
-          </Button>
-          <span className={styles.pageInfo}>
-            {currentPage} of {totalPages}
-          </span>
-          <Button
-            type="button"
-            onClick={() =>
-              setCurrentPage((prev) => Math.min(totalPages, prev + 1))
-            }
-            disabled={currentPage === totalPages}
-            variant="ghost"
-          >
-            &gt;
-          </Button>
-        </div>
-      )}
-
       {showSelectAll && filteredItems.length >= 2 && (
         <SelectAllCheckbox
           id="select-all-fields"
@@ -140,6 +114,32 @@ export function CheckboxPagination({
           />
         ))}
       </CheckboxFieldsContainer>
+
+      {totalPages > 1 && (
+        <div className={styles.paginationContainer}>
+          <Button
+            type="button"
+            onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+            disabled={currentPage === 1}
+            variant="ghost"
+          >
+            &lt;
+          </Button>
+          <span className={styles.pageInfo}>
+            {currentPage} of {totalPages}
+          </span>
+          <Button
+            type="button"
+            onClick={() =>
+              setCurrentPage((prev) => Math.min(totalPages, prev + 1))
+            }
+            disabled={currentPage === totalPages}
+            variant="ghost"
+          >
+            &gt;
+          </Button>
+        </div>
+      )}
 
       {filteredItems.length === 0 && searchTerm && (
         <div className={styles.noResults}>

--- a/src/components/ui-base/Checkbox/CheckboxPagination.tsx
+++ b/src/components/ui-base/Checkbox/CheckboxPagination.tsx
@@ -89,11 +89,15 @@ export function CheckboxPagination({
         </div>
       )}
 
+      {/* Select all checkbox */}
+      {/* // Render the "Select all" checkbox, which allows users to select or deselect all currently filtered items.
+      // This checkbox appears only if the `showSelectAll` prop is true and there are at least 2 items.
+      // The checked and indeterminate states reflect the selection state of the filtered items. */}
       {showSelectAll && items.length >= 2 && (
         <SelectAllCheckbox
           id="select-all-fields"
           isChecked={areAllFilteredItemsChecked}
-          label={`Select all ${filteredItems.length} ${searchTerm ? 'matching ' : ''}fields`}
+          label={`Select all ${filteredItems.length} ${searchTerm ? "matching " : ""}fields`}
           onCheckedChange={handleSelectAllChange}
           isIndeterminate={
             areSomeFilteredItemsChecked && !areAllFilteredItemsChecked

--- a/src/components/ui-base/Checkbox/CheckboxPagination.tsx
+++ b/src/components/ui-base/Checkbox/CheckboxPagination.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { Input } from "components/form/Input";
 import { Button } from "components/ui-base/Button";
 
 import {
@@ -25,6 +26,8 @@ interface CheckboxPaginationProps {
   isIndeterminate?: boolean;
   itemsPerPage?: number;
   showSelectAll?: boolean;
+  showSearch?: boolean;
+  searchPlaceholder?: string;
 }
 
 export function CheckboxPagination({
@@ -35,17 +38,46 @@ export function CheckboxPagination({
   isIndeterminate = false,
   itemsPerPage = 8,
   showSelectAll = true,
+  showSearch = true,
+  searchPlaceholder = "Search fields...",
 }: CheckboxPaginationProps) {
   const [currentPage, setCurrentPage] = useState(1);
+  const [searchTerm, setSearchTerm] = useState("");
 
-  // Calculate pagination
-  const totalPages = Math.ceil(items.length / itemsPerPage);
+  // Filter items based on search term
+  const filteredItems = items.filter((item) =>
+    item.label.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  // Calculate pagination for filtered items
+  const totalPages = Math.ceil(filteredItems.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
-  const currentPageItems = items.slice(startIndex, endIndex);
+  const currentPageItems = filteredItems.slice(startIndex, endIndex);
+
+  // Reset to first page when search term changes
+  const handleSearchChange = (value: string) => {
+    setSearchTerm(value);
+    setCurrentPage(1);
+  };
 
   return (
     <CheckboxGroup>
+      {showSearch && (
+        <div className={styles.searchContainer}>
+          <Input
+            id="field-search"
+            type="text"
+            placeholder={searchPlaceholder}
+            value={searchTerm}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleSearchChange(e.target.value)
+            }
+            className={styles.searchInput}
+          />
+        </div>
+      )}
+
       {totalPages > 1 && (
         <div className={styles.paginationContainer}>
           <Button
@@ -71,11 +103,12 @@ export function CheckboxPagination({
           </Button>
         </div>
       )}
-      {showSelectAll && items.length >= 2 && (
+
+      {showSelectAll && filteredItems.length >= 2 && (
         <SelectAllCheckbox
           id="select-all-fields"
           isChecked={isAllChecked}
-          label={`Select all ${items.length} fields`}
+          label={`Select all ${filteredItems.length} fields`}
           onCheckedChange={onSelectAllChange}
           isIndeterminate={isIndeterminate}
         />
@@ -94,6 +127,12 @@ export function CheckboxPagination({
           />
         ))}
       </CheckboxFieldsContainer>
+
+      {filteredItems.length === 0 && searchTerm && (
+        <div className={styles.noResults}>
+          No fields found matching &quot;{searchTerm}&quot;
+        </div>
+      )}
     </CheckboxGroup>
   );
 }

--- a/src/components/ui-base/Checkbox/checkboxPagination.module.css
+++ b/src/components/ui-base/Checkbox/checkboxPagination.module.css
@@ -8,4 +8,19 @@
   display: flex;
   align-items: center;
   color: var(--amp-colors-text-muted);
+}
+
+.searchContainer {
+  padding: 0.5rem;
+}
+
+.searchInput {
+  width: 100%;
+}
+
+.noResults {
+  text-align: center;
+  padding: 1rem;
+  color: var(--amp-colors-text-muted);
+  font-style: italic;
 } 


### PR DESCRIPTION
### Summary
checkbox components are paginated, but with hundreds of fields a searching ux is need. This PR adds the search functionality to the paginated checkbox component and refactors optional fields and write to use the new search ux.
- pagination moved down since less likely to be used with search
- filter applies to groups of fields 
- note the buttons moving to the bottom still makes the ux clucky to navigate to next page since the page length changes. should be less of a concern with search being instructed by builders to find specific fields.

#### demo
![search-checkbox-ux](https://github.com/user-attachments/assets/58b86fde-0d24-4a1f-869c-3b87a7718b9f)
