### PR TITLE
fix/rm/feat: simplify value mapping

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,7 +1,7 @@
 import { FormEventHandler } from "react";
-import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
 import isEqual from "lodash.isequal";
 import { Button } from "src/components/ui-base/Button";
+import { useInstallation } from "src/headless/installation/useInstallation";
 
 import { FormErrorBox } from "components/FormErrorBox";
 import { LoadingCentered } from "components/Loading";
@@ -35,7 +35,7 @@ export function ConfigureInstallationBase({
   isCreateMode = false,
   errorMsg,
 }: ConfigureInstallationBaseProps) {
-  const { installation } = useInstallIntegrationProps();
+  const { installation } = useInstallation();
   const { hydratedRevision, loading } = useHydratedRevision();
   const { configureState, selectedObjectName } = useSelectedConfigureState();
 
@@ -47,14 +47,17 @@ export function ConfigureInstallationBase({
       !!getReadObject(config, selectedObjectName)) ||
     false;
 
+  // fetched from server
+  const serverValueMappings =
+    selectedObjectName &&
+    config?.content?.read?.objects?.[selectedObjectName]?.selectedValueMappings;
+
   // is modified derived state
-  const savedValueMappings =
-    configureState?.read?.savedConfig?.selectedValueMappings;
   const selectedValueMappings = configureState?.read?.selectedValueMappings;
 
   // check if value mappings (local) is equal to saved value mappings (server)
-  const isValueMappingsModified = isEqual(
-    savedValueMappings,
+  const isValueMappingsModified = !isEqual(
+    serverValueMappings,
     selectedValueMappings,
   );
 

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,5 +1,4 @@
 import { FormEventHandler } from "react";
-import isEqual from "lodash.isequal";
 import { Button } from "src/components/ui-base/Button";
 import { useInstallation } from "src/headless/installation/useInstallation";
 
@@ -15,6 +14,7 @@ import { useHydratedRevision } from "../state/HydratedRevisionContext";
 import { getReadObject } from "../utils";
 
 import { ReadFields } from "./fields/ReadFields";
+import { isValueMappingsEqual } from "./fields/ValueMapping/utils";
 import { WriteFields } from "./fields/WriteFields";
 import { ManageContent } from "./manage/ManageContent";
 import { useSelectedConfigureState } from "./useSelectedConfigureState";
@@ -48,15 +48,16 @@ export function ConfigureInstallationBase({
     false;
 
   // fetched from server
-  const serverValueMappings =
-    selectedObjectName &&
-    config?.content?.read?.objects?.[selectedObjectName]?.selectedValueMappings;
+  const serverValueMappings = selectedObjectName
+    ? config?.content?.read?.objects?.[selectedObjectName]
+        ?.selectedValueMappings
+    : undefined;
 
   // is modified derived state
   const selectedValueMappings = configureState?.read?.selectedValueMappings;
 
   // check if value mappings (local) is equal to saved value mappings (server)
-  const isValueMappingsModified = !isEqual(
+  const isValueMappingsModified = !isValueMappingsEqual(
     serverValueMappings,
     selectedValueMappings,
   );

--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -1,5 +1,6 @@
 import { FormEventHandler } from "react";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
+import isEqual from "lodash.isequal";
 import { Button } from "src/components/ui-base/Button";
 
 import { FormErrorBox } from "components/FormErrorBox";
@@ -46,11 +47,22 @@ export function ConfigureInstallationBase({
       !!getReadObject(config, selectedObjectName)) ||
     false;
 
+  // is modified derived state
+  const savedValueMappings =
+    configureState?.read?.savedConfig?.selectedValueMappings;
+  const selectedValueMappings = configureState?.read?.selectedValueMappings;
+
+  // check if value mappings (local) is equal to saved value mappings (server)
+  const isValueMappingsModified = isEqual(
+    savedValueMappings,
+    selectedValueMappings,
+  );
+
   // has the form been modified?
   const isReadModified =
     configureState?.read?.isOptionalFieldsModified ||
     configureState?.read?.isRequiredMapFieldsModified ||
-    configureState?.read?.isValueMappingsModified;
+    isValueMappingsModified;
   const isWriteModified = configureState?.write?.isWriteModified;
   const isModified = isReadModified || isWriteModified;
 

--- a/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "src/components/ui-base/Button";
 import { ComboBox } from "src/components/ui-base/ComboBox/ComboBox";
-import { ErrorBoundary, useErrorState } from "src/context/ErrorContextProvider";
 
 import { useSelectedConfigureState } from "../../useSelectedConfigureState";
 
@@ -22,7 +21,6 @@ interface ValueMappingItemProps {
   fieldName: string;
   onSelectChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   allValueOptions: ValueOption[];
-  hasError?: boolean;
 }
 
 export function ValueMappingItem({
@@ -30,14 +28,10 @@ export function ValueMappingItem({
   onSelectChange,
   fieldName,
   allValueOptions,
-  hasError,
 }: ValueMappingItemProps) {
   const { configureState, selectedObjectName, setConfigureState } =
     useSelectedConfigureState();
   const [disabled, setDisabled] = useState(true);
-
-  const { getError, setError, resetBoundary, isError, removeError } =
-    useErrorState();
 
   const selectedValueMappingForField = useMemo(
     () => configureState?.read?.selectedValueMappings?.[fieldName] || {},
@@ -73,37 +67,6 @@ export function ValueMappingItem({
     (item: { value: string } | null) => {
       if (!item) return;
 
-      // Validate that target values are unique within the same field
-      // This prevents multiple source values from mapping to the same target value
-      if (
-        Object.entries(selectedValueMappingForField).some(
-          ([key, mapping]) =>
-            mapping === item.value && key !== mappedValue.mappedValue,
-        )
-      ) {
-        // Find all the fields that have the same value that need to shown as
-        // error'ed out fields
-        const duplicateKeys = [
-          ...Object.entries(selectedValueMappingForField)
-            .filter(
-              ([key, mapping]) =>
-                mapping === item.value && key !== mappedValue.mappedValue,
-            )
-            .map(([key]) => key),
-          mappedValue.mappedValue,
-        ];
-
-        // Set error for all the fields that have the same value
-        setError(ErrorBoundary.VALUE_MAPPING, fieldName, duplicateKeys);
-        return;
-      }
-
-      if (getError(ErrorBoundary.VALUE_MAPPING, fieldName)) {
-        // if you're here in the code, it means that the value is not already mapped to another field
-        // so we can remove the error for all the fields that have the same value
-        resetBoundary(ErrorBoundary.VALUE_MAPPING);
-      }
-
       onSelectChange({
         target: {
           name: mappedValue.mappedValue,
@@ -112,15 +75,7 @@ export function ValueMappingItem({
         } as unknown as HTMLSelectElement,
       } as unknown as React.ChangeEvent<HTMLSelectElement>);
     },
-    [
-      onSelectChange,
-      selectedValueMappingForField,
-      fieldName,
-      mappedValue.mappedValue,
-      resetBoundary,
-      setError,
-      getError,
-    ],
+    [onSelectChange, fieldName, mappedValue.mappedValue],
   );
 
   const SelectComponent = useMemo(
@@ -133,13 +88,12 @@ export function ValueMappingItem({
         onSelectedItemChange={onValueChange}
         placeholder="Please select one"
         style={{
-          border: hasError ? "2px solid red" : undefined,
           borderRadius: "8px",
           width: "100%",
         }}
       />
     ),
-    [fieldValue, disabled, items, onValueChange, hasError],
+    [fieldValue, disabled, items, onValueChange],
   );
 
   const onClear = useCallback(() => {
@@ -151,18 +105,12 @@ export function ValueMappingItem({
         "",
         fieldName,
       );
-
-      if (isError(ErrorBoundary.VALUE_MAPPING, fieldName)) {
-        removeError(ErrorBoundary.VALUE_MAPPING, fieldName);
-      }
     }
   }, [
     selectedObjectName,
     setConfigureState,
     mappedValue.mappedValue,
     fieldName,
-    isError,
-    removeError,
   ]);
   return (
     <div

--- a/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValueMappingItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { Button } from "src/components/ui-base/Button";
 import { ComboBox } from "src/components/ui-base/ComboBox/ComboBox";
 
@@ -31,7 +31,6 @@ export function ValueMappingItem({
 }: ValueMappingItemProps) {
   const { configureState, selectedObjectName, setConfigureState } =
     useSelectedConfigureState();
-  const [disabled, setDisabled] = useState(true);
 
   const selectedValueMappingForField = useMemo(
     () => configureState?.read?.selectedValueMappings?.[fieldName] || {},
@@ -42,16 +41,6 @@ export function ValueMappingItem({
     () => selectedValueMappingForField?.[mappedValue.mappedValue],
     [selectedValueMappingForField, mappedValue.mappedValue],
   );
-
-  useEffect(() => {
-    setDisabled(false);
-  }, [
-    mappedValue,
-    setConfigureState,
-    selectedObjectName,
-    fieldValue,
-    configureState,
-  ]);
 
   const items = useMemo(
     () =>
@@ -82,7 +71,6 @@ export function ValueMappingItem({
     () => (
       <ComboBox
         key={fieldValue}
-        disabled={disabled}
         items={items}
         selectedValue={fieldValue || null}
         onSelectedItemChange={onValueChange}
@@ -93,7 +81,7 @@ export function ValueMappingItem({
         }}
       />
     ),
-    [fieldValue, disabled, items, onValueChange],
+    [fieldValue, items, onValueChange],
   );
 
   const onClear = useCallback(() => {

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from "react";
-import { ErrorBoundary, useErrorState } from "context/ErrorContextProvider";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
 import isEqual from "lodash.isequal";
 import { FormControl } from "src/components/form/FormControl";
@@ -7,6 +6,11 @@ import { FormControl } from "src/components/form/FormControl";
 import { useSelectedConfigureState } from "../../useSelectedConfigureState";
 
 import { setValueMapping, setValueMappingModified } from "./setValueMapping";
+import {
+  getAvailableOptions,
+  getFieldDisplayName,
+  validateFieldMapping,
+} from "./utils";
 import { ValueHeader } from "./ValueHeader";
 import { ValueMappingItem } from "./ValueMappingItem";
 
@@ -69,7 +73,6 @@ export function ValueMappings() {
   const { fieldMapping } = useInstallIntegrationProps();
   const { selectedObjectName, configureState, setConfigureState } =
     useSelectedConfigureState();
-  const { isError, removeError, getError } = useErrorState();
 
   const selectedFieldMappings = configureState?.read?.selectedFieldMappings;
   const selectedMappings = configureState?.read?.selectedValueMappings;
@@ -117,67 +120,51 @@ export function ValueMappings() {
           fieldName,
         );
       }
-
-      if (isError(ErrorBoundary.VALUE_MAPPING, name)) {
-        removeError(ErrorBoundary.VALUE_MAPPING, name);
-      }
     },
-    [selectedObjectName, setConfigureState, isError, removeError],
+    [selectedObjectName, setConfigureState],
   );
 
-  // Separate useEffect to check for modifications when selectedMappings changes
-  // update the modified flag when the value mappings are modified
+  // Track modifications when value mappings change
   useEffect(() => {
-    if (
-      selectedObjectName &&
-      selectedMappings &&
-      configureState?.read?.savedConfig?.selectedValueMappings
-    ) {
-      const savedValueMappings =
-        configureState?.read?.savedConfig?.selectedValueMappings;
-      const updatedValueMappings = selectedMappings;
-      const isModified = !isEqual(savedValueMappings, updatedValueMappings);
+    if (!selectedObjectName || !selectedMappings) return;
 
+    const savedValueMappings =
+      configureState?.read?.savedConfig?.selectedValueMappings;
+
+    // Compare with saved state if available
+    if (savedValueMappings) {
+      const isModified = !isEqual(savedValueMappings, selectedMappings);
       setValueMappingModified(
         selectedObjectName,
         setConfigureState,
         isModified,
       );
+      return;
+    }
+
+    // If no saved state, check if any mappings exist
+    const fieldsWithMappings =
+      fieldMapping?.[selectedObjectName]?.filter(
+        (f) => f.fieldName && f.mappedValues!.length > 0,
+      ) || [];
+
+    const hasAnyMappings = fieldsWithMappings.some((field) => {
+      const mappingsForField = selectedMappings[field.fieldName!] || {};
+      return Object.keys(mappingsForField).length > 0;
+    });
+
+    if (
+      hasAnyMappings &&
+      fieldsWithMappings.length > 0 &&
+      !isValueMappingsModified
+    ) {
+      setValueMappingModified(selectedObjectName, setConfigureState, true);
     }
   }, [
     selectedMappings,
     selectedObjectName,
     setConfigureState,
     configureState?.read?.savedConfig?.selectedValueMappings,
-  ]);
-
-  // update the modified flag when the value mappings is initialized
-  useEffect(() => {
-    if (selectedObjectName && selectedMappings) {
-      // Find all fields that have mappedValues
-      const fieldsWithMappings =
-        fieldMapping?.[selectedObjectName]?.filter(
-          (f) => f.fieldName && f.mappedValues!.length > 0,
-        ) || [];
-
-      // Check if any values are mapped for any field
-      const hasAnyMappings = fieldsWithMappings.some((field) => {
-        const mappingsForField = selectedMappings[field.fieldName!] || {};
-        return Object.keys(mappingsForField).length > 0;
-      });
-
-      if (hasAnyMappings && fieldsWithMappings.length > 0) {
-        // Set modified flag as soon as any mapping is made
-        if (!isValueMappingsModified) {
-          setValueMappingModified(selectedObjectName, setConfigureState, true);
-        }
-      }
-    }
-  }, [
-    selectedMappings,
-    valuesMappings,
-    selectedObjectName,
-    setConfigureState,
     fieldMapping,
     isValueMappingsModified,
   ]);
@@ -186,32 +173,12 @@ export function ValueMappings() {
     <>
       {/* value mappings for each field */}
       {valuesMappings.map((field) => {
-        // show the values mapping only if the field has fieldName
-        if (!field.fieldName) return null;
+        const fieldMetadata =
+          configureState?.read?.allFieldsMetadata?.[field.fieldName!];
+        const validation = validateFieldMapping(field, fieldMetadata);
 
-        // show the values mapping only for singleSelect and multiSelect type fields
-        const fieldNameObject =
-          configureState?.read?.allFieldsMetadata?.[field.fieldName];
-        const fieldNameValueType = fieldNameObject?.valueType;
-        if (!["singleSelect", "multiSelect"].includes(fieldNameValueType)) {
-          const errorMsg = "fieldName is not a singleSelect or multiSelect";
-          console.error(errorMsg, field);
-          return null;
-        }
-
-        // show the values mapping only if the field has values array
-        const fieldNameValues = fieldNameObject?.values;
-        if (!fieldNameValues) return null;
-
-        // special note: Show if the values array is of the same length as the mappedValues array
-        const fieldNameValuesLength = Object.keys(fieldNameValues).length;
-        const mappedValuesLength = Object.keys(
-          field?.mappedValues || [],
-        ).length;
-        if (fieldNameValuesLength !== mappedValuesLength) {
-          const errorMsg =
-            "field values and the values to be mapped are not of the same length";
-          console.error(errorMsg, field, fieldNameValues);
+        if (!validation.isValid) {
+          console.error(validation.errorMessage, field);
           return null;
         }
 
@@ -219,72 +186,33 @@ export function ValueMappings() {
           <>
             <ValueHeader
               string="Map the values for "
-              fieldName={
-                field.mapToDisplayName || field.mapToName || field.fieldName
-              }
+              fieldName={getFieldDisplayName(field)}
             />
             <div
               style={{ display: "flex", gap: "1rem", flexDirection: "column" }}
             >
               <FormControl
-                id={field.mapToName || field.fieldName}
-                key={field.mapToName || field.fieldName}
+                id={getFieldDisplayName(field)}
+                key={getFieldDisplayName(field)}
               >
                 {field?.mappedValues?.map((value) => {
-                  const errors = getError(
-                    ErrorBoundary.VALUE_MAPPING,
-                    field.fieldName!,
-                  );
-                  const hasError =
-                    Array.isArray(errors) && errors.includes(value.mappedValue);
-
-                  // Get all available options
-                  const allValueOptions =
-                    configureState?.read?.allFieldsMetadata?.[field.fieldName!]
-                      ?.values || [];
-
-                  // Get currently selected values for this field (excluding current value)
+                  const allValueOptions = fieldMetadata?.values || [];
                   const mappingsForField =
                     selectedMappings?.[field.fieldName!] || {};
-                  const currentlySelectedValues =
-                    Object.values(mappingsForField).filter(Boolean);
-                  const currentValueSelection =
-                    mappingsForField[value.mappedValue];
-
-                  // Filter options to show: unselected values + current selection (if any)
-                  const availableOptions = allValueOptions.filter(
-                    (option: { value: string }) => {
-                      const isCurrentSelection =
-                        option.value === currentValueSelection;
-                      const isAlreadySelected =
-                        currentlySelectedValues.includes(option.value);
-                      return isCurrentSelection || !isAlreadySelected;
-                    },
+                  const availableOptions = getAvailableOptions(
+                    allValueOptions,
+                    mappingsForField,
+                    value.mappedValue,
                   );
 
                   return (
-                    <>
-                      <ValueMappingItem
-                        key={`${value.mappedValue}-${field.fieldName}`}
-                        allValueOptions={availableOptions}
-                        mappedValue={value}
-                        onSelectChange={onSelectChange}
-                        fieldName={field?.fieldName || ""}
-                        hasError={hasError}
-                      />
-                      {hasError && (
-                        <span
-                          key={value.mappedValue}
-                          style={{
-                            color: "red",
-                            fontSize: "14px",
-                            marginTop: "4px",
-                          }}
-                        >
-                          {`Each ${field.mapToName || field.fieldName} must be mapped to a unique value`}
-                        </span>
-                      )}
-                    </>
+                    <ValueMappingItem
+                      key={`${value.mappedValue}-${field.fieldName}`}
+                      allValueOptions={availableOptions}
+                      mappedValue={value}
+                      onSelectChange={onSelectChange}
+                      fieldName={field?.fieldName || ""}
+                    />
                   );
                 })}
               </FormControl>

--- a/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
+++ b/src/components/Configure/content/fields/ValueMapping/ValuesMapping.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
-import isEqual from "lodash.isequal";
 import { FormControl } from "src/components/form/FormControl";
 
 import { useSelectedConfigureState } from "../../useSelectedConfigureState";
 
-import { setValueMapping, setValueMappingModified } from "./setValueMapping";
+import { setValueMapping } from "./setValueMapping";
 import {
   getAvailableOptions,
   getFieldDisplayName,
@@ -76,7 +75,6 @@ export function ValueMappings() {
 
   const selectedFieldMappings = configureState?.read?.selectedFieldMappings;
   const selectedMappings = configureState?.read?.selectedValueMappings;
-  const isValueMappingsModified = configureState?.read?.isValueMappingsModified;
 
   const valuesMappings = useMemo(() => {
     // get all the fields that have fieldMappings from the selected object
@@ -123,51 +121,6 @@ export function ValueMappings() {
     },
     [selectedObjectName, setConfigureState],
   );
-
-  // Track modifications when value mappings change
-  useEffect(() => {
-    if (!selectedObjectName || !selectedMappings) return;
-
-    const savedValueMappings =
-      configureState?.read?.savedConfig?.selectedValueMappings;
-
-    // Compare with saved state if available
-    if (savedValueMappings) {
-      const isModified = !isEqual(savedValueMappings, selectedMappings);
-      setValueMappingModified(
-        selectedObjectName,
-        setConfigureState,
-        isModified,
-      );
-      return;
-    }
-
-    // If no saved state, check if any mappings exist
-    const fieldsWithMappings =
-      fieldMapping?.[selectedObjectName]?.filter(
-        (f) => f.fieldName && f.mappedValues!.length > 0,
-      ) || [];
-
-    const hasAnyMappings = fieldsWithMappings.some((field) => {
-      const mappingsForField = selectedMappings[field.fieldName!] || {};
-      return Object.keys(mappingsForField).length > 0;
-    });
-
-    if (
-      hasAnyMappings &&
-      fieldsWithMappings.length > 0 &&
-      !isValueMappingsModified
-    ) {
-      setValueMappingModified(selectedObjectName, setConfigureState, true);
-    }
-  }, [
-    selectedMappings,
-    selectedObjectName,
-    setConfigureState,
-    configureState?.read?.savedConfig?.selectedValueMappings,
-    fieldMapping,
-    isValueMappingsModified,
-  ]);
 
   return valuesMappings?.length ? (
     <>

--- a/src/components/Configure/content/fields/ValueMapping/setValueMapping.ts
+++ b/src/components/Configure/content/fields/ValueMapping/setValueMapping.ts
@@ -52,18 +52,3 @@ export function setValueMapping(
     ),
   );
 }
-
-export function setValueMappingModified(
-  selectedObjectName: string,
-  setConfigureState: (
-    objectName: string,
-    producer: (draft: Draft<ConfigureState>) => void,
-  ) => void,
-  isModified: boolean,
-) {
-  setConfigureState(selectedObjectName, (draft) => {
-    if (draft.read) {
-      draft.read.isValueMappingsModified = isModified;
-    }
-  });
-}

--- a/src/components/Configure/content/fields/ValueMapping/utils.ts
+++ b/src/components/Configure/content/fields/ValueMapping/utils.ts
@@ -1,3 +1,5 @@
+import isEqual from "lodash.isequal";
+
 interface Field {
   fieldName?: string;
   mapToName?: string;
@@ -56,6 +58,46 @@ export function validateFieldMapping(
   }
 
   return { isValid: true };
+}
+
+/**
+ * Compares two value mapping objects, treating undefined and empty objects as equal
+ */
+export function isValueMappingsEqual(
+  mappings1: Record<string, Record<string, string>> | undefined | null,
+  mappings2: Record<string, Record<string, string>> | undefined | null,
+): boolean {
+  // Helper function to check if a mapping object is effectively empty
+  const isEmpty = (
+    obj: Record<string, Record<string, string>> | undefined | null,
+  ): boolean => {
+    if (!obj) return true;
+
+    const keys = Object.keys(obj);
+    if (keys.length === 0) return true;
+
+    // Check if all field mappings are empty
+    return keys.every((key) => {
+      const fieldMapping = obj[key];
+      return !fieldMapping || Object.keys(fieldMapping).length === 0;
+    });
+  };
+
+  const isEmpty1 = isEmpty(mappings1);
+  const isEmpty2 = isEmpty(mappings2);
+
+  // If both are empty, they're equal
+  if (isEmpty1 && isEmpty2) {
+    return true;
+  }
+
+  // If only one is empty, they're not equal
+  if (isEmpty1 !== isEmpty2) {
+    return false;
+  }
+
+  // Both are non-empty, use deep equality check
+  return isEqual(mappings1, mappings2);
 }
 
 /**

--- a/src/components/Configure/content/fields/ValueMapping/utils.ts
+++ b/src/components/Configure/content/fields/ValueMapping/utils.ts
@@ -1,0 +1,78 @@
+interface Field {
+  fieldName?: string;
+  mapToName?: string;
+  mapToDisplayName?: string;
+  mappedValues?: Array<{ mappedValue: string; mappedDisplayValue: string }>;
+}
+
+interface FieldMetadata {
+  valueType: string;
+  values?: Record<string, any>;
+}
+
+/**
+ * Gets the display name for a field, preferring mapToDisplayName over mapToName over fieldName
+ */
+export function getFieldDisplayName(field: Field): string {
+  return field.mapToDisplayName || field.mapToName || field.fieldName || "";
+}
+
+/**
+ * Validates if a field mapping is valid for display
+ */
+export function validateFieldMapping(
+  field: Field,
+  fieldMetadata?: FieldMetadata,
+): { isValid: boolean; errorMessage?: string } {
+  // Field must have a fieldName
+  if (!field.fieldName) {
+    return { isValid: false, errorMessage: "Field name is missing" };
+  }
+
+  // Field must be singleSelect or multiSelect
+  const fieldValueType = fieldMetadata?.valueType;
+  if (!["singleSelect", "multiSelect"].includes(fieldValueType || "")) {
+    return {
+      isValid: false,
+      errorMessage: "fieldName is not a singleSelect or multiSelect",
+    };
+  }
+
+  // Field must have values array
+  const fieldValues = fieldMetadata?.values;
+  if (!fieldValues) {
+    return { isValid: false, errorMessage: "Field values array is missing" };
+  }
+
+  // Values array must match mappedValues array length
+  const fieldValuesLength = Object.keys(fieldValues).length;
+  const mappedValuesLength = Object.keys(field?.mappedValues || []).length;
+  if (fieldValuesLength !== mappedValuesLength) {
+    return {
+      isValid: false,
+      errorMessage:
+        "field values and the values to be mapped are not of the same length",
+    };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Gets available options for a field, filtering out already selected values
+ */
+export function getAvailableOptions(
+  allOptions: Array<{ value: string; displayValue: string }>,
+  selectedMappings: Record<string, string>,
+  currentValue: string,
+): Array<{ value: string; displayValue: string }> {
+  const currentlySelectedValues =
+    Object.values(selectedMappings).filter(Boolean);
+  const currentValueSelection = selectedMappings[currentValue];
+
+  return allOptions.filter((option) => {
+    const isCurrentSelection = option.value === currentValueSelection;
+    const isAlreadySelected = currentlySelectedValues.includes(option.value);
+    return isCurrentSelection || !isAlreadySelected;
+  });
+}

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -1,6 +1,6 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { NavIcon } from "assets/NavIcon";
-import isEqual from "lodash.isequal";
+import { isValueMappingsEqual } from "src/components/Configure/content/fields/ValueMapping/utils";
 import {
   NavObject,
   ObjectConfigurationsState,
@@ -116,21 +116,10 @@ export function VerticalTabs({
             configureState?.read?.selectedValueMappings;
 
           // check if value mappings (local) is equal to saved value mappings (server)
-          const isValueMappingsModified = !isEqual(
+          const isValueMappingsModified = !isValueMappingsEqual(
             savedValueMappings,
             selectedValueMappings,
           );
-
-          console.group("object", object.name);
-          console.log("isOptionalFieldsModified", isOptionalFieldsModified);
-          console.log(
-            "isRequiredMapFieldsModified",
-            isRequiredMapFieldsModified,
-          );
-          console.log("isValueMappingsModified", isValueMappingsModified);
-          console.log("savedValueMappings", savedValueMappings);
-          console.log("selectedValueMappings", selectedValueMappings);
-          console.groupEnd();
 
           const isPending =
             isOptionalFieldsModified ||

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -1,10 +1,12 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { NavIcon } from "assets/NavIcon";
+import isEqual from "lodash.isequal";
 import {
   NavObject,
   ObjectConfigurationsState,
 } from "src/components/Configure/types";
 import { Divider } from "src/components/ui-base/Divider";
+import { useInstallation } from "src/headless/installation/useInstallation";
 
 import { WRITE_CONST } from "../../constant";
 
@@ -85,6 +87,9 @@ export function VerticalTabs({
   objectConfigurationsState,
   writeNavObject,
 }: VerticalTabsProps) {
+  const { installation } = useInstallation();
+  const serverConfig = installation?.config; // from server
+
   return (
     <Tabs.Root
       value={value}
@@ -93,23 +98,56 @@ export function VerticalTabs({
     >
       <Tabs.List className={styles.tabsList}>
         {/* Read tabs */}
-        {readNavObjects.map((object) => (
-          <NavObjectTab
-            key={object.name}
-            objectName={object.name}
-            displayName={object.displayName}
-            completed={object.completed}
-            pending={
-              objectConfigurationsState?.[object.name]?.read
-                ?.isOptionalFieldsModified ||
-              objectConfigurationsState?.[object.name]?.read
-                ?.isRequiredMapFieldsModified ||
-              objectConfigurationsState?.[object.name]?.read
-                ?.isValueMappingsModified ||
-              false
-            }
-          />
-        ))}
+        {readNavObjects.map((object) => {
+          const serverReadConfig =
+            serverConfig?.content?.read?.objects?.[object.name];
+          const configureState = objectConfigurationsState?.[object.name]; // local state
+
+          // todo migrate to derived state
+          const isOptionalFieldsModified =
+            configureState?.read?.isOptionalFieldsModified;
+          const isRequiredMapFieldsModified =
+            configureState?.read?.isRequiredMapFieldsModified;
+
+          // derived state for value mappings modified
+          // is modified derived state
+          const savedValueMappings = serverReadConfig?.selectedValueMappings;
+          const selectedValueMappings =
+            configureState?.read?.selectedValueMappings;
+
+          // check if value mappings (local) is equal to saved value mappings (server)
+          const isValueMappingsModified = !isEqual(
+            savedValueMappings,
+            selectedValueMappings,
+          );
+
+          console.group("object", object.name);
+          console.log("isOptionalFieldsModified", isOptionalFieldsModified);
+          console.log(
+            "isRequiredMapFieldsModified",
+            isRequiredMapFieldsModified,
+          );
+          console.log("isValueMappingsModified", isValueMappingsModified);
+          console.log("savedValueMappings", savedValueMappings);
+          console.log("selectedValueMappings", selectedValueMappings);
+          console.groupEnd();
+
+          const isPending =
+            isOptionalFieldsModified ||
+            isRequiredMapFieldsModified ||
+            isValueMappingsModified ||
+            false;
+
+          return (
+            <NavObjectTab
+              key={object.name}
+              objectName={object.name}
+              displayName={object.displayName}
+              completed={object.completed}
+              pending={isPending}
+            />
+          );
+        })}
         {/* Other / Write Tab */}
         {writeNavObject && (
           <WriteTab

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -133,7 +133,6 @@ export function ConfigurationProvider({
           if (readDraft) {
             readDraft.isOptionalFieldsModified = false;
             readDraft.isRequiredMapFieldsModified = false;
-            readDraft.isValueMappingsModified = false;
           }
         }),
       );

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -102,7 +102,6 @@ const generateConfigurationStateRead = (
     selectedValueMappings,
     isOptionalFieldsModified: false,
     isRequiredMapFieldsModified: false,
-    isValueMappingsModified: false,
     savedConfig: {
       optionalFields: optionalFieldsSaved, // from config
       requiredMapFields: requiredMapFieldsSaved, // from config

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -105,7 +105,6 @@ const generateConfigurationStateRead = (
     savedConfig: {
       optionalFields: optionalFieldsSaved, // from config
       requiredMapFields: requiredMapFieldsSaved, // from config
-      selectedValueMappings,
     },
   };
 };

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -47,7 +47,6 @@ export type ConfigureStateRead = {
   selectedValueMappings: SelectValueMappings | null;
   isOptionalFieldsModified: boolean; // checks if selected optional fields is modified
   isRequiredMapFieldsModified: boolean; // checks if required map fields is modified
-  isValueMappingsModified: boolean; // checks if value mappings is modified
   savedConfig: SavedConfigureState; // check when to know if config is saved / modified
 };
 

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -53,7 +53,6 @@ export type ConfigureStateRead = {
 type SavedConfigureState = {
   optionalFields: SelectOptionalFields;
   requiredMapFields: SelectMappingFields;
-  selectedValueMappings: SelectValueMappings;
 };
 
 export type ConfigureState = {


### PR DESCRIPTION
### Summary  
Tracking the `isModified` state has resulted in unnecessary complexity as the product has scaled. With multiple states updating a legacy draft state and a legacy saved state, the “source of truth” has been ambiguous, leading to bugs that are difficult to debug. A state rewrite was needed to debug this issue. 

This PR simplifies the `ValueMappings` implementation in the following ways:  
- **Remove inline validation**: Since we now enforce uniqueness at the selection step (via filter), post-input validation is no longer required. This reduces maintenance burden.  
- **Remove `isValueMappingsModified` state tracking**: No longer stored in state; simplifies logic and reduces potential divergence.  
- **Add `isValueMappingsEqual` helper**: Ensures `undefined` (server) and `{}` (local) are treated as equal (not yet modified).  

### Other details
cleaned up value mappings  with utility functions
- getFieldDisplayName
- validateFieldMapping
- getAvailableOptions

---

### Legacy Data Rendering (pre-reactQuery)  
1. Server pulls data → reset saved value mappings (from config)  
2. Local draft created  
3. Local draft modified  
4. Trigger `isEqual` check  
5. Update `isValueMappingsModified`  
6. Submit  
7. Update server saved  

This approach was fragile—errors were hard to locate, and debugging required juggling multiple configs (`valueMappings`, `readConfig`, `writeConfig`). Tracking the "Save" button state became overly complex.  

Debugging saw a problem where after create installation was fired off, the submit button was still enabled. This rendering issue was caused because the savedValueMapping (server) state was not updated locally calling a manual reset. Instead of navigating how to call a reset; we removed the tracking; and implemented a new data flow architecture below.

---

### New Approach (with React Query)  
1. `useQuery` pulls installation → **server config is the single source of truth**  
2. `selectedValueMappings` tracks local draft only  
3. `isValueMappingsModified` becomes derived state (compare 1 & 2 directly)  

---

### Takeaways  
- The MVP blurred the separation between server state and local draft state.  
- That design was later scaffolded and “patched” (including by AI tools), but the flawed foundation made debugging impossible.  
- Removing explicit local tracking of `isModified` eliminates a recurring class of bugs.  
- **Recommendation**: Apply this pattern consistently across the form—remove local state management of modified state wherever possible.  (starting with isWriteModified, isReadModified, isOptional etc...)

### Testing
![simplify-rendering-state](https://github.com/user-attachments/assets/8168927c-aa70-4f2f-a68e-ed08bb390ed6)

