### PR TITLE
[ENG-4083, ENG-4077] fix(ApiKeyAuth): add persistent label to API key field

### DIFF
--- a/src/components/Docs/DocsHelperTextMinimal.tsx
+++ b/src/components/Docs/DocsHelperTextMinimal.tsx
@@ -55,7 +55,7 @@ export function DocsHelperTextHeader({
               trailing={
                 url && (
                   <AccessibleLink href={url} newTab>
-                    Learn more →
+                    learn more →
                   </AccessibleLink>
                 )
               }
@@ -67,7 +67,7 @@ export function DocsHelperTextHeader({
                 newTab
                 className={styles.learnMoreLink}
               >
-                Learn more →
+                learn more →
               </AccessibleLink>
             )
           )}

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -94,7 +94,7 @@ export function ApiKeyAuthForm({
         <FormComponent.PasswordInput
           id="apiKey"
           name="apiKey"
-          placeholder="API Key"
+          placeholder="Paste your API key here"
           onChange={handleChange}
         />
       </div>

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -61,6 +61,7 @@ export function ApiKeyAuthForm({
   const isSubmitDisabled =
     isButtonDisabled || !isApiKeyValid || !isMetadataValid;
   const docsURL = providerInfo.apiKeyOpts?.docsURL;
+  const providerDisplayName = providerName || capitalize(provider);
 
   const onHandleSubmit = () => {
     const metadata = getProviderMetadata(metadataInputs, formData);
@@ -83,7 +84,12 @@ export function ApiKeyAuthForm({
       <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
         <DocsHelperTextHeader
           url={docsURL}
-          inputName={`${providerName || capitalize(provider)} API Key`}
+          inputName={`${providerDisplayName} API Key`}
+          prompt={
+            docsURL
+              ? `Where to find your ${providerDisplayName} API key:`
+              : undefined
+          }
         />
         <FormComponent.PasswordInput
           id="apiKey"

--- a/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
+++ b/src/components/auth/ApiKeyAuth/ApiKeyAuthContent.tsx
@@ -11,7 +11,7 @@ import {
 import { capitalize } from "src/utils";
 
 import { MetadataInput } from "components/auth/MetadataInput";
-import { DocsHelperText } from "components/Docs/DocsHelperText";
+import { DocsHelperTextHeader } from "components/Docs/DocsHelperTextMinimal";
 
 import {
   getProviderMetadata,
@@ -80,19 +80,18 @@ export function ApiKeyAuthForm({
         marginTop: "1rem",
       }}
     >
-      {docsURL && (
-        <DocsHelperText
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+        <DocsHelperTextHeader
           url={docsURL}
-          providerDisplayName={providerName || capitalize(provider)}
-          credentialName="API key"
+          inputName={`${providerName || capitalize(provider)} API Key`}
         />
-      )}
-      <FormComponent.PasswordInput
-        id="apiKey"
-        name="apiKey"
-        placeholder="API Key"
-        onChange={handleChange}
-      />
+        <FormComponent.PasswordInput
+          id="apiKey"
+          name="apiKey"
+          placeholder="API Key"
+          onChange={handleChange}
+        />
+      </div>
       {metadataInputs.map((metadata: MetadataItemInput) => (
         <MetadataInput
           key={metadata.name}


### PR DESCRIPTION
## Context

Customer feedback: in the API key connection flow, it's unclear that the input field is for an API key. The field previously had **only a placeholder** (`placeholder="API Key"`) and no persistent label — so the only indication disappeared as soon as the user typed, focused the field, or a password manager pre-filled it.

## Change

Render the API key field with the **same UI as the metadata inputs** in the same form — wrapping a `DocsHelperTextHeader` above the `PasswordInput`, mirroring `MetadataInput`:

- Persistent **"{Provider} API Key"** header (e.g. "Salesforce API Key") above the field.
- The provider's `docsURL` is folded into the header's "Help" expander (omitted automatically when there's no docs URL), replacing the old always-visible "Learn more about where to find your {provider} API key." text.

The edit is in the shared `ApiKeyAuthForm`, so it covers **both** API key flows:
- Initial setup (`ApiKeyAuthContent`)
- Update/manage connection (`UpdateApiKeyConnect`)

## Verification

- Manual check: confirm the "{Provider} API Key" header renders above the password input styled like the metadata headers; the "Help" expander reveals the docs link when a `docsURL` exists and is omitted otherwise; the header persists on focus/typing; and the same header appears in the update-connection flow.

<img width="706" height="390" alt="updated-api-key-ux" src="https://github.com/user-attachments/assets/7d0d6559-26d9-4e23-a11c-3431e7edca25" />

