### PR TITLE
[auto] Update openapi dependency

### DIFF
--- a/generated-sources/api/src/apis/InstallationApi.ts
+++ b/generated-sources/api/src/apis/InstallationApi.ts
@@ -163,7 +163,7 @@ export interface InstallationApiInterface {
     listInstallationsForProject(requestParameters: ListInstallationsForProjectRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Installation>>;
 
     /**
-     * 
+     * NOTE: Updating an installation with the Subscribe action typically takes 1–2 minutes, but it may take up to 10 minutes to take effect due to delays in the provider’s system. 
      * @summary Update an installation
      * @param {string} projectIdOrName The Ampersand project ID or project name.
      * @param {string} integrationId The integration ID.
@@ -176,6 +176,7 @@ export interface InstallationApiInterface {
     updateInstallationRaw(requestParameters: UpdateInstallationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Installation>>;
 
     /**
+     * NOTE: Updating an installation with the Subscribe action typically takes 1–2 minutes, but it may take up to 10 minutes to take effect due to delays in the provider’s system. 
      * Update an installation
      */
     updateInstallation(requestParameters: UpdateInstallationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Installation>;
@@ -438,6 +439,7 @@ export class InstallationApi extends runtime.BaseAPI implements InstallationApiI
     }
 
     /**
+     * NOTE: Updating an installation with the Subscribe action typically takes 1–2 minutes, but it may take up to 10 minutes to take effect due to delays in the provider’s system. 
      * Update an installation
      */
     async updateInstallationRaw(requestParameters: UpdateInstallationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Installation>> {
@@ -487,6 +489,7 @@ export class InstallationApi extends runtime.BaseAPI implements InstallationApiI
     }
 
     /**
+     * NOTE: Updating an installation with the Subscribe action typically takes 1–2 minutes, but it may take up to 10 minutes to take effect due to delays in the provider’s system. 
      * Update an installation
      */
     async updateInstallation(requestParameters: UpdateInstallationOperationRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Installation> {

--- a/generated-sources/api/src/apis/OrgApi.ts
+++ b/generated-sources/api/src/apis/OrgApi.ts
@@ -49,7 +49,7 @@ export interface CreateOrgOperationRequest {
 
 export interface CreateOrgInviteOperationRequest {
     orgId: string;
-    createOrgInviteRequest?: CreateOrgInviteRequest;
+    invite?: CreateOrgInviteRequest;
 }
 
 export interface DeleteOrgInviteRequest {
@@ -76,7 +76,7 @@ export interface ListOrgInvitesRequest {
 
 export interface UpdateOrgOperationRequest {
     orgId: string;
-    updateOrgRequest: UpdateOrgRequest;
+    orgUpdate: UpdateOrgRequest;
 }
 
 /**
@@ -105,7 +105,7 @@ export interface OrgApiInterface {
      * 
      * @summary Invite a user to an organization
      * @param {string} orgId ID of the organization.
-     * @param {CreateOrgInviteRequest} [createOrgInviteRequest] 
+     * @param {CreateOrgInviteRequest} [invite] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrgApiInterface
@@ -198,7 +198,7 @@ export interface OrgApiInterface {
      * 
      * @summary Update an organization
      * @param {string} orgId ID of the organization.
-     * @param {UpdateOrgRequest} updateOrgRequest 
+     * @param {UpdateOrgRequest} orgUpdate 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrgApiInterface
@@ -293,7 +293,7 @@ export class OrgApi extends runtime.BaseAPI implements OrgApiInterface {
             method: 'POST',
             headers: headerParameters,
             query: queryParameters,
-            body: CreateOrgInviteRequestToJSON(requestParameters.createOrgInviteRequest),
+            body: CreateOrgInviteRequestToJSON(requestParameters.invite),
         }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => InviteFromJSON(jsonValue));
@@ -532,8 +532,8 @@ export class OrgApi extends runtime.BaseAPI implements OrgApiInterface {
             throw new runtime.RequiredError('orgId','Required parameter requestParameters.orgId was null or undefined when calling updateOrg.');
         }
 
-        if (requestParameters.updateOrgRequest === null || requestParameters.updateOrgRequest === undefined) {
-            throw new runtime.RequiredError('updateOrgRequest','Required parameter requestParameters.updateOrgRequest was null or undefined when calling updateOrg.');
+        if (requestParameters.orgUpdate === null || requestParameters.orgUpdate === undefined) {
+            throw new runtime.RequiredError('orgUpdate','Required parameter requestParameters.orgUpdate was null or undefined when calling updateOrg.');
         }
 
         const queryParameters: any = {};
@@ -559,7 +559,7 @@ export class OrgApi extends runtime.BaseAPI implements OrgApiInterface {
             method: 'PATCH',
             headers: headerParameters,
             query: queryParameters,
-            body: UpdateOrgRequestToJSON(requestParameters.updateOrgRequest),
+            body: UpdateOrgRequestToJSON(requestParameters.orgUpdate),
         }, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => OrgFromJSON(jsonValue));


### PR DESCRIPTION
This updates the dependency to version [19ffe4331d7d02f353a21a59e2b3db622344f9f6](https://github.com/amp-labs/openapi/commit/19ffe4331d7d02f353a21a59e2b3db622344f9f6) from [main](https://github.com/amp-labs/openapi/tree/main)