### PR TITLE
[ENG-4158]feat: show displayName for nested objects

### DIFF
--- a/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
+++ b/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { HydratedIntegrationFieldExistent } from "services/api";
-import { isIntegrationFieldMapping } from "src/utils/manifest";
+import {
+  getFieldDisplayName,
+  isIntegrationFieldMapping,
+} from "src/utils/manifest";
 
 import {
   CheckboxItem,
@@ -35,8 +38,9 @@ export function OptionalFieldsV2() {
             "displayName" in field,
         )
         .map((field) => ({
+          // id stays the provider field name: it is the key used in the config
           id: field.fieldName,
-          label: field.displayName,
+          label: getFieldDisplayName(field),
           isChecked: !!selectedOptionalFields?.[field.fieldName],
         }))
         .sort((a, b) => a.label.localeCompare(b.label)) || [],

--- a/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
+++ b/src/components/Configure/content/fields/OptionalFields/OptionalFieldsV2.tsx
@@ -38,7 +38,6 @@ export function OptionalFieldsV2() {
             "displayName" in field,
         )
         .map((field) => ({
-          // id stays the provider field name: it is the key used in the config
           id: field.fieldName,
           label: getFieldDisplayName(field),
           isChecked: !!selectedOptionalFields?.[field.fieldName],

--- a/src/components/Configure/content/fields/RequiredFields.tsx
+++ b/src/components/Configure/content/fields/RequiredFields.tsx
@@ -1,4 +1,3 @@
-import { HydratedIntegrationFieldExistent } from "services/api";
 import { useManifest } from "src/headless";
 import { useProjectQuery } from "src/hooks/query";
 import {
@@ -41,19 +40,12 @@ export function RequiredFields() {
         }}
       >
         {requiredFields?.length
-          ? requiredFields
-              .filter(
-                (field): field is HydratedIntegrationFieldExistent =>
-                  !isIntegrationFieldMapping(field),
-              )
-              // the server sorts by its own displayName, which is not what we
-              // render, so re-sort by the label the user actually sees
-              .sort((a, b) =>
-                getFieldDisplayName(a).localeCompare(getFieldDisplayName(b)),
-              )
-              .map((field) => (
+          ? requiredFields.map((field) => {
+              if (isIntegrationFieldMapping(field)) return null;
+              return (
                 <Tag key={field.fieldName}>{getFieldDisplayName(field)}</Tag>
-              ))
+              );
+            })
           : "There are no required fields."}
       </div>
     </>

--- a/src/components/Configure/content/fields/RequiredFields.tsx
+++ b/src/components/Configure/content/fields/RequiredFields.tsx
@@ -1,6 +1,10 @@
+import { HydratedIntegrationFieldExistent } from "services/api";
 import { useManifest } from "src/headless";
 import { useProjectQuery } from "src/hooks/query";
-import { isIntegrationFieldMapping } from "src/utils/manifest";
+import {
+  getFieldDisplayName,
+  isIntegrationFieldMapping,
+} from "src/utils/manifest";
 
 import { Tag } from "components/ui-base/Tag";
 
@@ -37,10 +41,19 @@ export function RequiredFields() {
         }}
       >
         {requiredFields?.length
-          ? requiredFields.map((field) => {
-              if (isIntegrationFieldMapping(field)) return null;
-              return <Tag key={field.fieldName}>{field.displayName}</Tag>;
-            })
+          ? requiredFields
+              .filter(
+                (field): field is HydratedIntegrationFieldExistent =>
+                  !isIntegrationFieldMapping(field),
+              )
+              // the server sorts by its own displayName, which is not what we
+              // render, so re-sort by the label the user actually sees
+              .sort((a, b) =>
+                getFieldDisplayName(a).localeCompare(getFieldDisplayName(b)),
+              )
+              .map((field) => (
+                <Tag key={field.fieldName}>{getFieldDisplayName(field)}</Tag>
+              ))
           : "There are no required fields."}
       </div>
     </>

--- a/src/components/InstallWizard/steps/ReviewStep.tsx
+++ b/src/components/InstallWizard/steps/ReviewStep.tsx
@@ -9,6 +9,7 @@ import {
   useManifest,
 } from "src/headless";
 import { handleServerError } from "src/utils/handleServerError";
+import { getFieldDisplayName } from "src/utils/manifest";
 
 import { StepHeader } from "../components/StepHeader";
 import { useWizard } from "../wizard/WizardContext";
@@ -34,7 +35,7 @@ export function ReviewStep() {
         manifestObj?.getRequiredFields("no-mappings") ?? []
       )
         .filter((f) => "fieldName" in f)
-        .map((f) => ("fieldName" in f ? f.displayName || f.fieldName : ""));
+        .map(getFieldDisplayName);
 
       // Selected optional fields
       const selectedOptionalFields = (
@@ -44,7 +45,7 @@ export function ReviewStep() {
           const fieldName = "fieldName" in f ? f.fieldName : "";
           return fieldName && configObj?.getSelectedField(fieldName);
         })
-        .map((f) => ("fieldName" in f ? f.displayName || f.fieldName : ""));
+        .map(getFieldDisplayName);
 
       // Configured field mappings (source → destination)
       const allMapFields = [

--- a/src/components/InstallWizard/steps/configure-objects/ConfigureObjectsStep.tsx
+++ b/src/components/InstallWizard/steps/configure-objects/ConfigureObjectsStep.tsx
@@ -3,6 +3,7 @@ import { useInstallIntegrationProps } from "context/InstallIIntegrationContextPr
 import { useLocalConfig, useManifest } from "src/headless";
 import { useProjectQuery } from "src/hooks/query/useProjectQuery";
 import { useProvider } from "src/hooks/useProvider";
+import { getFieldDisplayName } from "src/utils/manifest";
 
 import type { CheckboxItem } from "components/ui-base/Checkbox/CheckboxPagination";
 
@@ -13,7 +14,7 @@ import { AdditionalFieldsContent } from "./additional/AdditionalFieldsContent";
 import { FieldsContent } from "./fields/FieldsContent";
 import { MappingsContent } from "./mappings/MappingsContent";
 import { ObjectTabs } from "./ObjectTabs";
-import { getFieldDisplayName, getFieldName } from "./subPageUtils";
+import { getFieldName } from "./subPageUtils";
 import { useSubPageNavigation } from "./useSubPageNavigation";
 
 import styles from "./configureObjectsStep.module.css";

--- a/src/components/InstallWizard/steps/configure-objects/fields/FieldsContent.tsx
+++ b/src/components/InstallWizard/steps/configure-objects/fields/FieldsContent.tsx
@@ -1,8 +1,9 @@
 import type { HydratedIntegrationField } from "@generated/api/src";
 import { ArrowRightIcon, WidthIcon } from "@radix-ui/react-icons";
+import { getFieldDisplayName } from "src/utils/manifest";
 
 import { SectionHeader } from "../../../components/SectionHeader";
-import { getFieldDisplayName, getFieldName } from "../subPageUtils";
+import { getFieldName } from "../subPageUtils";
 
 import sharedStyles from "../configureObjectsStep.module.css";
 import styles from "./fieldsContent.module.css";

--- a/src/components/InstallWizard/steps/configure-objects/subPageUtils.ts
+++ b/src/components/InstallWizard/steps/configure-objects/subPageUtils.ts
@@ -14,10 +14,6 @@ export function getFieldName(field: HydratedIntegrationField): string {
   return isExistentField(field) ? field.fieldName : "";
 }
 
-// Label resolution is shared with the non-wizard Configure view, so that a
-// builder's mapToName/mapToDisplayName wins in both UIs.
-export { getFieldDisplayName } from "src/utils/manifest";
-
 /**
  * Determine the initial sub-page for an object based on what data it has.
  */

--- a/src/components/InstallWizard/steps/configure-objects/subPageUtils.ts
+++ b/src/components/InstallWizard/steps/configure-objects/subPageUtils.ts
@@ -14,10 +14,9 @@ export function getFieldName(field: HydratedIntegrationField): string {
   return isExistentField(field) ? field.fieldName : "";
 }
 
-export function getFieldDisplayName(field: HydratedIntegrationField): string {
-  if (isExistentField(field)) return field.displayName || field.fieldName;
-  return "";
-}
+// Label resolution is shared with the non-wizard Configure view, so that a
+// builder's mapToName/mapToDisplayName wins in both UIs.
+export { getFieldDisplayName } from "src/utils/manifest";
 
 /**
  * Determine the initial sub-page for an object based on what data it has.

--- a/src/utils/manifest.test.ts
+++ b/src/utils/manifest.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "@jest/globals";
+import type {
+  HydratedIntegrationFieldExistent,
+  IntegrationFieldMapping,
+} from "@generated/api/src";
+
+import { getFieldDisplayName, isIntegrationFieldMapping } from "./manifest";
+
+describe("isIntegrationFieldMapping", () => {
+  it("treats a field without fieldName as a mapping", () => {
+    expect(isIntegrationFieldMapping({ mapToName: "priority" })).toBe(true);
+  });
+
+  it("treats a field with fieldName as an existent field", () => {
+    expect(
+      isIntegrationFieldMapping({ fieldName: "email", displayName: "Email" }),
+    ).toBe(false);
+  });
+});
+
+describe("getFieldDisplayName", () => {
+  describe("existent fields", () => {
+    it("uses the provider displayName when the builder defined no mapping", () => {
+      const field: HydratedIntegrationFieldExistent = {
+        fieldName: "email",
+        displayName: "Email",
+      };
+
+      expect(getFieldDisplayName(field)).toBe("Email");
+    });
+
+    it("falls back to fieldName when there is no displayName", () => {
+      const field = {
+        fieldName: "estimate_number",
+        displayName: "",
+      } as HydratedIntegrationFieldExistent;
+
+      expect(getFieldDisplayName(field)).toBe("estimate_number");
+    });
+
+    // The reported bug. A nested field has no provider metadata, so the server
+    // hydrates displayName as TitleCase(fieldName) and the raw path renders.
+    it("prefers mapToDisplayName over a JSONPath displayName", () => {
+      const field: HydratedIntegrationFieldExistent = {
+        fieldName: "$['Customer']['Email']",
+        displayName: "$['Customer']['Email']",
+        mapToName: "customer_email",
+        mapToDisplayName: "Customer Email",
+      };
+
+      expect(getFieldDisplayName(field)).toBe("Customer Email");
+    });
+
+    it("uses mapToName for a nested field when mapToDisplayName is absent", () => {
+      const field: HydratedIntegrationFieldExistent = {
+        fieldName: "$['Customer']['First_name']",
+        displayName: "$['Customer']['First_name']",
+        mapToName: "customer_first_name",
+      };
+
+      expect(getFieldDisplayName(field)).toBe("customer_first_name");
+    });
+
+    // Per the feature request, builder-defined names win even when the field is
+    // not nested and the provider supplied a perfectly good display name.
+    it("prefers mapToDisplayName over a usable provider displayName", () => {
+      const field: HydratedIntegrationFieldExistent = {
+        fieldName: "firstname",
+        displayName: "First Name",
+        mapToName: "customer_first_name",
+        mapToDisplayName: "Customer First Name",
+      };
+
+      expect(getFieldDisplayName(field)).toBe("Customer First Name");
+    });
+
+    it("prefers mapToName over a usable provider displayName", () => {
+      const field: HydratedIntegrationFieldExistent = {
+        fieldName: "phone",
+        displayName: "Business Phone",
+        mapToName: "customer_phone",
+      };
+
+      expect(getFieldDisplayName(field)).toBe("customer_phone");
+    });
+  });
+
+  describe("field mappings", () => {
+    it("uses mapToDisplayName when present", () => {
+      const field: IntegrationFieldMapping = {
+        mapToName: "priority",
+        mapToDisplayName: "Priority",
+      };
+
+      expect(getFieldDisplayName(field)).toBe("Priority");
+    });
+
+    it("falls back to mapToName", () => {
+      const field: IntegrationFieldMapping = { mapToName: "priority" };
+
+      expect(getFieldDisplayName(field)).toBe("priority");
+    });
+  });
+});

--- a/src/utils/manifest.test.ts
+++ b/src/utils/manifest.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from "@jest/globals";
 import type {
   HydratedIntegrationFieldExistent,
   IntegrationFieldMapping,
 } from "@generated/api/src";
+import { describe, expect, it } from "@jest/globals";
 
 import { getFieldDisplayName, isIntegrationFieldMapping } from "./manifest";
 

--- a/src/utils/manifest.test.ts
+++ b/src/utils/manifest.test.ts
@@ -51,18 +51,18 @@ describe("getFieldDisplayName", () => {
       expect(getFieldDisplayName(field)).toBe("Customer Email");
     });
 
-    it("uses mapToName for a nested field when mapToDisplayName is absent", () => {
+    // displayName outranks mapToName, and the server always populates it, so a
+    // nested field needs mapToDisplayName to render a readable label.
+    it("falls back to displayName when mapToDisplayName is absent", () => {
       const field: HydratedIntegrationFieldExistent = {
         fieldName: "$['Customer']['First_name']",
         displayName: "$['Customer']['First_name']",
         mapToName: "customer_first_name",
       };
 
-      expect(getFieldDisplayName(field)).toBe("customer_first_name");
+      expect(getFieldDisplayName(field)).toBe("$['Customer']['First_name']");
     });
 
-    // Per the feature request, builder-defined names win even when the field is
-    // not nested and the provider supplied a perfectly good display name.
     it("prefers mapToDisplayName over a usable provider displayName", () => {
       const field: HydratedIntegrationFieldExistent = {
         fieldName: "firstname",
@@ -74,14 +74,14 @@ describe("getFieldDisplayName", () => {
       expect(getFieldDisplayName(field)).toBe("Customer First Name");
     });
 
-    it("prefers mapToName over a usable provider displayName", () => {
+    it("prefers the provider displayName over mapToName", () => {
       const field: HydratedIntegrationFieldExistent = {
         fieldName: "phone",
         displayName: "Business Phone",
         mapToName: "customer_phone",
       };
 
-      expect(getFieldDisplayName(field)).toBe("customer_phone");
+      expect(getFieldDisplayName(field)).toBe("Business Phone");
     });
   });
 

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -16,6 +16,35 @@ export function isIntegrationFieldMapping(
 }
 
 /**
+ * Returns the label to show for a field in the read UI.
+ *
+ * Names the builder defined in amp.yaml (mapToDisplayName, then mapToName) take
+ * precedence over the provider's own displayName, for two reasons:
+ *
+ * 1. A nested field has no provider metadata for its path, so the server falls
+ *    back to TitleCase(fieldName) and the raw JSONPath leaks into the UI
+ *    (e.g. "$['Customer']['Email']").
+ * 2. Even when the provider's name is good, the end user is configuring what
+ *    lands in the builder's product, so the builder's naming is what they
+ *    recognize.
+ *
+ * @param field HydratedIntegrationField
+ * @returns string
+ */
+export function getFieldDisplayName(field: HydratedIntegrationField): string {
+  if (isIntegrationFieldMapping(field)) {
+    return field.mapToDisplayName || field.mapToName;
+  }
+
+  return (
+    field.mapToDisplayName ||
+    field.mapToName ||
+    field.displayName ||
+    field.fieldName
+  );
+}
+
+/**
  * Returns the required existent fields from an object (mappings excluded).
  * For required mapping fields use getRequiredMapFieldsFromObject.
  *

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -32,15 +32,15 @@ export function isIntegrationFieldMapping(
  * @returns string
  */
 export function getFieldDisplayName(field: HydratedIntegrationField): string {
-  if (isIntegrationFieldMapping(field)) {
-    return field.mapToDisplayName || field.mapToName;
-  }
+  // displayName and fieldName only exist on HydratedIntegrationFieldExistent.
+  // On an IntegrationFieldMapping they are undefined and get skipped.
+  const existent = field as HydratedIntegrationFieldExistent;
 
   return (
     field.mapToDisplayName ||
+    existent.displayName ||
     field.mapToName ||
-    field.displayName ||
-    field.fieldName
+    existent.fieldName
   );
 }
 

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -18,15 +18,16 @@ export function isIntegrationFieldMapping(
 /**
  * Returns the label to show for a field in the read UI.
  *
- * Names the builder defined in amp.yaml (mapToDisplayName, then mapToName) take
- * precedence over the provider's own displayName, for two reasons:
+ * Precedence: mapToDisplayName > displayName > mapToName > fieldName.
  *
- * 1. A nested field has no provider metadata for its path, so the server falls
- *    back to TitleCase(fieldName) and the raw JSONPath leaks into the UI
- *    (e.g. "$['Customer']['Email']").
- * 2. Even when the provider's name is good, the end user is configuring what
- *    lands in the builder's product, so the builder's naming is what they
- *    recognize.
+ * mapToDisplayName wins so a builder can give a nested field a readable label.
+ * The provider has no metadata for a nested path, so the server falls back to
+ * TitleCase(fieldName) and the raw JSONPath would otherwise show, e.g.
+ * "$['Customer']['Email']".
+ *
+ * displayName sits above mapToName so a provider's own label is preferred over a
+ * builder's machine name. Note the server always populates displayName, so
+ * mapToName is only reached for an IntegrationFieldMapping, which has none.
  *
  * @param field HydratedIntegrationField
  * @returns string


### PR DESCRIPTION
## What does this change do?
* Read-field labels now prefer the builder's `mapToDisplayName` from `amp.yaml` over the provider's `displayName`.
* Nested fields have no provider metadata for their path, so the server falls back to `TitleCase(fieldName)` — as a result users saw `$['Customer']['Email']`.
* New shared `getFieldDisplayName()` in `src/utils/manifest.ts`, precedence: `mapToDisplayName → displayName → mapToName → fieldName`
* Used in the Configure view (`RequiredFields`, `OptionalFieldsV2`) and the InstallWizard (`FieldsContent`, `ConfigureObjectsStep`, `ReviewStep`).
* `subPageUtils` loses its local copy of `getFieldDisplayName`; its two consumers now import the shared helper directly.

## Testing
- Added new unit tests.
- Manual E2E: deployed a Housecall Pro `estimates` integration, verified in the MailMonkey demo app against a local build.
  - before: `$['Customer']['Email']`, `$['Customer']['First_name']`, 
 
<img width="1153" height="816" alt="Screenshot 2026-07-30 at 15 25 18" src="https://github.com/user-attachments/assets/a3bfd349-579d-47c0-b168-c6258eb8aa13" />
<img width="927" height="962" alt="Screenshot 2026-07-30 at 17 19 52" src="https://github.com/user-attachments/assets/ee888929-6bc9-4c9e-b1ba-db80eb989e28" />


  - after: `Customer Email`, `Customer First Name`, `customer_home_number`, …
<img width="1183" height="933" alt="Screenshot 2026-07-30 at 17 00 25" src="https://github.com/user-attachments/assets/574da8b5-9aa9-46e8-a496-4096f506fbdc" />
<img width="873" height="952" alt="Screenshot 2026-07-30 at 17 28 16" src="https://github.com/user-attachments/assets/c5fe1581-ea4d-4dc9-bff3-b4c1481f7b04" />


- Test integration was:
```
{
  "name": "hcpReadTest",
  "provider": "housecallPro",
  "displayName": "HCP Read Test",
  "read": {
    "objects": [
      {
        "objectName": "estimates",
        "destination": "test-webhook",
        "schedule": "0 * * * *",
        "mapToName": "estimate",
        "mapToDisplayName": "Estimate",
        "requiredFields": [
          {
            "fieldName": "id"
          },
          {
            "fieldName": "status"
          },
          {
            "fieldName": "$['customer']['email']",
            "mapToName": "customer_email",
            "mapToDisplayName": "Customer Email"
          },
          {
            "fieldName": "$['customer']['home_number']",
            "mapToName": "customer_home_number"
          },
          {
            "fieldName": "$['customer']['work_number']"
          },
          {
            "fieldName": "company_name",
            "mapToName": "hatch_company",
            "mapToDisplayName": "Hatch Company"
          },
          {
            "fieldName": "work_status",
            "mapToName": "hatch_work_status"
          },
          {
            "mapToName": "hatch_priority",
            "mapToDisplayName": "Priority",
            "prompt": "Which Housecall Pro field tracks priority?"
          },
          {
            "mapToName": "hatch_source",
            "prompt": "Which Housecall Pro field records the lead source?"
          }
        ],
        "optionalFields": [
          {
            "fieldName": "lead_source"
          },
          {
            "fieldName": "estimate_number",
            "mapToName": "hatch_estimate_number",
            "mapToDisplayName": "Hatch Estimate Number"
          },
          {
            "fieldName": "address",
            "mapToName": "hatch_address"
          },
          {
            "mapToName": "hatch_optional_tag",
            "mapToDisplayName": "Optional Tag",
            "prompt": "Which field holds an optional tag?"
          }
        ]
      },
      {
        "objectName": "customers",
        "destination": "test-webhook",
        "schedule": "0 * * * *",
        "requiredFields": [
          {
            "fieldName": "id"
          },
          {
            "fieldName": "email"
          }
        ],
        "optionalFields": [
          {
            "mapToName": "hatch_customer_tier",
            "mapToDisplayName": "Customer Tier",
            "prompt": "Which field records the customer tier?"
          }
        ],
        "optionalFieldsAuto": "all"
      }
    ]
  }
}```

