### PR TITLE
fix: revert conditional logic for light/dark logo

### DIFF
--- a/src/layout/AuthCardLayout/AmpersandFooter.tsx
+++ b/src/layout/AuthCardLayout/AmpersandFooter.tsx
@@ -33,22 +33,11 @@ export function AmpersandFooter() {
         aria-label="Go to Ampersand"
         rel="noreferrer noopener"
       >
-        <picture>
-          <source
-            srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg"
-            media="(prefers-color-scheme: light)"
-          />
-          <source
-            srcSet="https://res.cloudinary.com/dycvts6vp/image/upload/v1735853540/ampersand_logo_white.svg"
-            media="(prefers-color-scheme: dark)"
-          />
-          {/* Default */}
-          <img
-            style={{ height: ".8em" }}
-            src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg"
-            alt="Ampersand"
-          />
-        </picture>
+      <img
+        style={{ height: ".8em" }}
+        src="https://res.cloudinary.com/dycvts6vp/image/upload/v1723671980/ampersand-logo-black.svg"
+        alt="Ampersand"
+      />
       </a>
     </footer>
   );


### PR DESCRIPTION
Reverts the logic introduced in https://github.com/amp-labs/react/pull/779, since I've seen many cases of it not working (when I've seen screenshots that others have shared). Having a white logo when it's light mode looks pretty awkward since the logo isn't visible. 