### PR TITLE
[ENG-3843] feat: disambiguate duplicate field labels with API name 

### DIFF
--- a/src/components/Configure/content/fields/FieldMappings/FieldMappingRow.tsx
+++ b/src/components/Configure/content/fields/FieldMappings/FieldMappingRow.tsx
@@ -31,17 +31,26 @@ export function FieldMappingRow({
   const selectedFieldMappings = configureState?.read?.selectedFieldMappings;
   const fieldValue = selectedFieldMappings?.[field.mapToName];
 
-  const items = useMemo(
-    () =>
-      allFields
-        .map((f) => ({
-          id: f.fieldName,
-          label: f.displayName,
-          value: f.fieldName,
-        }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    [allFields],
-  );
+  const items = useMemo(() => {
+    const displayNameCounts = new Map<string, number>();
+    allFields.forEach((f) => {
+      displayNameCounts.set(
+        f.displayName,
+        (displayNameCounts.get(f.displayName) ?? 0) + 1,
+      );
+    });
+    return allFields
+      .map((f) => ({
+        id: f.fieldName,
+        label: f.displayName,
+        value: f.fieldName,
+        sublabel:
+          (displayNameCounts.get(f.displayName) ?? 0) > 1
+            ? f.fieldName
+            : undefined,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [allFields]);
 
   const SelectComponent = (
     <ComboBox

--- a/src/components/InstallWizard/steps/configure-objects/mappings/MappingRow.tsx
+++ b/src/components/InstallWizard/steps/configure-objects/mappings/MappingRow.tsx
@@ -27,17 +27,26 @@ export function MappingRow({
 }: MappingRowProps) {
   const selectedValue = configHandlers.getFieldMapping(mapping.mapToName) ?? "";
 
-  const items = useMemo(
-    () =>
-      customerFieldOptions
-        .map((f) => ({
-          id: f.fieldName,
-          label: f.displayName,
-          value: f.fieldName,
-        }))
-        .sort((a, b) => a.label.localeCompare(b.label)),
-    [customerFieldOptions],
-  );
+  const items = useMemo(() => {
+    const displayNameCounts = new Map<string, number>();
+    customerFieldOptions.forEach((f) => {
+      displayNameCounts.set(
+        f.displayName,
+        (displayNameCounts.get(f.displayName) ?? 0) + 1,
+      );
+    });
+    return customerFieldOptions
+      .map((f) => ({
+        id: f.fieldName,
+        label: f.displayName,
+        value: f.fieldName,
+        sublabel:
+          (displayNameCounts.get(f.displayName) ?? 0) > 1
+            ? f.fieldName
+            : undefined,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [customerFieldOptions]);
 
   return (
     <div className={styles.mappingRow}>

--- a/src/components/ui-base/ComboBox/ComboBox.tsx
+++ b/src/components/ui-base/ComboBox/ComboBox.tsx
@@ -8,6 +8,7 @@ interface Option {
   id: string;
   label: string;
   value: string;
+  sublabel?: string;
 }
 
 // Define the props for the ComboBox component
@@ -29,7 +30,8 @@ function getOptionsFilter(inputValue: string) {
     return (
       !inputValue ||
       option.label.toLowerCase().includes(lowerCasedInputValue) ||
-      option.value.toLowerCase().includes(lowerCasedInputValue)
+      option.value.toLowerCase().includes(lowerCasedInputValue) ||
+      !!option.sublabel?.toLowerCase().includes(lowerCasedInputValue)
     );
   };
 }
@@ -173,6 +175,9 @@ export function ComboBox({
               {...getItemProps({ item, index })}
             >
               <span>{item.label}</span>
+              {item.sublabel && (
+                <span className={styles.sublabel}>{item.sublabel}</span>
+              )}
             </li>
           ))}
       </ul>

--- a/src/components/ui-base/ComboBox/combobox.module.css
+++ b/src/components/ui-base/ComboBox/combobox.module.css
@@ -87,6 +87,11 @@
   font-weight: bold;
 }
 
+.sublabel {
+  color: var(--amp-text-secondary);
+  font-size: 0.75rem;
+}
+
 .hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
2 labels can be the same while the value is different. This UI change adds the value if there is duplicate labels. Keeps the rest as displayname to keep options uncrowded. 

- Alternative to #1584: only surface the API name when the field's display name actually collides with another field's display name in the same list.
- Unique labels render unchanged (no extra noise), duplicates show the API name as a muted secondary line so users can tell them apart.
- The sublabel is included in the ComboBox filter so users can also search by API name when a collision exists.

Applied at both field-mapping call sites: legacy `FieldMappingRow` (Configure) and InstallWizard `MappingRow`. Duplicate detection is a simple `Map<displayName, count>` pass over the field list, memoized alongside the existing items build.

Linear: [ENG-3843](https://linear.app/ampersand/issue/ENG-3843)

## Test plan
- [x] Salesforce integration with two fields sharing a label: both render with the API name underneath
- [x] Salesforce integration with a custom field whose label is unique: renders as just the label, no sublabel row
- [x] Typing the API name of a colliding field filters to the matching option

## only duplicate lable value shown
<img width="561" height="397" alt="Screenshot 2026-04-15 at 3 03 48 PM" src="https://github.com/user-attachments/assets/ce93b8cc-02a7-4a79-9249-5872e4b0dbdc" />

## show value for duplicate labels
<img width="529" height="369" alt="Screenshot 2026-04-15 at 3 03 41 PM" src="https://github.com/user-attachments/assets/ab110b27-c23c-4191-80bb-d21dbefbbe26" />

## also supports search by value if duplicate present
<img width="568" height="446" alt="Screenshot 2026-04-15 at 3 03 56 PM" src="https://github.com/user-attachments/assets/f9256330-8b44-448b-813a-c679026f8754" />
