### PR TITLE
[ENG-3882] fix(InstallWizard): land on correct sub-page when object has only mappings

### DIFF
--- a/src/components/InstallWizard/steps/configure-objects/fields/FieldsContent.tsx
+++ b/src/components/InstallWizard/steps/configure-objects/fields/FieldsContent.tsx
@@ -82,7 +82,8 @@ export function FieldsContent({
 
       {!hasFieldsContent && (
         <p className={styles.noFields}>
-          No configurable fields for {objectDisplayName}.
+          No configuration needed for {objectDisplayName}. Click Next to
+          continue.
         </p>
       )}
     </>

--- a/src/components/InstallWizard/steps/configure-objects/useSubPageNavigation.ts
+++ b/src/components/InstallWizard/steps/configure-objects/useSubPageNavigation.ts
@@ -22,8 +22,14 @@ export function useSubPageNavigation() {
 
   const { selectedObjects, currentObjectIndex } = state;
 
-  // Local sub-page state
-  const [subPage, setSubPage] = useState<SubPage>("fields");
+  // Local sub-page state — initialize from the manifest so we don't land on
+  // a sub-page the object doesn't have (e.g. "fields" when the object only
+  // has mappings).
+  const [subPage, setSubPage] = useState<SubPage>(() =>
+    currentObjectName
+      ? getInitialSubPage(manifest, currentObjectName)
+      : "fields",
+  );
   const pendingSubPageRef = useRef<SubPage | null>(null);
   const prevObjectNameRef = useRef(currentObjectName);
 


### PR DESCRIPTION
## Summary

### Problem: 
When there are no required fields, we see a page with no configuration. 

### Solution:
We have existing logic that shows which subpages we should have. We need to fix the hard coded first page to the first existing page. 

## before
notice there is no active dot, this page is should not be part of the flow
<img width="1101" height="701" alt="Screenshot 2026-04-27 at 6 26 11 PM" src="https://github.com/user-attachments/assets/ca515910-3010-4f1c-8d7b-a5db2c56716e" />

## after
first page is a field mapping.
<img width="1085" height="766" alt="Screenshot 2026-04-27 at 6 26 27 PM" src="https://github.com/user-attachments/assets/a4eff352-cd97-4d35-b970-c84b25119a54" />

## Test plan
- [x] Wizard opens on an object with only field mappings → lands on the **Mappings** tab, not the empty Fields tab.
- [x] Wizard opens on an object with required fields → still lands on **Fields** tab (existing behavior).
- [x] Wizard opens on an object with object-level mapping (`mapToName`) → still lands on **Fields** tab (existing behavior).
- [x] Navigating between objects with different sub-page shapes still resets correctly.
- [x] Backward navigation from a later object lands on the previous object's last sub-page.
- [x] `ObjectTabs` highlights the correct tab on initial render.

