### PR TITLE
[ENG-3724] feat(ConnectProvider): source Salesforce packageInstallURL from ProviderApp.metadata

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { MetadataItemInput } from "@generated/api/src";
+import { useProviderAppByProvider } from "src/hooks/query";
 import {
   AuthCardLayout,
   AuthTitle,
@@ -24,8 +25,11 @@ export function WorkspaceEntryContent({
   metadataInputs,
 }: WorkspaceEntryProps) {
   const isSalesforce = provider.startsWith("salesforce");
+  const { providerApp } = useProviderAppByProvider(
+    isSalesforce ? provider : undefined,
+  );
   const packageInstallUrl = isSalesforce
-    ? getPackageInstallUrl(metadataInputs)
+    ? getPackageInstallUrl(providerApp)
     : null;
   const [step, setStep] = useState<"install" | "authorize">(
     packageInstallUrl ? "install" : "authorize",

--- a/src/components/auth/PackageInstallBanner/getPackageInstallUrl.ts
+++ b/src/components/auth/PackageInstallBanner/getPackageInstallUrl.ts
@@ -1,23 +1,6 @@
-import { MetadataItemInput } from "@generated/api/src";
+import { ProviderApp } from "@generated/api/src";
 
-/**
- * // TODO: remove dummy URL and implement real logic after testing
- * Extracts a packageInstallUrl from metadata inputs.
- * The field may be present on any metadata item but is not yet in the generated types.
- * Returns the first non-empty URL found, or null.
- */
-export function getPackageInstallUrl(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _metadataInputs: MetadataItemInput[],
-): string | null {
-  // TODO: remove dummy URL and restore real logic after testing
-  // return "https://login.salesforce.com/packaging/installPackage.apexp?p0=04t000000000000";
-
-  // for (const item of metadataInputs) {
-  //   const url = (item as unknown as Record<string, unknown>).packageInstallUrl;
-  //   if (typeof url === "string" && url.length > 0) {
-  //     return url;
-  //   }
-  // }
-  return null;
+export function getPackageInstallUrl(providerApp?: ProviderApp): string | null {
+  const url = providerApp?.metadata?.providerParams?.packageInstallURL;
+  return typeof url === "string" && url.length > 0 ? url : null;
 }

--- a/src/components/auth/PackageInstallBanner/getPackageInstallUrl.ts
+++ b/src/components/auth/PackageInstallBanner/getPackageInstallUrl.ts
@@ -1,5 +1,25 @@
 import { ProviderApp } from "@generated/api/src";
 
+/**
+ * Reads the Salesforce managed-package install URL off the builder's
+ * ProviderApp. Used only for Salesforce External Client App providers, where
+ * a Salesforce admin must install a managed package into their org before the
+ * end-user can authorize the OAuth connection.
+ *
+ * Source: `ProviderApp.metadata.providerParams.packageInstallURL` — the
+ * per-project value the Ampersand customer (builder) sets in the dashboard
+ * when configuring their Salesforce ProviderApp. Not sourced from
+ * `ProviderInfo.metadata.input[]` (connection-level descriptors like workspace
+ * subdomain) or `ProviderInfo.providerAppMetadata` (catalog-level descriptors
+ * describing *which* fields to collect).
+ *
+ * Key casing matches the OpenAPI spec exactly: `packageInstallURL` (capital URL).
+ *
+ * Returns null when:
+ *   - No ProviderApp exists for this provider (platform-managed credentials).
+ *   - The builder left the URL blank.
+ *   - Any link in the chain (metadata, providerParams) is undefined.
+ */
 export function getPackageInstallUrl(providerApp?: ProviderApp): string | null {
   const url = providerApp?.metadata?.providerParams?.packageInstallURL;
   return typeof url === "string" && url.length > 0 ? url : null;

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -5,6 +5,7 @@ import { useListInstallationsQuery } from "./useListInstallationsQuery";
 import { useListProviderAppsQuery } from "./useListProviderAppsQuery";
 import { useOauthConnectQuery } from "./useOauthConnectQuery";
 import { useProjectQuery } from "./useProjectQuery";
+import { useProviderAppByProvider } from "./useProviderAppByProvider";
 
 export {
   useConnectionQuery,
@@ -14,4 +15,5 @@ export {
   useListProviderAppsQuery,
   useOauthConnectQuery,
   useProjectQuery,
+  useProviderAppByProvider,
 };

--- a/src/hooks/query/useProviderAppByProvider.ts
+++ b/src/hooks/query/useProviderAppByProvider.ts
@@ -1,0 +1,9 @@
+import { useListProviderAppsQuery } from "./useListProviderAppsQuery";
+
+export const useProviderAppByProvider = (provider?: string) => {
+  const { data, ...rest } = useListProviderAppsQuery();
+  const providerApp = provider
+    ? data?.find((app) => app.provider === provider)
+    : undefined;
+  return { providerApp, ...rest };
+};


### PR DESCRIPTION
## Summary
The Salesforce managed-package install step (merged in #1524 as a UI scaffold) was reading the install URL from the wrong source. `getPackageInstallUrl` was a stub. PR updates the business logic. 

- The install URL now flows from the **builder's `ProviderApp.metadata.providerParams.packageInstallURL`** — the value set per-project in the Ampersand dashboard.
- Adds `useProviderAppByProvider` selector hook (thin wrapper over `useListProviderAppsQuery`) so the component can look up its `ProviderApp` without a new API call.

## added a dummy url to dashboard for testing
<img width="1106" height="872" alt="salesforce-install-url" src="https://github.com/user-attachments/assets/5e1688e9-8b15-4ab7-86e8-b58ca480106c" />

## Test plan

### Dashboard setup (prerequisite)

1. Open the [Ampersand dashboard](https://dashboard.withampersand.com) → select your test project.
2. Go to **Providers** → **Salesforce** → **External Client App**.
3. Fill in (or pick an existing) ProviderApp:
   - Client ID, Client Secret, scopes — as usual for Salesforce External Client App.
   - Under **Provider-specific fields** (rendered from the `providerAppMetadata.providerParams` descriptor), set **Package install URL** to a real Salesforce managed package URL, e.g. `https://login.salesforce.com/packaging/installPackage.apexp?p0=04t<18-char-package-id>`.
4. Save. Confirm via the API that the value landed:
   ```bash
   curl -H "X-Api-Key: $AMP_API_KEY" \
     "https://api.withampersand.com/projects/$PROJECT/provider-apps" | jq '.[] | select(.provider=="salesforce") | .metadata.providerParams.packageInstallURL'
   ```

### Consumer-app checks (this PR)

- [x] **URL set → step renders with correct href.** Consumer app using `@amp-labs/react` (linked build of this branch, or local `yarn link`) renders `InstallIntegration` / `ConnectProvider` for Salesforce. The "Install Salesforce Package" button is visible on step 1. Inspect the DOM: `<a href>` matches the `packageInstallURL` you set in the dashboard exactly.
- [x] **Clicking the button** opens the Salesforce package install page in a new tab (`target="_blank"`, `rel="noopener noreferrer"`).
- [x] **"Already installed? Skip to authorization"** link jumps straight to step 2 (workspace/subdomain entry).
- [x] **URL cleared → step skipped.** Remove `packageInstallURL` from the ProviderApp in the dashboard, reload the consumer app. The install step should be skipped entirely; the flow opens on the workspace/subdomain entry screen.
- [x] **No ProviderApp → step skipped.** Switch to an Ampersand project that has no Salesforce ProviderApp configured (platform-managed credentials). Install step should not render.
- [x] **Non-Salesforce provider → no-op.** Connect HubSpot (or any non-Salesforce provider). `useProviderAppByProvider` is not called, no `PackageInstallStep` rendered.
- [x] **React Query caching.** DevTools → Network: `listProviderApps` fires once per project, not per component render.
