### PR TITLE
refactor: create installation to use headless installation hooks

### DIFF
--- a/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
+++ b/src/components/Configure/actions/read/onSaveReadCreateInstallation.ts
@@ -43,7 +43,7 @@ const getObjectFromHydratedRevision = (
  * @param consumerRef
  * @returns
  */
-const generateCreateReadConfigFromConfigureState = (
+export const generateCreateReadConfigFromConfigureState = (
   configureState: ConfigureState,
   objectName: string,
   hydratedRevision: HydratedRevision,


### PR DESCRIPTION
### Summary
Migrates old create read installation to use headless installation hooks. 

JWT requires full migration away from using a legacy passed around api key. A few things need to happen: 
- migrate to unified API service (no need api key), also support JWT
- remove old set state actions (implemented before react-query)
- simplify create installation flow

This PR does replaces legacy implementation by using the createInstallation headless hook; we do not fully migrate to the config manager which is much a larger change. We use an existing helper function to create the config object which is passed into the headless createInstallation mutation. 

All changes should still render in the existing API key flow. 




