### PR TITLE
[ENG-2596] refactor: remove write modified state

### DIFF
--- a/src/components/Configure/content/ConfigureInstallationBase.tsx
+++ b/src/components/Configure/content/ConfigureInstallationBase.tsx
@@ -12,6 +12,7 @@ import {
 } from "../nav/ObjectManagementNav/constant";
 import { useHydratedRevision } from "../state/HydratedRevisionContext";
 import {
+  areWriteObjectsEqual,
   getServerFieldMappings,
   getServerOptionalSelectedFields,
 } from "../state/utils";
@@ -101,12 +102,22 @@ export function ConfigureInstallationBase({
     selectedValueMappings,
   );
 
+  // write objects ///////////////
+  // fetched from server
+  const serverWriteObjects = config?.content?.write?.objects;
+  const selectedWriteObjects = configureState?.write?.selectedWriteObjects;
+
+  // is modified derived state
+  const isWriteModified = !areWriteObjectsEqual(
+    serverWriteObjects || {},
+    selectedWriteObjects || {},
+  );
+
   // has the form been modified?
   const isReadModified =
     isOptionalFieldsModified ||
     isFieldMappingsModified ||
     isValueMappingsModified;
-  const isWriteModified = configureState?.write?.isWriteModified;
   const isModified = isReadModified || isWriteModified;
 
   // if the read object is not completed, it is a new state

--- a/src/components/Configure/content/CreateInstallation.tsx
+++ b/src/components/Configure/content/CreateInstallation.tsx
@@ -34,7 +34,6 @@ export function CreateInstallation() {
     resetMutateInstallationErrorState,
     resetConfigureState,
     objectConfigurationsState,
-    resetPendingConfigurationState,
     configureState,
     onInstallSuccess,
     onNextIncompleteTab,
@@ -119,7 +118,6 @@ export function CreateInstallation() {
           setInstallation(installation);
           onInstallSuccess?.(installation.id, installation.config);
           setLoadingState(false);
-          resetPendingConfigurationState(selectedObjectName);
           onNextIncompleteTab();
         },
         onError: (error) => {
@@ -163,7 +161,6 @@ export function CreateInstallation() {
           setInstallation(installation);
           onInstallSuccess?.(installation.id, installation.config);
           setLoadingState(false);
-          resetPendingConfigurationState(selectedObjectName); // reset write pending/isModified state
           onNextIncompleteTab();
         },
         onError: (error) => {

--- a/src/components/Configure/content/UpdateInstallation.tsx
+++ b/src/components/Configure/content/UpdateInstallation.tsx
@@ -29,7 +29,6 @@ export function UpdateInstallation({ installation }: UpdateInstallationProps) {
     setMutateInstallationError,
     getMutateInstallationError,
     resetConfigureState,
-    resetPendingConfigurationState,
     configureState,
     onUpdateSuccess,
     onNextIncompleteTab,
@@ -121,7 +120,6 @@ export function UpdateInstallation({ installation }: UpdateInstallationProps) {
           setInstallation(installation);
           onUpdateSuccess?.(installation.id, installation.config);
           setLoadingState(false);
-          resetPendingConfigurationState(selectedObjectName!);
           onNextIncompleteTab();
         },
         onError: (error) => {
@@ -156,7 +154,6 @@ export function UpdateInstallation({ installation }: UpdateInstallationProps) {
           setInstallation(installation);
           onUpdateSuccess?.(installation.id, installation.config);
           setLoadingState(false);
-          resetPendingConfigurationState(selectedObjectName!);
           onNextIncompleteTab();
         },
         onError: (error) => {

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/setValueDefaultWriteField.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/setValueDefaultWriteField.tsx
@@ -38,7 +38,6 @@ function setValueDefaultWriteFieldProducer(
       }
     }
 
-
     // DEBUG: print out the draft
     // console.debug('Set default value', JSON.stringify(draft?.write, null, 2));
   }

--- a/src/components/Configure/content/fields/FieldDefaultValueMapping/setValueDefaultWriteField.tsx
+++ b/src/components/Configure/content/fields/FieldDefaultValueMapping/setValueDefaultWriteField.tsx
@@ -1,6 +1,5 @@
 import { Draft } from "immer";
 
-import { areWriteObjectsEqual } from "../../../state/utils";
 import { ConfigureState } from "../../../types";
 
 function setValueDefaultWriteFieldProducer(
@@ -39,18 +38,6 @@ function setValueDefaultWriteFieldProducer(
       }
     }
 
-    // check is modified
-    if (draft?.write?.savedConfig?.selectedWriteObjects) {
-      const savedWriteObjects = draft.write.savedConfig.selectedWriteObjects;
-      const updatedWriteObjects = draftSelectedWriteFields;
-      const isModified = !areWriteObjectsEqual(
-        savedWriteObjects,
-        updatedWriteObjects,
-      );
-      // immer syntax to set a value
-
-      draft.write.isWriteModified = isModified;
-    }
 
     // DEBUG: print out the draft
     // console.debug('Set default value', JSON.stringify(draft?.write, null, 2));

--- a/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
+++ b/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
@@ -1,6 +1,5 @@
 import { Draft } from "immer";
 
-import { areWriteObjectsEqual } from "../../../state/utils";
 import { ConfigureState } from "../../../types";
 
 function setNonConfigurableWriteFieldProducer(
@@ -24,18 +23,6 @@ function setNonConfigurableWriteFieldProducer(
       delete draftSelectedWriteFields[fieldKey];
     }
 
-    // check is modified
-    if (draft?.write?.savedConfig?.selectedWriteObjects) {
-      const savedWriteObjects = draft.write.savedConfig.selectedWriteObjects;
-      const updatedWriteObjects = draftSelectedWriteFields;
-      const isModified = !areWriteObjectsEqual(
-        savedWriteObjects,
-        updatedWriteObjects,
-      );
-      // immer syntax to set a value
-
-      draft.write.isWriteModified = isModified;
-    }
 
     // DEBUG: print out the draft
     // console.debug(JSON.stringify(draft, null, 2));

--- a/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
+++ b/src/components/Configure/content/fields/WriteFields/setNonConfigurableWriteField.tsx
@@ -23,7 +23,6 @@ function setNonConfigurableWriteFieldProducer(
       delete draftSelectedWriteFields[fieldKey];
     }
 
-
     // DEBUG: print out the draft
     // console.debug(JSON.stringify(draft, null, 2));
   }

--- a/src/components/Configure/content/useMutateInstallation.tsx
+++ b/src/components/Configure/content/useMutateInstallation.tsx
@@ -31,11 +31,8 @@ export const useMutateInstallation = () => {
   const apiKey = useApiKey();
   const { projectIdOrName } = useAmpersandProviderProps();
   const { resetBoundary, setErrors, setError, getError } = useErrorState();
-  const {
-    resetConfigureState,
-    objectConfigurationsState,
-    resetPendingConfigurationState,
-  } = useObjectsConfigureState();
+  const { resetConfigureState, objectConfigurationsState } =
+    useObjectsConfigureState();
   const configureState = getConfigureState(
     selectedObjectName || "",
     objectConfigurationsState,
@@ -101,7 +98,6 @@ export const useMutateInstallation = () => {
     resetMutateInstallationErrorState,
     resetConfigureState,
     objectConfigurationsState,
-    resetPendingConfigurationState,
     configureState,
     onInstallSuccess,
     onUpdateSuccess,

--- a/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
+++ b/src/components/Configure/nav/ObjectManagementNav/v2/Tabs/index.tsx
@@ -1,6 +1,7 @@
 import * as Tabs from "@radix-ui/react-tabs";
 import { NavIcon } from "assets/NavIcon";
 import {
+  areWriteObjectsEqual,
   getServerFieldMappings,
   getServerOptionalSelectedFields,
 } from "src/components/Configure/state/utils";
@@ -100,6 +101,10 @@ export function VerticalTabs({
   const { installation } = useInstallation();
   const serverConfig = installation?.config; // from server
 
+  const serverWriteObjects = serverConfig?.content?.write?.objects;
+  const selectedWriteObjects =
+    objectConfigurationsState?.other?.write?.selectedWriteObjects;
+
   return (
     <Tabs.Root
       value={value}
@@ -171,15 +176,21 @@ export function VerticalTabs({
           );
         })}
         {/* Other / Write Tab */}
-        {writeNavObject && (
-          <WriteTab
-            completed={writeNavObject.completed}
-            pending={
-              objectConfigurationsState?.other?.write?.isWriteModified || false
-            }
-            displayName="Write"
-          />
-        )}
+        {writeNavObject &&
+          (() => {
+            const isWriteModified = !areWriteObjectsEqual(
+              serverWriteObjects || {},
+              selectedWriteObjects || {},
+            );
+
+            return (
+              <WriteTab
+                completed={writeNavObject.completed}
+                pending={isWriteModified}
+                displayName="Write"
+              />
+            );
+          })()}
 
         {/* Manage Tab */}
         <ManageTab />

--- a/src/components/Configure/state/ConfigurationStateProvider.tsx
+++ b/src/components/Configure/state/ConfigurationStateProvider.tsx
@@ -9,7 +9,6 @@ import React, {
 import { useInstallIntegrationProps } from "context/InstallIIntegrationContextProvider/InstallIntegrationContextProvider";
 import { Draft, produce } from "immer";
 
-import { WRITE_CONST } from "../nav/ObjectManagementNav/constant";
 import { ConfigureState, ObjectConfigurationsState } from "../types";
 
 import { useHydratedRevision } from "./HydratedRevisionContext";
@@ -29,7 +28,6 @@ export const ConfigurationContext = createContext<
         objectName: string,
         configureState: ConfigureState,
       ) => void;
-      resetPendingConfigurationState: (objectName: string) => void;
     }
   | undefined
 >(undefined);
@@ -114,47 +112,14 @@ export function ConfigurationProvider({
     [setObjectConfigurationsState],
   );
 
-  // todo: remove this function and use derived state instead
-  const resetWritePendingConfigurationState = useCallback(() => {
-    setObjectConfigurationsState(
-      produce((draft) => {
-        const writeDraft = draft.other.write;
-        if (writeDraft) {
-          writeDraft.isWriteModified = false;
-        }
-      }),
-    );
-  }, [setObjectConfigurationsState]);
-
-  // todo: remove this function and use derived state instead
-  // set configure state of single object
-  const resetPendingConfigurationState = useCallback(
-    (objectName: string) => {
-      // write case
-      if (objectName === WRITE_CONST) {
-        resetWritePendingConfigurationState();
-      } else {
-        // read case
-        // no longer needed, is derived state
-      }
-    },
-    [resetWritePendingConfigurationState],
-  );
-
   const contextValue = useMemo(
     () => ({
       objectConfigurationsState,
       setObjectConfigurationsState,
       setConfigureState,
       resetConfigureState,
-      resetPendingConfigurationState,
     }),
-    [
-      objectConfigurationsState,
-      resetConfigureState,
-      resetPendingConfigurationState,
-      setConfigureState,
-    ],
+    [objectConfigurationsState, resetConfigureState, setConfigureState],
   );
 
   return (

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -1,4 +1,3 @@
-import isEqual from "lodash.isequal";
 import {
   Config,
   HydratedIntegrationFieldExistent,
@@ -27,12 +26,30 @@ import {
   isIntegrationFieldMapping,
 } from "../utils";
 
-// uses lodash deep equality check to compare two saved write objects (typed checked)
+// compares two write objects by checking if they have the same objectNames
+// implemntation detail: sdk generates selectedValueDefaults, selectedFieldSettings;
+// todo: switch to not pass the undefined values to the sdk
 export function areWriteObjectsEqual(
   prevWriteObjects: SelectedWriteObjects,
   currentWriteObjects: SelectedWriteObjects,
 ): boolean {
-  return isEqual(prevWriteObjects, currentWriteObjects);
+  // check if the write objects have the same objectNames
+  // (do not check for equality of the write object selected values, selected fields, etc. yet)
+  const prevObjectNames = new Set(
+    Object.values(prevWriteObjects).map(
+      (writeObject) => writeObject?.objectName,
+    ),
+  );
+  const currentObjectNames = new Set(
+    Object.values(currentWriteObjects).map(
+      (writeObject) => writeObject?.objectName,
+    ),
+  );
+
+  return (
+    prevObjectNames.size === currentObjectNames.size &&
+    [...prevObjectNames].every((name) => currentObjectNames.has(name))
+  );
 }
 
 const generateConfigurationStateRead = (
@@ -94,10 +111,6 @@ const generateConfigurationStateWrite = (
   return {
     writeObjects: writeAction?.objects || [],
     selectedWriteObjects: writeObjects || {},
-    isWriteModified: false,
-    savedConfig: {
-      selectedWriteObjects: writeObjects || {},
-    },
   };
 };
 

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -28,7 +28,10 @@ import {
 
 // compares two write objects by checking if they have the same objectNames
 // implementation detail: sdk generates selectedValueDefaults, selectedFieldSettings;
-// todo: switch to not pass the undefined values to the sdk
+// todo: update openapi spec so the generated SDK no longer have
+//    undefined values for selectedValueDefaults, selectedFieldSettings
+// note: nothing is passing undefined values to the SDK,
+//    the SDK is generating fields with undefined values
 export function areWriteObjectsEqual(
   prevWriteObjects: SelectedWriteObjects,
   currentWriteObjects: SelectedWriteObjects,

--- a/src/components/Configure/state/utils.ts
+++ b/src/components/Configure/state/utils.ts
@@ -27,7 +27,7 @@ import {
 } from "../utils";
 
 // compares two write objects by checking if they have the same objectNames
-// implemntation detail: sdk generates selectedValueDefaults, selectedFieldSettings;
+// implementation detail: sdk generates selectedValueDefaults, selectedFieldSettings;
 // todo: switch to not pass the undefined values to the sdk
 export function areWriteObjectsEqual(
   prevWriteObjects: SelectedWriteObjects,

--- a/src/components/Configure/types.ts
+++ b/src/components/Configure/types.ts
@@ -10,17 +10,11 @@ export type SelectedWriteObjects = {
   [objectName: string]: BaseWriteConfigObject;
 };
 
-type SavedWriteConfigureState = {
-  selectedWriteObjects: SelectedWriteObjects;
-};
-
 // write state slice
 // currently tracks all write objects insteaad of just a single objectname
 export type ConfigureStateWrite = {
   writeObjects: HydratedIntegrationWriteObject[] | null;
   selectedWriteObjects: SelectedWriteObjects | null;
-  isWriteModified: boolean;
-  savedConfig: SavedWriteConfigureState; // check when to know if config is saved / modified
 };
 
 export type SelectOptionalFields = {

--- a/src/headless/installation/useUpdateInstallation.ts
+++ b/src/headless/installation/useUpdateInstallation.ts
@@ -58,10 +58,17 @@ export function useUpdateInstallation() {
 
     // add write objects to update mask
     const updateMask = [];
-    // add write objects to update mask
+    const currentWriteObjectsLength = Object.keys(
+      config?.write?.objects || {},
+    ).length;
+    const previousWriteObjectsLength = Object.keys(
+      installation?.config?.content?.write?.objects || {},
+    ).length;
+
+    // push update mask if write objects length > 0 or if length === 0 and installation had objects previously
     if (
-      config?.write?.objects &&
-      Object.keys(config.write.objects).length > 0
+      currentWriteObjectsLength > 0 ||
+      (currentWriteObjectsLength === 0 && previousWriteObjectsLength > 0)
     ) {
       updateMask.push("config.content.write.objects");
     }
@@ -89,6 +96,10 @@ export function useUpdateInstallation() {
         },
       },
     };
+
+    console.group("Update Installation");
+    console.log("updateInstallationRequest", updateInstallationRequest);
+    console.groupEnd();
 
     return updateInstallationMutation(updateInstallationRequest, {
       onSuccess: (data) => {

--- a/src/headless/installation/useUpdateInstallation.ts
+++ b/src/headless/installation/useUpdateInstallation.ts
@@ -97,10 +97,6 @@ export function useUpdateInstallation() {
       },
     };
 
-    console.group("Update Installation");
-    console.log("updateInstallationRequest", updateInstallationRequest);
-    console.groupEnd();
-
     return updateInstallationMutation(updateInstallationRequest, {
       onSuccess: (data) => {
         onSuccess?.(data);


### PR DESCRIPTION
### Summary
Continued work to migrate write modified state to derived state to reduce state management complexity.
- fix: headless write objects update mask
- add write objects to update mask if it is modified from server state


![testWriteObjects](https://github.com/user-attachments/assets/3303355c-1f3f-4ae4-b2bc-5c29bc3eb291)


