### PR TITLE
build: update types to be an object

### DIFF
--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -29,7 +29,13 @@ interface AmpersandProviderProps {
      * Callback function to get a JWT token for authorization.
      * This function should return a Promise that resolves to a JWT token string.
      */
-    getToken?: (consumerRef: string, groupRef: string) => Promise<string>;
+    getToken?: ({
+      consumerRef,
+      groupRef,
+    }: {
+      consumerRef: string;
+      groupRef: string;
+    }) => Promise<string>;
   };
   children: React.ReactNode;
 }

--- a/src/context/JwtTokenContextProvider.tsx
+++ b/src/context/JwtTokenContextProvider.tsx
@@ -23,14 +23,26 @@ const getSessionStorageKey = (cacheKey: string) =>
   `${SESSION_STORAGE_PREFIX}${cacheKey}`;
 
 interface JwtTokenContextValue {
-  getToken?: (consumerRef: string, groupRef: string) => Promise<string>;
+  getToken?: ({
+    consumerRef,
+    groupRef,
+  }: {
+    consumerRef: string;
+    groupRef: string;
+  }) => Promise<string>;
 }
 
 const JwtTokenContext = createContext<JwtTokenContextValue | null>(null);
 
 interface JwtTokenProviderProps {
   getTokenCallback:
-    | ((consumerRef: string, groupRef: string) => Promise<string>)
+    | (({
+        consumerRef,
+        groupRef,
+      }: {
+        consumerRef: string;
+        groupRef: string;
+      }) => Promise<string>)
     | null;
   children: React.ReactNode;
 }
@@ -169,7 +181,13 @@ export function JwtTokenProvider({
   );
 
   const getToken = useCallback(
-    async (consumerRef: string, groupRef: string): Promise<string> => {
+    async ({
+      consumerRef,
+      groupRef,
+    }: {
+      consumerRef: string;
+      groupRef: string;
+    }): Promise<string> => {
       // Check all caches first
       const cachedToken = getCachedToken(consumerRef, groupRef);
       if (cachedToken) {
@@ -182,7 +200,7 @@ export function JwtTokenProvider({
       }
 
       try {
-        const token = await getTokenCallback(consumerRef, groupRef);
+        const token = await getTokenCallback({ consumerRef, groupRef });
         await setCachedToken(consumerRef, groupRef, token);
         return token;
       } catch (error) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -182,7 +182,7 @@ export function useAPI(): () => Promise<ApiService> {
           "Unable to create JWT API service without consumerRef or groupRef.",
         );
       }
-      const token = await getToken(consumerRef, groupRef);
+      const token = await getToken({ consumerRef, groupRef });
       const auth = createJwtAuth(token);
       const configWithAuth = createAuthConfig(auth.header, auth.value);
       return new ApiService(configWithAuth);


### PR DESCRIPTION
### Summary 
changes getToken types to be less likely to mix up.
- getToken: ({consumerRef, groupRef}) => Promise<string>

### Mailmonkey

<img width="727" height="686" alt="Screenshot 2025-08-13 at 11 23 34 AM" src="https://github.com/user-attachments/assets/001d9ff0-3f18-4e01-8958-2d234d61c746" />

