### PR TITLE
[ENG-2451] build(oauth): use projectIdOrName on /oauth-connect

### DIFF
--- a/generated-sources/api/src/models/OauthConnectRequest.ts
+++ b/generated-sources/api/src/models/OauthConnectRequest.ts
@@ -27,11 +27,11 @@ import {
  */
 export interface OauthConnectRequest {
     /**
-     * The Ampersand project ID.
+     * The Ampersand project ID or project name.
      * @type {string}
      * @memberof OauthConnectRequest
      */
-    projectId: string;
+    projectIdOrName: string;
     /**
      * The provider that this app connects to.
      * @type {string}
@@ -93,7 +93,7 @@ export interface OauthConnectRequest {
  */
 export function instanceOfOauthConnectRequest(value: object): boolean {
     let isInstance = true;
-    isInstance = isInstance && "projectId" in value;
+    isInstance = isInstance && "projectIdOrName" in value;
     isInstance = isInstance && "provider" in value;
     isInstance = isInstance && "groupRef" in value;
     isInstance = isInstance && "consumerRef" in value;
@@ -111,7 +111,7 @@ export function OauthConnectRequestFromJSONTyped(json: any, ignoreDiscriminator:
     }
     return {
         
-        'projectId': json['projectId'],
+        'projectIdOrName': json['projectIdOrName'],
         'provider': json['provider'],
         'groupRef': json['groupRef'],
         'groupName': !exists(json, 'groupName') ? undefined : json['groupName'],
@@ -133,7 +133,7 @@ export function OauthConnectRequestToJSON(value?: OauthConnectRequest | null): a
     }
     return {
         
-        'projectId': value.projectId,
+        'projectIdOrName': value.projectIdOrName,
         'provider': value.provider,
         'groupRef': value.groupRef,
         'groupName': value.groupName,

--- a/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
@@ -10,8 +10,8 @@ import {
   isProviderMetadataValid,
   ProviderMetadata,
 } from "src/components/auth/providerMetadata";
+import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider/AmpersandContextProvider";
 import { useCreateOauthConnectionMutation } from "src/hooks/mutation/useCreateOauthConnectionMutation";
-import { useProjectQuery } from "src/hooks/query";
 import { useConnectionsListQuery } from "src/hooks/query/useConnectionsListQuery";
 import { AMP_SERVER } from "src/services/api";
 
@@ -59,7 +59,7 @@ export function OauthFlow2({
   metadataInputs,
   moduleError,
 }: OauthFlowProps) {
-  const { projectId } = useProjectQuery();
+  const { projectIdOrName } = useAmpersandProviderProps();
   const queryClient = useQueryClient();
   const popupRef = useRef<Window | null>(null);
 
@@ -138,7 +138,7 @@ export function OauthFlow2({
           provider,
           consumerRef,
           groupRef,
-          projectId: projectId || "", // todo - update to use projectIdOrName
+          projectIdOrName,
           consumerName,
           groupName,
           providerWorkspaceRef: metadata?.workspace?.value,

--- a/src/hooks/query/useOauthConnectQuery.ts
+++ b/src/hooks/query/useOauthConnectQuery.ts
@@ -13,13 +13,14 @@ export const useOauthConnectQuery = (request: OauthConnectRequest) => {
     queryKey: [
       "amp",
       "oauthConnect",
-      request.projectId,
+      request.projectIdOrName,
       request.groupRef,
       request.consumerRef,
       request.provider,
     ],
     queryFn: async () => {
-      if (!request.projectId) throw new Error("Project ID is required");
+      if (!request.projectIdOrName)
+        throw new Error("Project ID or Name is required");
       if (!request?.providerAppId)
         throw new Error("Provider App ID is required");
       if (!request?.provider) throw new Error("Provider is required");


### PR DESCRIPTION
## Summary
OAuth connect previously only supported projectId, we update to use projectIdorName.

- Regenerate the API SDK after [amp-labs/openapi#354](https://github.com/amp-labs/openapi/pull/354) — the `/oauth-connect` request body now uses `projectIdOrName` instead of `projectId`.
- Update `useOauthConnectQuery` and `OauthFlow2` to the new field name.
- Pull `projectIdOrName` directly from `useAmpersandProviderProps()` instead of resolving the UUID via `useProjectQuery()` first — removes an unnecessary fetch dependency from the OAuth flow.
- Pairs with backend [amp-labs/server#3839](https://github.com/amp-labs/server/pull/3839).

The regenerated SDK also picks up unrelated `providerInfo` subscribe-support changes that already merged in [amp-labs/openapi#352](https://github.com/amp-labs/openapi/pull/352).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `yarn lint` clean (0 errors)
- [x] Manual end-to-end: configure `AmpersandProvider` with a project **name** (not UUID), trigger an OAuth flow via `OauthFlow2`, verify the `POST /oauth-connect` body contains `projectIdOrName` and the connection is created
- [x] Repeat with a project UUID to confirm both forms still work

