### PR TITLE
feat: show field API name alongside label in field picker [ENG-3843]

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/FieldMappingRow.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMappingRow.tsx
@@ -38,6 +38,7 @@ export function FieldMappingRow({
           id: f.fieldName,
           label: f.displayName,
           value: f.fieldName,
+          sublabel: f.fieldName !== f.displayName ? f.fieldName : undefined,
         }))
         .sort((a, b) => a.label.localeCompare(b.label)),
     [allFields],

--- a/src/components/InstallWizard/steps/configure-objects/mappings/MappingRow.tsx
+++ b/src/components/InstallWizard/steps/configure-objects/mappings/MappingRow.tsx
@@ -34,6 +34,7 @@ export function MappingRow({
           id: f.fieldName,
           label: f.displayName,
           value: f.fieldName,
+          sublabel: f.fieldName !== f.displayName ? f.fieldName : undefined,
         }))
         .sort((a, b) => a.label.localeCompare(b.label)),
     [customerFieldOptions],

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -8,6 +8,7 @@ interface Option {
   id: string;
   label: string;
   value: string;
+  sublabel?: string;
 }
 
 // Define the props for the ComboBox component
@@ -29,7 +30,8 @@ function getOptionsFilter(inputValue: string) {
     return (
       !inputValue ||
       option.label.toLowerCase().includes(lowerCasedInputValue) ||
-      option.value.toLowerCase().includes(lowerCasedInputValue)
+      option.value.toLowerCase().includes(lowerCasedInputValue) ||
+      !!option.sublabel?.toLowerCase().includes(lowerCasedInputValue)
     );
   };
 }
@@ -173,6 +175,9 @@ export function ComboBox({
               {...getItemProps({ item, index })}
             >
               <span>{item.label}</span>
+              {item.sublabel && (
+                <span className={styles.sublabel}>{item.sublabel}</span>
+              )}
             </li>
           ))}
       </ul>

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -87,6 +87,11 @@
   font-weight: bold;
 }
 
+.sublabel {
+  color: var(--amp-text-secondary);
+  font-size: 0.75rem;
+}
+
 .hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
Some customers have issues where the field value is different but labels may be the same. We need a way for users to tell difference between matching labels.

- Salesforce allows multiple fields on the same object to share a label (e.g. a standard `LinkedIn` and a custom `LinkedIn__c`, both displaying as "LinkedIn"). The InstallationFlow field-mapping UI only rendered the label, so end users could not tell duplicates apart.
- Added an optional `sublabel` on the `ComboBox` `Option` type and surfaced it as a muted secondary line below the label. Populated it with the field's API name at the field-mapping call sites (legacy `FieldMappingRow` and InstallWizard `MappingRow`) whenever the API name differs from the display name.
- The sublabel is also matched by the `ComboBox` filter, so users can search by API name.

Linear: [ENG-3843](https://linear.app/ampersand/issue/ENG-3843)

## Test plan
- [ ] Visual check: Salesforce integration with a duplicate-label field renders the API name in muted text under the label
- [ ] Typing the API name in the picker filters to the matching option

## Request for value also in combobox.

<img width="670" height="520" alt="Screenshot 2026-04-14 at 4 28 46 PM" src="https://github.com/user-attachments/assets/2f9d2cab-6f63-40f7-8ff1-9786fb54c3f9" />

<img width="526" height="273" alt="Screenshot 2026-04-14 at 4 28 53 PM" src="https://github.com/user-attachments/assets/9f289054-f023-4fb1-b41d-e48f091b3348" />
