### PR TITLE
[ENG-3822] style: modernize MetadataInput and DocsHelperText layout

### DIFF
--- a/src/components/Docs/DocsHelperTextMinimal.module.css
+++ b/src/components/Docs/DocsHelperTextMinimal.module.css
@@ -1,0 +1,53 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0;
+  color: var(--amp-text-secondary);
+  font-size: var(--amp-font-size-sm);
+  font-weight: var(--amp-font-medium);
+  line-height: 1.4;
+}
+
+.helpButton {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--amp-text-muted);
+  font-size: var(--amp-font-size-xs);
+  font-family: inherit;
+  padding: var(--amp-space-1) var(--amp-space-2);
+  border-radius: var(--amp-radius-sm);
+  display: flex;
+  align-items: center;
+  gap: var(--amp-space-1);
+  transition: color var(--amp-duration-fast) ease,
+    background-color var(--amp-duration-fast) ease;
+}
+
+.helpButton:hover {
+  color: var(--amp-text-primary);
+  background-color: var(--amp-surface-hover);
+}
+
+.chevron {
+  font-size: 1rem;
+  transition: transform var(--amp-duration-fast) ease;
+}
+
+.chevronExpanded {
+  transform: rotate(90deg);
+}
+
+.promptWrapper {
+  overflow: hidden;
+  transition: max-height var(--amp-duration-normal) ease,
+    opacity var(--amp-duration-normal) ease;
+  max-height: 0;
+  opacity: 0;
+}
+
+.promptWrapperExpanded {
+  max-height: 12rem;
+  opacity: 1;
+}

--- a/src/components/Docs/DocsHelperTextMinimal.tsx
+++ b/src/components/Docs/DocsHelperTextMinimal.tsx
@@ -1,7 +1,11 @@
-import { sanitizeHtmlId } from "src/utils";
+import { useState } from "react";
+import classNames from "classnames";
 
 import { AccessibleLink } from "../ui-base/AccessibleLink";
-import { LabelTooltip } from "../ui-base/Tooltip";
+
+import { MetadataPromptText } from "./MetadataPromptText";
+
+import styles from "./DocsHelperTextMinimal.module.css";
 
 type DocsHelperTextProps = {
   url?: string;
@@ -14,29 +18,44 @@ export function DocsHelperTextHeader({
   prompt,
   inputName,
 }: DocsHelperTextProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   return (
-    <p
-      style={{
-        color: "var(--amp-colors-text-muted)",
-        display: "flex",
-        justifyContent: "space-between",
-      }}
-    >
-      <span>
-        {url ? (
-          <AccessibleLink href={url} newTab>
-            <span style={{ textDecoration: "underline" }}>{inputName}</span>
-          </AccessibleLink>
-        ) : (
-          <span>{inputName}</span>
-        )}{" "}
+    <div>
+      <p className={styles.header}>
+        <span>
+          {url ? (
+            <AccessibleLink href={url} newTab>
+              <span style={{ textDecoration: "underline" }}>{inputName}</span>
+            </AccessibleLink>
+          ) : (
+            <span>{inputName}</span>
+          )}
+        </span>
         {prompt && (
-          <LabelTooltip
-            id={`docs-helper-text-${sanitizeHtmlId(inputName || prompt?.slice(0, 50))}`}
-            tooltipText={prompt}
-          />
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            className={styles.helpButton}
+          >
+            <span
+              className={classNames(styles.chevron, {
+                [styles.chevronExpanded]: isExpanded,
+              })}
+            >
+              ▸
+            </span>
+            Help
+          </button>
         )}
-      </span>
-    </p>
+      </p>
+      <div
+        className={classNames(styles.promptWrapper, {
+          [styles.promptWrapperExpanded]: isExpanded,
+        })}
+      >
+        {prompt && <MetadataPromptText prompt={prompt} />}
+      </div>
+    </div>
   );
 }

--- a/src/components/Docs/MetadataPromptText.module.css
+++ b/src/components/Docs/MetadataPromptText.module.css
@@ -1,8 +1,8 @@
 .container {
   color: var(--amp-colors-text-muted);
-  font-size: 0.8125rem;
-  margin-top: 0.375rem;
-  margin-bottom: 0.75rem;
+  font-size: var(--amp-font-size-xs);
+  padding-top: var(--amp-space-1);
+  padding-bottom: var(--amp-space-2);
   line-height: 1.5;
 }
 

--- a/src/components/auth/MetadataInput/MetadataInput.module.css
+++ b/src/components/auth/MetadataInput/MetadataInput.module.css
@@ -1,3 +1,5 @@
-.metadataInputWrapper:not(:last-child) {
-  margin-bottom: 1.5rem;
+.metadataInputWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }


### PR DESCRIPTION
## Summary (PR 2/2)
- Replaced tooltip icon with **expandable "Help" toggle** for prompt text (collapsed by default)
- Moved inline styles to **CSS module** using design tokens
- Added **CSS transition** for smooth expand/collapse animation
- Tightened **label-to-input gap** (0.25rem) and removed redundant margin-bottom
- Added **hover state** to Help button

![modernize-metadata-styles](https://github.com/user-attachments/assets/b8fd2cbf-0fac-4d35-9442-b42187dce907)

## Test plan
- [x] Verify "Help" toggle expands/collapses prompt text with animation
- [x] Verify spacing is consistent between credential inputs and metadata inputs





