### PR TITLE
[ENG-3724] fix(WorkspaceEntry): show package install banner on initial render

### DIFF
--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
@@ -25,23 +25,27 @@ export function WorkspaceEntryContent({
   metadataInputs,
 }: WorkspaceEntryProps) {
   const isSalesforce = provider.startsWith("salesforce");
-  const { providerApp } = useProviderAppByProvider(
+  const { providerApp, isPending } = useProviderAppByProvider(
     isSalesforce ? provider : undefined,
   );
+  const [installDismissed, setInstallDismissed] = useState(false);
+
+  // Wait for the providerApp query before rendering — otherwise we'd flash the
+  // subdomain form then flip to the install banner once data arrives.
+  if (isSalesforce && isPending) return null;
+
   const packageInstallUrl = isSalesforce
     ? getPackageInstallUrl(providerApp)
     : null;
-  const [step, setStep] = useState<"install" | "authorize">(
-    packageInstallUrl ? "install" : "authorize",
-  );
+  const showInstallStep = !!packageInstallUrl && !installDismissed;
 
-  if (packageInstallUrl && step === "install") {
+  if (showInstallStep) {
     return (
       <AuthCardLayout>
         <PackageInstallStep
           packageInstallUrl={packageInstallUrl}
           providerName={providerName}
-          onSkip={() => setStep("authorize")}
+          onSkip={() => setInstallDismissed(true)}
         />
       </AuthCardLayout>
     );
@@ -52,7 +56,10 @@ export function WorkspaceEntryContent({
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
         <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
         {packageInstallUrl && (
-          <Stepper currentStep={2} onStepClick={() => setStep("install")} />
+          <Stepper
+            currentStep={2}
+            onStepClick={() => setInstallDismissed(false)}
+          />
         )}
         <AuthErrorAlert error={error} />
         {metadataInputs.map((metadata: MetadataItemInput) => (


### PR DESCRIPTION
## Summary
The package install url is not rendering the callout correctly. The root cause is a rendering issue where a useState was only showing the first render and not waiting for the package install url data. This fix simplifies the state rendering and makes the callout now derived instead of requiring state management.

- Replaced the `step` state with an `installDismissed` boolean and derive the current view each render from `packageInstallUrl + installDismissed`.
- Added an `isPending` early return (after all hook calls) for Salesforce only, to prevent a cold-cache flash where the form briefly shows before flipping to the install banner.

Follow-up to #1592.

<img width="1065" height="702" alt="Screenshot 2026-04-23 at 5 22 50 PM" src="https://github.com/user-attachments/assets/0a745bc5-338d-481b-9c11-f3753787547c" />

<img width="1178" height="788" alt="package-install-url-fix" src="https://github.com/user-attachments/assets/dcf1ec0c-f73d-45b6-8a83-7b089fe39c0c" />

## Test plan

- [x] Salesforce with `packageInstallURL` set in dashboard: install banner appears on first render in `../mailmonkey-v2`
- [x] Click "Skip" on banner → subdomain form appears with Stepper showing both steps
- [x] Click step 1 in Stepper → returns to install banner
- [x] Salesforce with no `packageInstallURL` set: flow goes directly to subdomain form, no Stepper
