### PR TITLE
[ENG-3822] fix: standardize MetadataInput label and placeholder behavior

### DIFF
--- a/src/components/Connect/UpdateConnectionMetadata.tsx
+++ b/src/components/Connect/UpdateConnectionMetadata.tsx
@@ -109,7 +109,6 @@ export function UpdateConnectionMetadata({
           onChange={(event) =>
             handleFormDataChange(metadata.name, event.currentTarget.value)
           }
-          providerName={providerName}
           defaultValue={initialFormData[metadata.name]}
         />
       ))}

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -98,7 +98,6 @@ export function ApiKeyAuthForm({
           key={metadata.name}
           metadata={metadata}
           onChange={handleChange}
-          providerName={providerName || capitalize(provider)}
         />
       ))}
       <Button

--- a/src/components/auth/BasicAuth/BasicAuthContent.tsx
+++ b/src/components/auth/BasicAuth/BasicAuthContent.tsx
@@ -111,7 +111,6 @@ export function BasicAuthForm({
           key={metadata.name}
           metadata={metadata}
           onChange={handleChange}
-          providerName={providerName || capitalize(provider)}
         />
       ))}
       <Button

--- a/src/components/auth/CustomAuth/CustomAuthContent.tsx
+++ b/src/components/auth/CustomAuth/CustomAuthContent.tsx
@@ -68,7 +68,10 @@ export function CustomAuthForm({
       }}
     >
       {customInputs.map((input) => (
-        <div key={input.name}>
+        <div
+          key={input.name}
+          style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}
+        >
           <DocsHelperTextHeader
             url={input.docsURL}
             prompt={input.prompt}
@@ -88,7 +91,6 @@ export function CustomAuthForm({
           key={metadata.name}
           metadata={metadata}
           onChange={handleChange}
-          variant="header"
         />
       ))}
       <Button

--- a/src/components/auth/MetadataInput/MetadataInput.tsx
+++ b/src/components/auth/MetadataInput/MetadataInput.tsx
@@ -1,7 +1,5 @@
 import { MetadataItemInput } from "@generated/api/src";
-import { capitalize } from "src/utils";
 
-import { DocsHelperText } from "components/Docs/DocsHelperText";
 import { DocsHelperTextHeader } from "components/Docs/DocsHelperTextMinimal";
 import { FormComponent } from "components/form";
 
@@ -12,42 +10,26 @@ type MetadataInputProps = {
   onChange: (
     event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void;
-  providerName?: string;
-  variant?: "standard" | "header";
   defaultValue?: string;
 };
 
 export function MetadataInput({
   metadata,
   onChange,
-  providerName,
-  variant = "standard",
   defaultValue,
 }: MetadataInputProps) {
   return (
     <div className={styles.metadataInputWrapper}>
-      {metadata.docsURL && variant === "standard" && (
-        <DocsHelperText
-          url={metadata.docsURL}
-          providerDisplayName={providerName || ""}
-          credentialName={
-            metadata.displayName || capitalize(metadata.name.toLowerCase())
-          }
-          prompt={metadata.prompt}
-        />
-      )}
-      {variant === "header" && (
-        <DocsHelperTextHeader
-          url={metadata.docsURL}
-          prompt={metadata.prompt}
-          inputName={metadata.displayName || metadata.name}
-        />
-      )}
+      <DocsHelperTextHeader
+        url={metadata.docsURL}
+        prompt={metadata.prompt}
+        inputName={metadata.displayName || metadata.name}
+      />
       <FormComponent.Input
         id={metadata.name}
         name={metadata.name}
         type="text"
-        placeholder={metadata.displayName || metadata.name}
+        placeholder={metadata.defaultValue}
         defaultValue={defaultValue}
         onChange={onChange}
       />

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
@@ -48,10 +48,7 @@ export function WorkspaceEntryContent({
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
         <AuthTitle>Enter your {providerName} workspace</AuthTitle>
         {packageInstallUrl && (
-          <Stepper
-            currentStep={2}
-            onStepClick={() => setStep("install")}
-          />
+          <Stepper currentStep={2} onStepClick={() => setStep("install")} />
         )}
         <AuthErrorAlert error={error} />
         {metadataInputs.map((metadata: MetadataItemInput) => (
@@ -61,7 +58,6 @@ export function WorkspaceEntryContent({
             onChange={(event) =>
               setFormData(metadata.name, event.currentTarget.value)
             }
-            providerName={providerName}
           />
         ))}
         <Button

--- a/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
+++ b/src/components/auth/Oauth/ClientCredentials/ClientCredentialsContent.tsx
@@ -24,7 +24,6 @@ type ClientCredentialsFormProps = {
   explicitScopesRequired?: boolean;
   buttonVariant?: "ghost";
   metadataInputs: MetadataItemInput[];
-  providerName?: string;
 };
 
 type ClientCredentialsFormData = {
@@ -40,7 +39,6 @@ export function ClientCredentialsForm({
   explicitScopesRequired,
   buttonVariant,
   metadataInputs,
-  providerName,
 }: ClientCredentialsFormProps) {
   const [formData, setFormData] = useState<ClientCredentialsFormData>({
     clientSecret: "",
@@ -118,7 +116,6 @@ export function ClientCredentialsForm({
             key={metadata.name}
             metadata={metadata}
             onChange={handleChange}
-            providerName={providerName}
           />
         ))}
       </div>
@@ -164,7 +161,6 @@ export function ClientCredentialsContent({
         isButtonDisabled={isButtonDisabled || !!error}
         explicitScopesRequired={explicitScopesRequired}
         metadataInputs={metadataInputs}
-        providerName={providerName}
       />
     </AuthCardLayout>
   );


### PR DESCRIPTION
## Summary (PR 1/2)
standardizes the MetadataInput to always show a label and map placeholder to defaultValue if available. This changes from the previous conditional cases where sometimes there was a label in "header" variants, and "standard" variants had the legacy no label with displayName as a placeholder.

- **Always show a label** for every metadata field via `DocsHelperTextHeader`, regardless of `docsURL`
- **Placeholder uses `defaultValue`** from API metadata instead of repeating `displayName`
- **Removed `variant` prop** (`"standard"`/`"header"`) — single consistent rendering path
- **Removed `providerName` prop** and `DocsHelperText` ("Learn more...") usage from `MetadataInput`
- **Aligned** CustomAuth credential input wrapper spacing with MetadataInput

## Test plan
- [x] Verify all metadata fields show a label in every auth flow (OAuth, API Key, Basic, Custom)
- [x] Verify placeholder shows `defaultValue` when available, empty otherwise

**Stack:** 1/2 → next: style modernization PR

## Standardize label and add default value.
<img width="556" height="649" alt="Screenshot 2026-04-07 at 3 37 49 PM" src="https://github.com/user-attachments/assets/05dbe78a-95bb-4792-8e5f-c187705163d9" />

## Screenshot (with modern styles / followup PR)
<img width="527" height="607" alt="Screenshot 2026-04-07 at 3 36 49 PM" src="https://github.com/user-attachments/assets/bffc2b62-c75c-43e4-bc30-92ec21e229e5" />
