### PR TITLE
fix/style(DocsHelperText): inline learn-more link and fix focus outline clipping

### DIFF
--- a/src/components/Docs/DocsHelperTextMinimal.module.css
+++ b/src/components/Docs/DocsHelperTextMinimal.module.css
@@ -50,6 +50,10 @@
 .promptWrapperExpanded {
   max-height: 16rem;
   opacity: 1;
+  overflow: visible;
+  transition: max-height var(--amp-duration-normal) ease,
+    opacity var(--amp-duration-normal) ease,
+    overflow 0s var(--amp-duration-normal);
 }
 
 .learnMoreLink {

--- a/src/components/Docs/DocsHelperTextMinimal.tsx
+++ b/src/components/Docs/DocsHelperTextMinimal.tsx
@@ -49,11 +49,27 @@ export function DocsHelperTextHeader({
             [styles.promptWrapperExpanded]: isExpanded,
           })}
         >
-          {prompt && <MetadataPromptText prompt={prompt} />}
-          {url && (
-            <AccessibleLink href={url} newTab className={styles.learnMoreLink}>
-              Learn more →
-            </AccessibleLink>
+          {prompt ? (
+            <MetadataPromptText
+              prompt={prompt}
+              trailing={
+                url && (
+                  <AccessibleLink href={url} newTab>
+                    Learn more →
+                  </AccessibleLink>
+                )
+              }
+            />
+          ) : (
+            url && (
+              <AccessibleLink
+                href={url}
+                newTab
+                className={styles.learnMoreLink}
+              >
+                Learn more →
+              </AccessibleLink>
+            )
           )}
         </div>
       )}

--- a/src/components/Docs/MetadataPromptText.tsx
+++ b/src/components/Docs/MetadataPromptText.tsx
@@ -1,12 +1,17 @@
+import { ReactNode } from "react";
 import Markdown from "react-markdown";
 
 import styles from "./MetadataPromptText.module.css";
 
 type MetadataPromptTextProps = {
   prompt: string;
+  trailing?: ReactNode;
 };
 
-export function MetadataPromptText({ prompt }: MetadataPromptTextProps) {
+export function MetadataPromptText({
+  prompt,
+  trailing,
+}: MetadataPromptTextProps) {
   return (
     <div className={styles.container}>
       <Markdown
@@ -21,6 +26,7 @@ export function MetadataPromptText({ prompt }: MetadataPromptTextProps) {
       >
         {prompt}
       </Markdown>
+      {trailing ? <> {trailing}</> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
fix outline clipping

## before
<img width="610" height="481" alt="Screenshot 2026-04-24 at 2 31 17 PM" src="https://github.com/user-attachments/assets/c65210b0-3db8-4add-8313-2b993429452e" />


## after
<img width="615" height="256" alt="Screenshot 2026-04-24 at 2 30 25 PM" src="https://github.com/user-attachments/assets/13591cca-c407-483b-83a9-8d42cfd7a212" />

