### PR TITLE
[ENG-2581] fix/ux: allow only unique selections in value mappings

### DIFF
--- a/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
@@ -73,10 +73,17 @@ export function ValueMappingItem({
     (item: { value: string } | null) => {
       if (!item) return;
 
-      // check if the value is already mapped to another field
+      // Validate that target values are unique within the same field
+      // This prevents multiple source values from mapping to the same target value
+      // Examples:
+      //   ✅ Valid: red → orange, orange → red (bidirectional mapping allowed)
+      //   ❌ Invalid: red → green, orange → green (duplicate target "green")
+      // Compare against other source fields (keys), not the current target value
+      // This prevents false duplicates when a user selects the same value for the same source field
       if (
-        Object.values(selectedValueMappingForField).some(
-          (mapping) => mapping === item.value && mapping !== fieldValue,
+        Object.entries(selectedValueMappingForField).some(
+          ([key, mapping]) =>
+            mapping === item.value && key !== mappedValue.mappedValue,
         )
       ) {
         // Find all the fields that have the same value that need to shown as
@@ -84,9 +91,8 @@ export function ValueMappingItem({
         const duplicateKeys = [
           ...Object.entries(selectedValueMappingForField)
             .filter(
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              ([_, mapping]) =>
-                mapping === item.value && mapping !== fieldValue,
+              ([key, mapping]) =>
+                mapping === item.value && key !== mappedValue.mappedValue,
             )
             .map(([key]) => key),
           mappedValue.mappedValue,
@@ -114,7 +120,6 @@ export function ValueMappingItem({
     [
       onSelectChange,
       selectedValueMappingForField,
-      fieldValue,
       fieldName,
       mappedValue.mappedValue,
       resetBoundary,

--- a/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
@@ -75,11 +75,6 @@ export function ValueMappingItem({
 
       // Validate that target values are unique within the same field
       // This prevents multiple source values from mapping to the same target value
-      // Examples:
-      //   ✅ Valid: red → orange, orange → red (bidirectional mapping allowed)
-      //   ❌ Invalid: red → green, orange → green (duplicate target "green")
-      // Compare against other source fields (keys), not the current target value
-      // This prevents false duplicates when a user selects the same value for the same source field
       if (
         Object.entries(selectedValueMappingForField).some(
           ([key, mapping]) =>

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -126,6 +126,7 @@ export function ValueMappings() {
   );
 
   // Separate useEffect to check for modifications when selectedMappings changes
+  // update the modified flag when the value mappings are modified
   useEffect(() => {
     if (
       selectedObjectName &&
@@ -150,6 +151,7 @@ export function ValueMappings() {
     configureState?.read?.savedConfig?.selectedValueMappings,
   ]);
 
+  // update the modified flag when the value mappings is initialized
   useEffect(() => {
     if (selectedObjectName && selectedMappings) {
       // Find all fields that have mappedValues

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -180,15 +180,36 @@ export function ValueMappings() {
                   );
                   const hasError =
                     Array.isArray(errors) && errors.includes(value.mappedValue);
-                  const valueOptions =
+
+                  // Get all available options
+                  const allValueOptions =
                     configureState?.read?.allFieldsMetadata?.[field.fieldName!]
                       ?.values || [];
+
+                  // Get currently selected values for this field (excluding current value)
+                  const mappingsForField =
+                    selectedMappings?.[field.fieldName!] || {};
+                  const currentlySelectedValues =
+                    Object.values(mappingsForField).filter(Boolean);
+                  const currentValueSelection =
+                    mappingsForField[value.mappedValue];
+
+                  // Filter options to show: unselected values + current selection (if any)
+                  const availableOptions = allValueOptions.filter(
+                    (option: { value: string }) => {
+                      const isCurrentSelection =
+                        option.value === currentValueSelection;
+                      const isAlreadySelected =
+                        currentlySelectedValues.includes(option.value);
+                      return isCurrentSelection || !isAlreadySelected;
+                    },
+                  );
 
                   return (
                     <>
                       <ValueMappingItem
                         key={`${value.mappedValue}-${field.fieldName}`}
-                        allValueOptions={valueOptions}
+                        allValueOptions={availableOptions}
                         mappedValue={value}
                         onSelectChange={onSelectChange}
                         fieldName={field?.fieldName || ""}

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -18,7 +18,7 @@ import { ValueMappingItem } from "./ValueMappingItem";
  * The value mapping array must be of the same length as the mappedValues array (see documentation for provider)
  * example: Salesforce Clean Status has 8 mapped values, so the value mapping array must be of length 8
  *
- * i.e. to pass into Mailmonkey
+ * i.e. sample input to InstallIntegration
  * const mapping: FieldMapping = {
   "contact": [
     {

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -18,6 +18,51 @@ import { ValueMappingItem } from "./ValueMappingItem";
  * The value mapping array must be of the same length as the mappedValues array (see documentation for provider)
  * example: Salesforce Clean Status has 8 mapped values, so the value mapping array must be of length 8
  *
+ * i.e. to pass into Mailmonkey
+ * const mapping: FieldMapping = {
+  "contact": [
+    {
+      mapToName: "custom_enum",
+      prompt: "Map the values for custom_enum",
+      // 8 mapped values map to 8 values in contact: Clean Status
+      mappedValues: [
+        {
+          mappedValue: "red",
+          mappedDisplayValue: "red"
+        },
+        {
+          mappedValue: "orange",
+          mappedDisplayValue: "orange"
+        },
+        {
+          mappedValue: "blue",
+          mappedDisplayValue: "blue"
+        },
+        {
+          mappedValue: "green",
+          mappedDisplayValue: "green"
+        },
+        {
+          mappedValue: "yellow",
+          mappedDisplayValue: "yellow"
+        },
+        {
+          mappedValue: "purple",
+          mappedDisplayValue: "purple"
+        },
+        {
+          mappedValue: "brown",
+          mappedDisplayValue: "brown"
+        },
+        {
+          mappedValue: "gray",
+          mappedDisplayValue: "gray"
+        },
+      ]
+    }
+  ]
+};
+ * 
  * @returns
  */
 export function ValueMappings() {

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -10,6 +10,16 @@ import { setValueMapping, setValueMappingModified } from "./setValueMapping";
 import { ValueHeader } from "./ValueHeader";
 import { ValueMappingItem } from "./ValueMappingItem";
 
+/**
+ * ValueMappings component displays the value mappings for the selected object
+ * It shows the value mappings for a field mapping that overrides the default value mappings
+ *
+ * implementation detail:
+ * The value mapping array must be of the same length as the mappedValues array (see documentation for provider)
+ * example: Salesforce Clean Status has 8 mapped values, so the value mapping array must be of length 8
+ *
+ * @returns
+ */
 export function ValueMappings() {
   const { fieldMapping } = useInstallIntegrationProps();
   const { selectedObjectName, configureState, setConfigureState } =
@@ -146,7 +156,7 @@ export function ValueMappings() {
         const fieldNameValues = fieldNameObject?.values;
         if (!fieldNameValues) return null;
 
-        // Show if the values array is of the same length as the mappedValues array
+        // special note: Show if the values array is of the same length as the mappedValues array
         const fieldNameValuesLength = Object.keys(fieldNameValues).length;
         const mappedValuesLength = Object.keys(
           field?.mappedValues || [],


### PR DESCRIPTION
### Summary
customer reported fix: 
problem: 
1. value mappings doesn't clear disabled when swapping values
2. modifying value mappings save button remains disabled 

solution: 
- change the selection to only allow values not yet selected 
- check the value mappings object and update isModified accordingly
![improved-value-mapping-ux](https://github.com/user-attachments/assets/d1c2b673-6d75-4f45-9144-b7c35b0f4e2d)

#### not included
does not require all selections of value mappings to be mapped before submit/update

