### PR TITLE
fix(InstallWizard): show auto-discovered optional fields on Additional page

### DIFF
--- a/src/components/InstallWizard/steps/configure-objects/ConfigureObjectsStep.tsx
+++ b/src/components/InstallWizard/steps/configure-objects/ConfigureObjectsStep.tsx
@@ -96,16 +96,37 @@ export function ConfigureObjectsStep() {
     [configHandlers],
   );
 
-  const optionalFieldItems: CheckboxItem[] = useMemo(
-    () =>
-      optionalFields.map((field) => ({
-        id: getFieldName(field),
+  // Build the list of optional-field checkboxes shown on the Additional page.
+  // Merge explicit optionalFields (from amp.yaml) with auto-discovered customer
+  // fields (e.g. when amp.yaml uses `optionalFieldsAuto: all`). Explicit
+  // entries win on conflicts so the configured display name is preserved.
+  const optionalFieldItems: CheckboxItem[] = useMemo(() => {
+    const items: CheckboxItem[] = [];
+    const seen = new Set<string>();
+
+    optionalFields.forEach((field) => {
+      const fieldName = getFieldName(field);
+      if (!fieldName || seen.has(fieldName)) return;
+      seen.add(fieldName);
+      items.push({
+        id: fieldName,
         label: getFieldDisplayName(field),
-        isChecked:
-          configHandlers?.getSelectedField(getFieldName(field)) ?? false,
-      })),
-    [optionalFields, configHandlers],
-  );
+        isChecked: configHandlers?.getSelectedField(fieldName) ?? false,
+      });
+    });
+
+    Object.entries(customerFields).forEach(([fieldName, meta]) => {
+      if (!fieldName || seen.has(fieldName)) return;
+      seen.add(fieldName);
+      items.push({
+        id: fieldName,
+        label: meta.displayName || fieldName,
+        isChecked: configHandlers?.getSelectedField(fieldName) ?? false,
+      });
+    });
+
+    return items;
+  }, [optionalFields, customerFields, configHandlers]);
 
   // Check if all required mappings have been filled
   const requiredMappingsComplete = useMemo(

--- a/src/components/InstallWizard/steps/configure-objects/subPageUtils.ts
+++ b/src/components/InstallWizard/steps/configure-objects/subPageUtils.ts
@@ -60,9 +60,18 @@ export function getSubPages(manifest: Manifest, objectName: string): SubPage[] {
     (obj.getOptionalMapFields()?.length ?? 0) > 0;
   if (hasMappings) pages.push("mappings");
 
-  const hasOptionalFields =
+  // An object has optional fields to show on the "additional" page if it has
+  // an explicit optionalFields list OR if it has auto-discovered customer
+  // fields (e.g. from `optionalFieldsAuto: all` in amp.yaml). The latter
+  // surface via manifest.getCustomerFieldsForObject(...).allFields.
+  const hasExplicitOptionalFields =
     (obj.getOptionalFields("no-mappings")?.length ?? 0) > 0;
-  if (hasOptionalFields) pages.push("additional");
+  const hasAutoOptionalFields =
+    Object.keys(manifest.getCustomerFieldsForObject(objectName).allFields ?? {})
+      .length > 0;
+  if (hasExplicitOptionalFields || hasAutoOptionalFields) {
+    pages.push("additional");
+  }
 
   return pages.length > 0 ? pages : ["fields"];
 }

--- a/src/components/InstallWizard/steps/configure-objects/useSubPageNavigation.ts
+++ b/src/components/InstallWizard/steps/configure-objects/useSubPageNavigation.ts
@@ -53,11 +53,20 @@ export function useSubPageNavigation() {
     return required > 0 || optional > 0;
   }, [currentManifestObject]);
 
+  // Mirrors the check in getSubPages(): an object has an "additional" page if
+  // it has explicit optionalFields OR auto-discovered customer fields (e.g.
+  // from `optionalFieldsAuto: all`).
   const hasOptionalFields = useMemo(() => {
-    return (
-      (currentManifestObject?.getOptionalFields("no-mappings")?.length ?? 0) > 0
-    );
-  }, [currentManifestObject]);
+    const hasExplicit =
+      (currentManifestObject?.getOptionalFields("no-mappings")?.length ?? 0) >
+      0;
+    const hasAuto =
+      !!currentObjectName &&
+      Object.keys(
+        manifest.getCustomerFieldsForObject(currentObjectName).allFields ?? {},
+      ).length > 0;
+    return hasExplicit || hasAuto;
+  }, [currentManifestObject, manifest, currentObjectName]);
 
   const hasFieldsContent = useMemo(() => {
     const hasRequiredFields =


### PR DESCRIPTION
Closes #1599.

## Summary
- `getSubPages()` and `useSubPageNavigation` now consider an object to have optional fields when either the explicit `optionalFields` list OR the auto-discovered customer fields (from `optionalFieldsAuto: all`) are non-empty. Auto-discovered fields surface via `manifest.getCustomerFieldsForObject(objectName).allFields`.
- `optionalFieldItems` on the Additional page merges both sources, deduping by field name. Explicit `optionalFields` entries win on conflict so the `amp.yaml`-configured display names are preserved.

## Why
Before this change, an object whose `amp.yaml` declared only `optionalFieldsAuto: all` (no explicit `optionalFields`, no required fields, no mappings) would land on the empty Fields sub-page with "No configuration needed for X" — even though the user should have been able to pick from auto-discovered customer fields on the Additional sub-page.

## Test plan
- [ ] Object with only `optionalFieldsAuto: all` → wizard lands on **Additional fields**, all auto-discovered fields render as toggleable checkboxes.
- [ ] Object with explicit `optionalFields:` list → unchanged: lands on Additional, shows the explicit list.
- [ ] Object with both `optionalFields:` and `optionalFieldsAuto: all` → both render, explicit display names take precedence on duplicates.
- [ ] Object with only required fields (no optional, no auto) → unchanged: lands on Fields, no Additional tab.
- [ ] Object with only field mappings → unchanged from #1598: lands on Mappings.
- [ ] Genuinely empty object → unchanged: falls back to Fields with the "No configuration needed" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)