### PR TITLE
[ENG-3881] feat(ConnectProvider): make Salesforce subdomain optional

### DIFF
--- a/src/components/Configure/content/manage/AuthenticationSection.tsx
+++ b/src/components/Configure/content/manage/AuthenticationSection.tsx
@@ -1,3 +1,4 @@
+import { isSalesforceProvider } from "src/components/auth/Salesforce";
 import { useConnections } from "src/context/ConnectionsContextProvider";
 import { useProvider } from "src/hooks/useProvider";
 import { capitalize } from "src/utils";
@@ -23,7 +24,7 @@ function AuthenticationRow({
 export function AuthenticationSection() {
   const { selectedConnection } = useConnections();
   const { providerName } = useProvider();
-  const isSalesforce = selectedConnection?.provider === "salesforce";
+  const isSalesforce = isSalesforceProvider(selectedConnection?.provider);
   const workspaceString = isSalesforce ? "subdomain" : "workspace";
   const workspaceLabel = `${providerName} ${workspaceString}`;
 

--- a/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
@@ -205,7 +205,6 @@ export function OauthFlow2({
             isConnectionsFetching ||
             !!error
           }
-          provider={provider}
           providerName={providerName}
           metadataInputs={metadataInputs}
         />

--- a/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
@@ -10,6 +10,10 @@ import {
   isProviderMetadataValid,
   ProviderMetadata,
 } from "src/components/auth/providerMetadata";
+import {
+  isSalesforceProvider,
+  SalesforceLandingContent,
+} from "src/components/auth/Salesforce";
 import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider/AmpersandContextProvider";
 import { useCreateOauthConnectionMutation } from "src/hooks/mutation/useCreateOauthConnectionMutation";
 import { useConnectionsListQuery } from "src/hooks/query/useConnectionsListQuery";
@@ -62,6 +66,7 @@ export function OauthFlow2({
   const { projectIdOrName } = useAmpersandProviderProps();
   const queryClient = useQueryClient();
   const popupRef = useRef<Window | null>(null);
+  const isSalesforce = isSalesforceProvider(provider);
 
   // error state - initialize with moduleError if present
   const [error, setError] = useState<string | null>(moduleError || null);
@@ -123,8 +128,11 @@ export function OauthFlow2({
       console.debug("error with fetching connections");
     }
 
-    // Validate metadata fields if they exist
+    // Validate metadata fields if they exist.
+    // Salesforce treats workspace as optional (custom-domain disclosure), so
+    // skip the required-field check on the Salesforce path.
     if (
+      !isSalesforce &&
       metadataInputs.length > 0 &&
       !isProviderMetadataValid(metadataInputs, formData)
     ) {
@@ -166,6 +174,24 @@ export function OauthFlow2({
 
   // Determine which entry component to show based on provider and metadata
   const entryComponent = (() => {
+    // Salesforce: default to a no-workspace landing with an optional custom-domain
+    // disclosure. Workspace is optional — backend defaults to login.salesforce.com.
+    if (isSalesforce) {
+      return (
+        <SalesforceLandingContent
+          handleSubmit={handleSubmit}
+          setFormData={handleFormDataChange}
+          error={error}
+          isButtonDisabled={
+            isCreatingOauthConnection || isConnectionsFetching || !!error
+          }
+          provider={provider}
+          providerName={providerName}
+          metadataInputs={metadataInputs}
+        />
+      );
+    }
+
     // If there are metadata fields, show the workspace entry form
     if (metadataInputs.length > 0) {
       return (

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryContent.tsx
@@ -1,7 +1,4 @@
-import { useState } from "react";
 import { MetadataItemInput } from "@generated/api/src";
-import { isSalesforceProvider } from "src/components/auth/Salesforce";
-import { useProviderAppByProvider } from "src/hooks/query";
 import {
   AuthCardLayout,
   AuthTitle,
@@ -9,9 +6,6 @@ import {
 
 import { AuthErrorAlert } from "components/auth/AuthErrorAlert/AuthErrorAlert";
 import { MetadataInput } from "components/auth/MetadataInput";
-import { getPackageInstallUrl } from "components/auth/PackageInstallBanner/getPackageInstallUrl";
-import { PackageInstallStep } from "components/auth/PackageInstallBanner/PackageInstallStep";
-import { Stepper } from "components/auth/PackageInstallBanner/Stepper";
 import { Button } from "components/ui-base/Button";
 
 import { WorkspaceEntryProps } from "./WorkspaceEntryProps";
@@ -21,47 +15,13 @@ export function WorkspaceEntryContent({
   setFormData,
   error,
   isButtonDisabled,
-  provider,
   providerName,
   metadataInputs,
 }: WorkspaceEntryProps) {
-  const isSalesforce = isSalesforceProvider(provider);
-  const { providerApp, isPending } = useProviderAppByProvider(
-    isSalesforce ? provider : undefined,
-  );
-  const [installDismissed, setInstallDismissed] = useState(false);
-
-  // Wait for the providerApp query before rendering — otherwise we'd flash the
-  // subdomain form then flip to the install banner once data arrives.
-  if (isSalesforce && isPending) return null;
-
-  const packageInstallUrl = isSalesforce
-    ? getPackageInstallUrl(providerApp)
-    : null;
-  const showInstallStep = !!packageInstallUrl && !installDismissed;
-
-  if (showInstallStep) {
-    return (
-      <AuthCardLayout>
-        <PackageInstallStep
-          packageInstallUrl={packageInstallUrl}
-          providerName={providerName}
-          onSkip={() => setInstallDismissed(true)}
-        />
-      </AuthCardLayout>
-    );
-  }
-
   return (
     <AuthCardLayout>
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
         <AuthTitle>{`Set up ${providerName} integration`}</AuthTitle>
-        {packageInstallUrl && (
-          <Stepper
-            currentStep={2}
-            onStepClick={() => setInstallDismissed(false)}
-          />
-        )}
         <AuthErrorAlert error={error} />
         {metadataInputs.map((metadata: MetadataItemInput) => (
           <MetadataInput

--- a/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryProps.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/WorkspaceEntry/WorkspaceEntryProps.tsx
@@ -5,7 +5,6 @@ export type WorkspaceEntryProps = {
   setFormData: (metadata: string, value: string) => void;
   error: string | null;
   isButtonDisabled?: boolean;
-  provider: string;
   providerName?: string;
   metadataInputs: MetadataItemInput[];
 };

--- a/src/components/auth/Salesforce/SalesforceLanding.module.css
+++ b/src/components/auth/Salesforce/SalesforceLanding.module.css
@@ -1,0 +1,46 @@
+.disclosure {
+  border: 1px solid var(--amp-border-default);
+  border-radius: var(--amp-radius-md);
+  padding: 0;
+  background: var(--amp-surface-secondary);
+}
+
+.summary {
+  cursor: pointer;
+  list-style: none;
+  padding: var(--amp-space-3) var(--amp-space-4);
+  font-size: var(--amp-font-size-sm);
+  color: var(--amp-text-primary);
+  display: flex;
+  align-items: center;
+  gap: var(--amp-space-2);
+  user-select: none;
+}
+
+.summary::-webkit-details-marker {
+  display: none;
+}
+
+.summary::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid var(--amp-text-muted);
+  transition: transform var(--amp-duration-fast) ease;
+}
+
+.disclosure[open] > .summary::before {
+  transform: rotate(90deg);
+}
+
+.summary:focus-visible {
+  outline: 2px solid var(--amp-colors-focus-border);
+  outline-offset: 2px;
+  border-radius: var(--amp-radius-sm);
+}
+
+.body {
+  padding: 0 var(--amp-space-4) var(--amp-space-4);
+}

--- a/src/components/auth/Salesforce/SalesforceLandingContent.tsx
+++ b/src/components/auth/Salesforce/SalesforceLandingContent.tsx
@@ -80,7 +80,7 @@ export function SalesforceLandingContent({
         {workspaceInput && (
           <details className={styles.disclosure}>
             <summary className={styles.summary}>
-              Sign in with a custom domain
+              Use My Domain (advanced)
             </summary>
             <div className={styles.body}>
               <MetadataInput

--- a/src/components/auth/Salesforce/SalesforceLandingContent.tsx
+++ b/src/components/auth/Salesforce/SalesforceLandingContent.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { MetadataItemInput } from "@generated/api/src";
-import { isSalesforceProvider } from "src/components/auth/Salesforce";
 import { useProviderAppByProvider } from "src/hooks/query";
 import {
   AuthCardLayout,
+  AuthDescription,
   AuthTitle,
 } from "src/layout/AuthCardLayout/AuthCardLayout";
 
@@ -14,9 +14,21 @@ import { PackageInstallStep } from "components/auth/PackageInstallBanner/Package
 import { Stepper } from "components/auth/PackageInstallBanner/Stepper";
 import { Button } from "components/ui-base/Button";
 
-import { WorkspaceEntryProps } from "./WorkspaceEntryProps";
+import { SALESFORCE_WORKSPACE_FIELD } from "./salesforce";
 
-export function WorkspaceEntryContent({
+import styles from "./SalesforceLanding.module.css";
+
+export type SalesforceLandingContentProps = {
+  handleSubmit: () => void;
+  setFormData: (key: string, value: string) => void;
+  error: string | null;
+  isButtonDisabled?: boolean;
+  provider: string;
+  providerName?: string;
+  metadataInputs: MetadataItemInput[];
+};
+
+export function SalesforceLandingContent({
   handleSubmit,
   setFormData,
   error,
@@ -24,20 +36,15 @@ export function WorkspaceEntryContent({
   provider,
   providerName,
   metadataInputs,
-}: WorkspaceEntryProps) {
-  const isSalesforce = isSalesforceProvider(provider);
-  const { providerApp, isPending } = useProviderAppByProvider(
-    isSalesforce ? provider : undefined,
-  );
+}: SalesforceLandingContentProps) {
+  const { providerApp, isPending } = useProviderAppByProvider(provider);
   const [installDismissed, setInstallDismissed] = useState(false);
 
   // Wait for the providerApp query before rendering — otherwise we'd flash the
-  // subdomain form then flip to the install banner once data arrives.
-  if (isSalesforce && isPending) return null;
+  // landing then flip to the install banner once data arrives.
+  if (isPending) return null;
 
-  const packageInstallUrl = isSalesforce
-    ? getPackageInstallUrl(providerApp)
-    : null;
+  const packageInstallUrl = getPackageInstallUrl(providerApp);
   const showInstallStep = !!packageInstallUrl && !installDismissed;
 
   if (showInstallStep) {
@@ -52,6 +59,10 @@ export function WorkspaceEntryContent({
     );
   }
 
+  const workspaceInput = metadataInputs.find(
+    (item) => item.name === SALESFORCE_WORKSPACE_FIELD,
+  );
+
   return (
     <AuthCardLayout>
       <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
@@ -62,23 +73,35 @@ export function WorkspaceEntryContent({
             onStepClick={() => setInstallDismissed(false)}
           />
         )}
+        <AuthDescription>
+          {`Click Next to sign into the ${providerName} account you'd like to sync.`}
+        </AuthDescription>
         <AuthErrorAlert error={error} />
-        {metadataInputs.map((metadata: MetadataItemInput) => (
-          <MetadataInput
-            key={metadata.name}
-            metadata={metadata}
-            onChange={(event) =>
-              setFormData(metadata.name, event.currentTarget.value)
-            }
-          />
-        ))}
+        {workspaceInput && (
+          <details className={styles.disclosure}>
+            <summary className={styles.summary}>
+              Sign in with a custom domain
+            </summary>
+            <div className={styles.body}>
+              <MetadataInput
+                metadata={workspaceInput}
+                onChange={(event) =>
+                  setFormData(
+                    SALESFORCE_WORKSPACE_FIELD,
+                    event.currentTarget.value,
+                  )
+                }
+              />
+            </div>
+          </details>
+        )}
         <Button
           style={{ width: "100%" }}
           disabled={isButtonDisabled}
           type="submit"
           onClick={handleSubmit}
         >
-          Next
+          {isButtonDisabled && !error ? "Loading..." : "Next"}
         </Button>
       </div>
     </AuthCardLayout>

--- a/src/components/auth/Salesforce/index.ts
+++ b/src/components/auth/Salesforce/index.ts
@@ -1,0 +1,8 @@
+export {
+  SALESFORCE_PROVIDERS,
+  SALESFORCE_WORKSPACE_FIELD,
+  isSalesforceProvider,
+} from "./salesforce";
+export type { SalesforceProvider } from "./salesforce";
+export { SalesforceLandingContent } from "./SalesforceLandingContent";
+export type { SalesforceLandingContentProps } from "./SalesforceLandingContent";

--- a/src/components/auth/Salesforce/salesforce.ts
+++ b/src/components/auth/Salesforce/salesforce.ts
@@ -1,0 +1,15 @@
+export const SALESFORCE_PROVIDERS = [
+  "salesforce",
+  "salesforceSandbox",
+] as const;
+export type SalesforceProvider = (typeof SALESFORCE_PROVIDERS)[number];
+
+export function isSalesforceProvider(
+  provider: string | undefined | null,
+): provider is SalesforceProvider {
+  return (
+    !!provider && (SALESFORCE_PROVIDERS as readonly string[]).includes(provider)
+  );
+}
+
+export const SALESFORCE_WORKSPACE_FIELD = "workspace";


### PR DESCRIPTION
## Summary
The Salesforce workspace is optional in the OAuth endpoint. This PR updates the UX so that ConnectProvider also allows this interaction.

<img width="810" height="786" alt="ConnectProvider-Optional-Salesforce-domain" src="https://github.com/user-attachments/assets/7935efd2-97fe-4121-bd9a-26f85f330da9" />


- Salesforce OAuth in `ConnectProvider` now defaults to `login.salesforce.com` — no subdomain prompt by default. The `providerWorkspaceRef` field is already optional in the OAuth Connect endpoint.
- End users can still enter a subdomain via a "Sign in with a custom domain" `<details>` disclosure on the OAuth landing, for orgs whose admins have disabled `login.salesforce.com`.
- Salesforce-specific UI logic is now grouped 

Slack context: https://ampersand-company.slack.com/archives/C082KPRN4R4/p1777064901047689

**note**: This PR does not include testing for UpdateConnection. 

## Test plan
- [x] Salesforce in a consumer app: default landing shows "Next" + collapsed disclosure → popup opens against `login.salesforce.com`
- [x] Expand disclosure, enter `acme` → popup opens against `https://acme.my.salesforce.com/...`; verify `providerWorkspaceRef=acme` in the `/oauth-connect` request
- [x] Expand disclosure, leave empty, click Next → behaves as default (no `providerWorkspaceRef` sent)
- [x] Salesforce sandbox provider — same UX; existing sandbox connection now shows "subdomain" label in `AuthenticationSection`
- [x] Org with package install URL configured — package install step still renders before the new landing
- [x] Non-Salesforce providers with workspace metadata — `WorkspaceEntryContent` unchanged