### PR TITLE
[ENG-3836] style(DocsHelperTextHeader): move learn-more link into help section

### DIFF
--- a/src/components/Docs/DocsHelperTextMinimal.module.css
+++ b/src/components/Docs/DocsHelperTextMinimal.module.css
@@ -48,6 +48,13 @@
 }
 
 .promptWrapperExpanded {
-  max-height: 12rem;
+  max-height: 16rem;
   opacity: 1;
+}
+
+.learnMoreLink {
+  display: inline-block;
+  font-size: var(--amp-font-size-xs);
+  padding-top: var(--amp-space-1);
+  padding-bottom: var(--amp-space-2);
 }

--- a/src/components/Docs/DocsHelperTextMinimal.tsx
+++ b/src/components/Docs/DocsHelperTextMinimal.tsx
@@ -20,19 +20,13 @@ export function DocsHelperTextHeader({
 }: DocsHelperTextProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
+  const hasHelpContent = Boolean(prompt || url);
+
   return (
     <div>
       <p className={styles.header}>
-        <span>
-          {url ? (
-            <AccessibleLink href={url} newTab>
-              <span style={{ textDecoration: "underline" }}>{inputName}</span>
-            </AccessibleLink>
-          ) : (
-            <span>{inputName}</span>
-          )}
-        </span>
-        {prompt && (
+        <span>{inputName}</span>
+        {hasHelpContent && (
           <button
             type="button"
             onClick={() => setIsExpanded((prev) => !prev)}
@@ -49,13 +43,20 @@ export function DocsHelperTextHeader({
           </button>
         )}
       </p>
-      <div
-        className={classNames(styles.promptWrapper, {
-          [styles.promptWrapperExpanded]: isExpanded,
-        })}
-      >
-        {prompt && <MetadataPromptText prompt={prompt} />}
-      </div>
+      {hasHelpContent && (
+        <div
+          className={classNames(styles.promptWrapper, {
+            [styles.promptWrapperExpanded]: isExpanded,
+          })}
+        >
+          {prompt && <MetadataPromptText prompt={prompt} />}
+          {url && (
+            <AccessibleLink href={url} newTab className={styles.learnMoreLink}>
+              Learn more →
+            </AccessibleLink>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Moves the docsURL to be inside the collapsible section. 

- Title renders as plain text again — no more conditional underlined link in the label.
- Docs URL now appears as a `Learn more →` link **inside** the collapsible Help panel, below the prompt.

## Test plan
- [x] Metadata field with both `prompt` and `docsURL`: title is plain text; expanding Help shows prompt + `Learn more →` link; link opens docs in new tab.
- [ ] Metadata field with only `docsURL` (no prompt): Help toggle appears; expanding reveals just the link.
- [x] Metadata field with only `prompt` (no url): existing behavior preserved — toggle reveals just the prompt.
- [ ] Metadata field with neither: no Help toggle rendered.

<img width="1286" height="782" alt="learn-more-connect-provider" src="https://github.com/user-attachments/assets/f16474c7-f5a2-4369-a6dc-3ec882a658e4" />
