### PR TITLE
fix(InstallWizard): reassure users when read is disabled but subscribe is active

### DIFF
--- a/src/components/Configure/content/fields/ReEnableReadObject.tsx
+++ b/src/components/Configure/content/fields/ReEnableReadObject.tsx
@@ -7,6 +7,7 @@ import { useInstallation } from "src/headless/installation/useInstallation";
 import { useSelectedConfigureState } from "../useSelectedConfigureState";
 import { useSelectedObject } from "../useSelectedObject";
 
+import { SubscribeStillActiveBox } from "./SubscribeStillActiveBox";
 import { useToggleReadingObject } from "./useToggleReadingObject";
 
 export function ReEnableReadObject() {
@@ -18,6 +19,9 @@ export function ReEnableReadObject() {
   // Only show if read object is present and disabled
   const readObject = selectedObjectName
     ? installation?.config?.content?.read?.objects?.[selectedObjectName]
+    : undefined;
+  const subscribeObject = selectedObjectName
+    ? installation?.config?.content?.subscribe?.objects?.[selectedObjectName]
     : undefined;
   if (!readObject) return null;
 
@@ -86,6 +90,14 @@ export function ReEnableReadObject() {
             : `Re-enable reading from ${selectedObjectDisplayName}`}
         </Button>
       </FormCalloutBox>
+      {subscribeObject && (
+        <SubscribeStillActiveBox
+          subscribeObject={subscribeObject}
+          objectDisplayName={
+            selectedObjectDisplayName ?? selectedObjectName ?? ""
+          }
+        />
+      )}
     </>
   );
 }

--- a/src/components/Configure/content/fields/SubscribeStillActiveBox.tsx
+++ b/src/components/Configure/content/fields/SubscribeStillActiveBox.tsx
@@ -1,0 +1,70 @@
+import { SubscribeConfigObject } from "@generated/api/src";
+import { CheckCircledIcon } from "@radix-ui/react-icons";
+import { FormSuccessBox } from "src/components/FormSuccessBox";
+
+interface SubscribeStillActiveBoxProps {
+  subscribeObject: SubscribeConfigObject;
+  objectDisplayName: string;
+}
+
+function getSubscribedEventLabels(
+  subscribeObject: SubscribeConfigObject,
+): string[] {
+  const labels: string[] = [];
+  if (subscribeObject.createEvent) labels.push("Created");
+  if (subscribeObject.updateEvent) labels.push("Updated");
+  if (subscribeObject.deleteEvent) labels.push("Deleted");
+  if (subscribeObject.otherEvents?.length)
+    labels.push(...subscribeObject.otherEvents);
+  return labels;
+}
+
+export function SubscribeStillActiveBox({
+  subscribeObject,
+  objectDisplayName,
+}: SubscribeStillActiveBoxProps) {
+  const events = getSubscribedEventLabels(subscribeObject);
+
+  return (
+    <FormSuccessBox style={{ marginTop: "0.75rem" }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+        }}
+      >
+        <CheckCircledIcon
+          style={{
+            width: "16px",
+            height: "16px",
+            flexShrink: 0,
+          }}
+        />
+        <span style={{ fontWeight: 600 }}>
+          Event subscriptions are still active
+        </span>
+      </div>
+      <p style={{ marginTop: "0.5rem", fontSize: "0.875rem" }}>
+        You&apos;ll continue to receive <b>{objectDisplayName}</b> events even
+        though reading is disabled.
+      </p>
+      {events.length > 0 && (
+        <p style={{ marginTop: "0.25rem", fontSize: "0.875rem" }}>
+          <span style={{ fontWeight: 600 }}>Subscribed events: </span>
+          {events.join(", ")}
+        </p>
+      )}
+      <p
+        style={{
+          marginTop: "0.5rem",
+          fontSize: "0.75rem",
+          opacity: 0.75,
+        }}
+      >
+        This reflects configured subscriptions and does not confirm event
+        delivery.
+      </p>
+    </FormSuccessBox>
+  );
+}


### PR DESCRIPTION
## Summary

- When an integration has both read and subscribe configured for the same object, clicking **Stop reading from [Object]** now renders a follow-up success panel beneath the existing red callout, confirming that event subscriptions are still active and listing the subscribed events.
- The panel is gated on `installation.config.content.read.objects[X].disabled === true` AND `installation.config.content.subscribe?.objects?.[X]` being defined, so non-subscribe integrations and read-only objects are unchanged.
- No backend changes, no new public/headless API. Pure FE addition; reflects `amp.yaml` configuration, not delivery telemetry (footnote discloses this).

### Why

A customer (Outreach) reported their end users believed the integration was broken after disabling read on a subscribe-only setup — the UI showed only "Reading is currently disabled. This object is not being synced." with no acknowledgment that events were still flowing.

### Files

- **New** `src/components/Configure/content/fields/SubscribeStillActiveBox.tsx` — presentational panel, lists `createEvent`/`updateEvent`/`deleteEvent`/`otherEvents` from `SubscribeConfigObject`.
- **Modified** `src/components/Configure/content/fields/ReEnableReadObject.tsx` — reads subscribe config for selected object, renders the panel only when both gating conditions hold.

## Test plan

- [ ] **Read+subscribe object, read disabled** → red "Reading is currently disabled" callout still renders, new green "Event subscriptions are still active" panel renders below it with the correct event list.
- [ ] **Read-only object (no subscribe), read disabled** → only the existing red callout renders. No regression.
- [ ] **Subscribe-only integration, no read** → `ReEnableReadObject` early-returns `null` (existing behavior); panel never mounts.
- [ ] **Read enabled** → only the existing green "Reading from X is enabled" success box renders.
- [ ] `yarn lint` clean (0 errors; pre-existing warnings only).
- [ ] `yarn build` passes (tsc + vite + dts).
- [ ] Visually verify event list ordering and copy match design expectations.

## Out of scope / follow-ups

- First-class subscribe support in the library (own tab, toggle, headless API). This PR is a targeted fix for the customer-reported confusion only.
- Live event-delivery telemetry (`lastEventAt`, webhook health). Requires backend work.
- Parallel reassurance for `InstalledSuccessBox` when an integration is subscribe-only and skips the wizard entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)