### PR TITLE
fix(InstallWizard): surface structured API errors on install creation

### DIFF
--- a/src/components/InstallWizard/steps/ReviewStep.tsx
+++ b/src/components/InstallWizard/steps/ReviewStep.tsx
@@ -8,6 +8,7 @@ import {
   useLocalConfig,
   useManifest,
 } from "src/headless";
+import { handleServerError } from "src/utils/handleServerError";
 
 import { StepHeader } from "../components/StepHeader";
 import { useWizard } from "../wizard/WizardContext";
@@ -102,7 +103,7 @@ export function ReviewStep() {
         nextStep();
       },
       onError: (error) => {
-        setSubmissionError(error.message);
+        handleServerError(error, setSubmissionError);
       },
     });
   }, [


### PR DESCRIPTION
## Summary
The error handling for createInstallation was not being deconstructed by the standardized handleServerError function. 

## before
<img width="1083" height="739" alt="Screenshot 2026-04-27 at 6 35 50 PM" src="https://github.com/user-attachments/assets/e7255785-1172-43d7-b238-4b077e534d43" />

## after
<img width="1065" height="810" alt="Screenshot 2026-04-27 at 6 35 32 PM" src="https://github.com/user-attachments/assets/bced80cb-79f4-4db7-8265-473f693c3bf7" />




