### PR TITLE
docs: fix broken documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ yarn add @amp-labs/react @chakra-ui/react @emotion/react @emotion/styled framer-
 
 ## Usage
 
-Please visit [our documentation](https://docs.withampersand.com/v1.0/docs/embeddable-ui-components) to learn more about how to use this library.
+Please visit [our documentation](https://docs.withampersand.com/embeddable-ui-components) to learn more about how to use this library.
 
 ### Changes with 2.0
 In addition to importing components, the default stylesheet must also be imported. You may also override 


### PR DESCRIPTION
The "Usage" section links to
https://docs.withampersand.com/v1.0/docs/embeddable-ui-components which returns 404.

The /v1.0/docs/ path prefix predates the docs migration to Mintlify, which serves the page at the bare path. The rest of the repo already uses the current form, e.g. src/headless/config/useConfigHelper.tsx links to /write-actions and generated-sources links to /embeddable-ui-components.

Updated to https://docs.withampersand.com/embeddable-ui-components (verified 200). This was the only /v1.0/docs/ reference left in the repo.

Two other documentation links also 404, but they are left alone here because they live in generated SDK code and would be overwritten by the next regeneration -- they likely need fixing in the OpenAPI spec upstream:

  https://docs.withampersand.com/reference/oauth/get-url-for-oauth-flow
    generated-sources/api/src/apis/ConnectionApi.ts:118,129,289,327

  https://docs.withampersand.com/reference/provider-apps/create-provider-app
    generated-sources/api/src/models/OauthConnectRequest.ts:78

All other docs.withampersand.com links in the repo were checked and resolve: /cli/overview, /embeddable-ui-components, /headless, /write-actions, /reference/connection/list-connections and /reference/oauth/generate-oauth-authorization-url.


