### PR TITLE
[CON-3514] adding region parameter

### DIFF
--- a/src/components/auth/CustomAuth/MultiStep/MultiStepCustomAuthFlow.tsx
+++ b/src/components/auth/CustomAuth/MultiStep/MultiStepCustomAuthFlow.tsx
@@ -7,7 +7,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider";
 import { useCustomAuthConnectMutation } from "src/hooks/mutation/useCustomAuthConnectMutation";
-import { AMP_SERVER } from "src/services/api";
+import { getAmpServer } from "src/services/api";
 import { handleServerError } from "src/utils/handleServerError";
 
 import { CustomAuthFlowProps } from "../CustomAuthFlowProps";
@@ -85,7 +85,7 @@ export function MultiStepCustomAuthFlow({
   useEffect(() => {
     const onMessage = (ev: MessageEvent<CustomAuthCallbackMessage>) => {
       // Accept only messages from the API origin (where the callback is served).
-      if (ev.origin !== AMP_SERVER) return;
+      if (ev.origin !== getAmpServer()) return;
       if (ev.data?.source !== CALLBACK_MESSAGE_SOURCE) return;
 
       const sessionId = sessionIdRef.current;

--- a/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/windowHelpers.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OAuthWindow/windowHelpers.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { AMP_SERVER } from "services/api";
+import { getAmpServer } from "services/api";
 
 const DEFAULT_WIDTH = 600; // px
 const DEFAULT_HEIGHT = 600; // px
@@ -53,7 +53,7 @@ export function useReceiveMessageEventHandler(
   return useCallback(
     (event: MessageEvent) => {
       // Ignore messages from unexpected origins
-      if (event.origin !== AMP_SERVER) {
+      if (event.origin !== getAmpServer()) {
         return;
       }
 

--- a/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
+++ b/src/components/auth/Oauth/AuthorizationCode/OauthFlow2/OauthFlow2.tsx
@@ -17,7 +17,7 @@ import {
 import { useAmpersandProviderProps } from "src/context/AmpersandContextProvider/AmpersandContextProvider";
 import { useCreateOauthConnectionMutation } from "src/hooks/mutation/useCreateOauthConnectionMutation";
 import { useConnectionsListQuery } from "src/hooks/query/useConnectionsListQuery";
-import { AMP_SERVER } from "src/services/api";
+import { getAmpServer } from "src/services/api";
 
 import { enableCSRFProtection } from "../enableCSRFprotection";
 import { NoWorkspaceEntryContent } from "../NoWorkspaceEntry/NoWorkspaceEntryContent";
@@ -90,7 +90,7 @@ export function OauthFlow2({
   useEffect(() => {
     const onMessage = (ev: MessageEvent<AuthEvent>) => {
       // Accept only events from *your* popup origin
-      if (ev.origin !== AMP_SERVER) return;
+      if (ev.origin !== getAmpServer()) return;
 
       if (ev.data?.eventType === "AUTHORIZATION_SUCCEEDED") {
         setError(null);

--- a/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
+++ b/src/context/AmpersandContextProvider/AmpersandContextProvider.tsx
@@ -8,6 +8,7 @@
 import React, { createContext, useContext } from "react";
 import { ResponseError } from "@generated/api/src";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { setAmpersandRegion } from "src/services/apiEndpoint";
 
 import { ApiKeyProvider } from "../ApiKeyContextProvider";
 import { ErrorStateProvider } from "../ErrorContextProvider";
@@ -37,6 +38,22 @@ interface AmpersandProviderProps {
       consumerRef: string;
       groupRef: string;
     }) => Promise<string>;
+  };
+  children: React.ReactNode;
+}
+
+/**
+ * Internal props that extend the public options with the region option.
+ * This is not exported from the public API.
+ */
+interface AmpersandProviderInternalProps {
+  options: AmpersandProviderProps["options"] & {
+    /**
+     * Routes every API request to a regional endpoint, e.g. "eu" for
+     * https://api.eu.withampersand.com. Defaults to the global endpoint.
+     * Ignored when REACT_APP_AMP_SERVER is set.
+     */
+    region?: string;
   };
   children: React.ReactNode;
 }
@@ -83,9 +100,14 @@ const queryClient = new QueryClient({
 
 export function AmpersandProvider(props: AmpersandProviderProps) {
   const {
-    options: { apiKey, projectId, project, getToken },
+    options: { apiKey, projectId, project, getToken, region },
     children,
-  } = props;
+  } = props as AmpersandProviderInternalProps;
+
+  // Set during render, not in an effect: children fire API requests from their own effects,
+  // which run before the parent's, so an effect here would land after the first request.
+  setAmpersandRegion(region);
+
   const projectIdOrName = project || projectId;
   if (projectId && project) {
     throw new Error(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -30,6 +30,7 @@ import { useApiKey } from "src/context/ApiKeyContextProvider";
 import { useJwtToken } from "src/context/JwtTokenContextProvider";
 import { useInstallationProps } from "src/headless/InstallationProvider";
 
+import { getAmpersandRegion, resolveApiEndpoint } from "./apiEndpoint";
 import { ApiService } from "./ApiService";
 import { LIB_VERSION } from "./version";
 
@@ -46,44 +47,23 @@ import { LIB_VERSION } from "./version";
  *
  * */
 const VERSION = "v1";
-const prodEndpoint = "https://api.withampersand.com";
-
-function getApiEndpoint(): string {
-  try {
-    const ENV_SERVER = process.env.REACT_APP_AMP_SERVER;
-    switch (ENV_SERVER) {
-      case "local":
-        return "http://localhost:8080";
-      case "dev":
-        return "https://dev-api.withampersand.com";
-      case "staging":
-        return "https://staging-api.withampersand.com";
-      case "prod":
-        return prodEndpoint;
-      case "mock":
-        return "http://127.0.0.1:4010";
-      case "":
-        return prodEndpoint;
-      default:
-        // The user may provide an arbitrary URL here if they want to, or else the
-        // default prod url will be used.
-        return ENV_SERVER ?? prodEndpoint;
-    }
-  } catch {
-    return prodEndpoint;
-  }
-}
 
 const getApiRoot = (server: string, version: string): string =>
   `${server}/${version}`;
 
-// REACT_APP_AMP_SERVER=local npm start will use the local server
-function assignRoot(): string {
-  return getApiRoot(getApiEndpoint(), VERSION);
-}
+/**
+ * The API server origin, e.g. "https://api.withampersand.com". Resolved on every call because
+ * the region (set by AmpersandProvider) is not known at module load time.
+ *
+ * REACT_APP_AMP_SERVER=local npm start will use the local server.
+ */
+export const getAmpServer = (): string =>
+  resolveApiEndpoint(getAmpersandRegion());
 
-export const AMP_SERVER = getApiEndpoint();
-export const AMP_API_ROOT = assignRoot();
+/**
+ * The versioned API root used as the SDK basePath, e.g. "https://api.withampersand.com/v1".
+ */
+export const getAmpApiRoot = (): string => getApiRoot(getAmpServer(), VERSION);
 
 /**
  * we can modify the authentication, baseURL and other configurations to access
@@ -94,7 +74,7 @@ export const AMP_API_ROOT = assignRoot();
  * */
 
 const config = new Configuration({
-  basePath: AMP_API_ROOT,
+  basePath: getAmpApiRoot(),
   headers: {
     "X-Amp-Client": "react",
     "X-Amp-Client-Version": LIB_VERSION,
@@ -133,7 +113,7 @@ const createJwtAuth = (token: string) => {
 
 const createAuthConfig = (authHeader: string, authValue: string) =>
   new Configuration({
-    basePath: AMP_API_ROOT,
+    basePath: getAmpApiRoot(),
     headers: {
       "X-Amp-Client": "react",
       "X-Amp-Client-Version": LIB_VERSION,

--- a/src/services/apiEndpoint.test.ts
+++ b/src/services/apiEndpoint.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+import {
+  getAmpersandRegion,
+  PROD_ENDPOINT,
+  resolveApiEndpoint,
+  setAmpersandRegion,
+} from "./apiEndpoint";
+
+const ENV_KEY = "REACT_APP_AMP_SERVER";
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+  setAmpersandRegion(undefined);
+  jest.restoreAllMocks();
+});
+
+describe("resolveApiEndpoint", () => {
+  it("defaults to the global prod endpoint", () => {
+    expect(resolveApiEndpoint()).toBe(PROD_ENDPOINT);
+  });
+
+  it("maps the eu region to the eu endpoint", () => {
+    expect(resolveApiEndpoint("eu")).toBe("https://api.eu.withampersand.com");
+  });
+
+  it("ignores casing and surrounding whitespace in the region", () => {
+    expect(resolveApiEndpoint(" EU ")).toBe("https://api.eu.withampersand.com");
+  });
+
+  it("falls back to the prod endpoint for an unknown region", () => {
+    const error = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(resolveApiEndpoint("mars")).toBe(PROD_ENDPOINT);
+    expect(error).toHaveBeenCalled();
+  });
+
+  it("lets REACT_APP_AMP_SERVER take priority over the region", () => {
+    process.env[ENV_KEY] = "staging";
+    expect(resolveApiEndpoint("eu")).toBe(
+      "https://staging-api.withampersand.com",
+    );
+  });
+
+  it("lets an arbitrary REACT_APP_AMP_SERVER url take priority over the region", () => {
+    process.env[ENV_KEY] = "https://my-tunnel.example.com";
+    expect(resolveApiEndpoint("eu")).toBe("https://my-tunnel.example.com");
+  });
+
+  it("applies the region when REACT_APP_AMP_SERVER is empty", () => {
+    process.env[ENV_KEY] = "";
+    expect(resolveApiEndpoint("eu")).toBe("https://api.eu.withampersand.com");
+  });
+
+  it("resolves the documented env values", () => {
+    const cases: Array<[string, string]> = [
+      ["local", "http://localhost:8080"],
+      ["dev", "https://dev-api.withampersand.com"],
+      ["staging", "https://staging-api.withampersand.com"],
+      ["prod", PROD_ENDPOINT],
+      ["mock", "http://127.0.0.1:4010"],
+    ];
+
+    cases.forEach(([env, expected]) => {
+      process.env[ENV_KEY] = env;
+      expect(resolveApiEndpoint()).toBe(expected);
+    });
+  });
+});
+
+describe("region store", () => {
+  it("round-trips the region set by AmpersandProvider", () => {
+    expect(getAmpersandRegion()).toBeUndefined();
+    setAmpersandRegion("eu");
+    expect(getAmpersandRegion()).toBe("eu");
+    expect(resolveApiEndpoint(getAmpersandRegion())).toBe(
+      "https://api.eu.withampersand.com",
+    );
+  });
+});

--- a/src/services/apiEndpoint.test.ts
+++ b/src/services/apiEndpoint.test.ts
@@ -33,10 +33,33 @@ describe("resolveApiEndpoint", () => {
     expect(resolveApiEndpoint(" EU ")).toBe(PROD_EU_ENDPOINT);
   });
 
-  it("falls back to the prod endpoint for an unknown region", () => {
+  it("falls back to the us endpoint for an unknown region", () => {
     const error = jest.spyOn(console, "error").mockImplementation(() => {});
     expect(resolveApiEndpoint("mars")).toBe(PROD_US_ENDPOINT);
     expect(error).toHaveBeenCalled();
+  });
+
+  it("does not resolve inherited object keys to an endpoint", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    ["constructor", "__proto__", "toString", "valueOf", "hasOwnProperty"].forEach(
+      (key) => {
+        expect(resolveApiEndpoint(key)).toBe(PROD_US_ENDPOINT);
+      },
+    );
+  });
+
+  it("falls back instead of throwing for a non-string region", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    [123, true, {}, [], () => {}, Symbol("eu")].forEach((value) => {
+      expect(resolveApiEndpoint(value)).toBe(PROD_US_ENDPOINT);
+    });
+  });
+
+  it("treats null and whitespace-only as unset, without logging", () => {
+    const error = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(resolveApiEndpoint(null)).toBe(PROD_US_ENDPOINT);
+    expect(resolveApiEndpoint("   ")).toBe(PROD_US_ENDPOINT);
+    expect(error).not.toHaveBeenCalled();
   });
 
   it("lets REACT_APP_AMP_SERVER take priority over the region", () => {
@@ -73,6 +96,14 @@ describe("resolveApiEndpoint", () => {
 });
 
 describe("region store", () => {
+  it("stores only a known region, and drops an invalid one", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    setAmpersandRegion("mars");
+    expect(getAmpersandRegion()).toBeUndefined();
+    setAmpersandRegion(" EU ");
+    expect(getAmpersandRegion()).toBe("eu");
+  });
+
   it("round-trips the region set by AmpersandProvider", () => {
     expect(getAmpersandRegion()).toBeUndefined();
     setAmpersandRegion("eu");

--- a/src/services/apiEndpoint.test.ts
+++ b/src/services/apiEndpoint.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it, jest } from "@jest/globals";
 
 import {
   getAmpersandRegion,
-  PROD_ENDPOINT,
+  PROD_EU_ENDPOINT,
+  PROD_US_ENDPOINT,
   resolveApiEndpoint,
   setAmpersandRegion,
 } from "./apiEndpoint";
@@ -17,20 +18,24 @@ afterEach(() => {
 
 describe("resolveApiEndpoint", () => {
   it("defaults to the global prod endpoint", () => {
-    expect(resolveApiEndpoint()).toBe(PROD_ENDPOINT);
+    expect(resolveApiEndpoint()).toBe(PROD_US_ENDPOINT);
   });
 
   it("maps the eu region to the eu endpoint", () => {
-    expect(resolveApiEndpoint("eu")).toBe("https://api.eu.withampersand.com");
+    expect(resolveApiEndpoint("eu")).toBe(PROD_EU_ENDPOINT);
+  });
+
+  it("maps the us region to the default endpoint", () => {
+    expect(resolveApiEndpoint("us")).toBe(PROD_US_ENDPOINT);
   });
 
   it("ignores casing and surrounding whitespace in the region", () => {
-    expect(resolveApiEndpoint(" EU ")).toBe("https://api.eu.withampersand.com");
+    expect(resolveApiEndpoint(" EU ")).toBe(PROD_EU_ENDPOINT);
   });
 
   it("falls back to the prod endpoint for an unknown region", () => {
     const error = jest.spyOn(console, "error").mockImplementation(() => {});
-    expect(resolveApiEndpoint("mars")).toBe(PROD_ENDPOINT);
+    expect(resolveApiEndpoint("mars")).toBe(PROD_US_ENDPOINT);
     expect(error).toHaveBeenCalled();
   });
 
@@ -48,7 +53,7 @@ describe("resolveApiEndpoint", () => {
 
   it("applies the region when REACT_APP_AMP_SERVER is empty", () => {
     process.env[ENV_KEY] = "";
-    expect(resolveApiEndpoint("eu")).toBe("https://api.eu.withampersand.com");
+    expect(resolveApiEndpoint("eu")).toBe(PROD_EU_ENDPOINT);
   });
 
   it("resolves the documented env values", () => {
@@ -56,7 +61,7 @@ describe("resolveApiEndpoint", () => {
       ["local", "http://localhost:8080"],
       ["dev", "https://dev-api.withampersand.com"],
       ["staging", "https://staging-api.withampersand.com"],
-      ["prod", PROD_ENDPOINT],
+      ["prod", PROD_US_ENDPOINT],
       ["mock", "http://127.0.0.1:4010"],
     ];
 
@@ -72,8 +77,6 @@ describe("region store", () => {
     expect(getAmpersandRegion()).toBeUndefined();
     setAmpersandRegion("eu");
     expect(getAmpersandRegion()).toBe("eu");
-    expect(resolveApiEndpoint(getAmpersandRegion())).toBe(
-      "https://api.eu.withampersand.com",
-    );
+    expect(resolveApiEndpoint(getAmpersandRegion())).toBe(PROD_EU_ENDPOINT);
   });
 });

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -57,28 +57,61 @@ function getEnvEndpoint(): string | null {
   }
 }
 
-/**
- * Resolves a region to its endpoint, falling back to the default endpoint for an unknown region.
- */
-function getRegionalEndpoint(region?: string): string {
-  if (!region) return PROD_US_ENDPOINT;
+/** Values already reported, so a bad region logs once instead of on every render. */
+const warnedRegions = new Set<string>();
 
-  const endpoint = REGIONAL_ENDPOINTS[region.trim().toLowerCase()];
-  if (!endpoint) {
-    console.error(
-      `Unknown Ampersand region "${region}". Falling back to ${PROD_US_ENDPOINT}.`,
+function warnOnce(key: string, message: string): void {
+  if (warnedRegions.has(key)) return;
+  warnedRegions.add(key);
+  console.error(message);
+}
+
+/**
+ * Validates and canonicalises a region, returning undefined (meaning "use the US endpoint")
+ * for anything unrecognised. Builders reach this through a cast, so the value is untyped at
+ * runtime and may be any shape.
+ */
+function normalizeRegion(region?: unknown): string | undefined {
+  if (region === undefined || region === null) return undefined;
+
+  if (typeof region !== "string") {
+    warnOnce(
+      `type:${typeof region}`,
+      `Ampersand region must be a string, received ${typeof region}. Using ${PROD_US_ENDPOINT}.`,
     );
-    return PROD_US_ENDPOINT;
+    return undefined;
   }
 
-  return endpoint;
+  const normalized = region.trim().toLowerCase();
+  if (!normalized) return undefined;
+
+  // Own-property check only: a plain object inherits keys such as "constructor" and
+  // "__proto__", which would otherwise resolve to a function or prototype object.
+  if (!Object.prototype.hasOwnProperty.call(REGIONAL_ENDPOINTS, normalized)) {
+    warnOnce(
+      `region:${normalized}`,
+      `Unknown Ampersand region "${region}". Expected one of: ` +
+        `${Object.keys(REGIONAL_ENDPOINTS).join(", ")}. Using ${PROD_US_ENDPOINT}.`,
+    );
+    return undefined;
+  }
+
+  return normalized;
+}
+
+/**
+ * Resolves a region to its endpoint, falling back to the US endpoint for an unknown region.
+ */
+function getRegionalEndpoint(region?: unknown): string {
+  const normalized = normalizeRegion(region);
+  return normalized ? REGIONAL_ENDPOINTS[normalized] : PROD_US_ENDPOINT;
 }
 
 /**
  * The API server origin (no version path), e.g. "https://api.eu.withampersand.com".
  * `REACT_APP_AMP_SERVER` takes priority over `region`.
  */
-export function resolveApiEndpoint(region?: string): string {
+export function resolveApiEndpoint(region?: unknown): string {
   return getEnvEndpoint() ?? getRegionalEndpoint(region);
 }
 
@@ -89,8 +122,10 @@ export function resolveApiEndpoint(region?: string): string {
  */
 let ampersandRegion: string | undefined;
 
-export function setAmpersandRegion(region?: string): void {
-  ampersandRegion = region;
+export function setAmpersandRegion(region?: unknown): void {
+  // Validated here, at the provider, so an invalid value is reported once rather than on
+  // every request, and only a known region is ever stored.
+  ampersandRegion = normalizeRegion(region);
 }
 
 export function getAmpersandRegion(): string | undefined {

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -1,0 +1,93 @@
+/**
+ * Resolution of the Ampersand API endpoint.
+ *
+ * Two inputs decide which server the library talks to:
+ *
+ * 1. `REACT_APP_AMP_SERVER` — always wins, so the Ampersand team can point a build at
+ *    local / dev / staging (or an arbitrary URL).
+ * 2. `region` — an internal, undocumented option on `AmpersandProvider` that is not part of
+ *    the public TypeScript types. Ignored whenever `REACT_APP_AMP_SERVER` is set.
+ *
+ * With neither set, the default (global) production endpoint is used.
+ */
+
+export const PROD_ENDPOINT = "https://api.withampersand.com";
+
+/**
+ * Known regional endpoints, keyed by the `region` option. The default (no region) is the
+ * global production endpoint above; add a new entry here to support another region.
+ */
+const REGIONAL_ENDPOINTS: Record<string, string> = {
+  eu: "https://api.eu.withampersand.com",
+};
+
+/**
+ * Resolves `REACT_APP_AMP_SERVER`, or null when it is unset/empty (in which case the region
+ * and then the default endpoint apply).
+ */
+function getEnvEndpoint(): string | null {
+  try {
+    const ENV_SERVER = process.env.REACT_APP_AMP_SERVER;
+    switch (ENV_SERVER) {
+      case "local":
+        return "http://localhost:8080";
+      case "dev":
+        return "https://dev-api.withampersand.com";
+      case "staging":
+        return "https://staging-api.withampersand.com";
+      case "prod":
+        return PROD_ENDPOINT;
+      case "mock":
+        return "http://127.0.0.1:4010";
+      case undefined:
+      case "":
+        return null;
+      default:
+        // The user may provide an arbitrary URL here if they want to.
+        return ENV_SERVER;
+    }
+  } catch {
+    // process may not be defined in every consumer's bundle
+    return null;
+  }
+}
+
+/**
+ * Resolves a region to its endpoint, falling back to the default endpoint for an unknown region.
+ */
+function getRegionalEndpoint(region?: string): string {
+  if (!region) return PROD_ENDPOINT;
+
+  const endpoint = REGIONAL_ENDPOINTS[region.trim().toLowerCase()];
+  if (!endpoint) {
+    console.error(
+      `Unknown Ampersand region "${region}". Falling back to ${PROD_ENDPOINT}.`,
+    );
+    return PROD_ENDPOINT;
+  }
+
+  return endpoint;
+}
+
+/**
+ * The API server origin (no version path), e.g. "https://api.eu.withampersand.com".
+ * `REACT_APP_AMP_SERVER` takes priority over `region`.
+ */
+export function resolveApiEndpoint(region?: string): string {
+  return getEnvEndpoint() ?? getRegionalEndpoint(region);
+}
+
+/**
+ * The region is module state rather than context so that it stays out of the library's public
+ * types (like the `variant` prop on InstallIntegration). `AmpersandProvider` sets it during
+ * render — before any child effect or query runs — and readers resolve the endpoint lazily.
+ */
+let ampersandRegion: string | undefined;
+
+export function setAmpersandRegion(region?: string): void {
+  ampersandRegion = region;
+}
+
+export function getAmpersandRegion(): string | undefined {
+  return ampersandRegion;
+}

--- a/src/services/apiEndpoint.ts
+++ b/src/services/apiEndpoint.ts
@@ -8,17 +8,22 @@
  * 2. `region` — an internal, undocumented option on `AmpersandProvider` that is not part of
  *    the public TypeScript types. Ignored whenever `REACT_APP_AMP_SERVER` is set.
  *
- * With neither set, the default (global) production endpoint is used.
+ * With neither set, the US production endpoint is used.
  */
 
-export const PROD_ENDPOINT = "https://api.withampersand.com";
+/** US production endpoint. Used when no region is given. */
+export const PROD_US_ENDPOINT = "https://api.withampersand.com";
+
+/** EU production endpoint. */
+export const PROD_EU_ENDPOINT = "https://api.eu.withampersand.com";
 
 /**
- * Known regional endpoints, keyed by the `region` option. The default (no region) is the
- * global production endpoint above; add a new entry here to support another region.
+ * Production endpoints keyed by the `region` option. No region means US.
+ * Add an entry here to support another region.
  */
 const REGIONAL_ENDPOINTS: Record<string, string> = {
-  eu: "https://api.eu.withampersand.com",
+  us: PROD_US_ENDPOINT,
+  eu: PROD_EU_ENDPOINT,
 };
 
 /**
@@ -36,7 +41,7 @@ function getEnvEndpoint(): string | null {
       case "staging":
         return "https://staging-api.withampersand.com";
       case "prod":
-        return PROD_ENDPOINT;
+        return PROD_US_ENDPOINT;
       case "mock":
         return "http://127.0.0.1:4010";
       case undefined:
@@ -56,14 +61,14 @@ function getEnvEndpoint(): string | null {
  * Resolves a region to its endpoint, falling back to the default endpoint for an unknown region.
  */
 function getRegionalEndpoint(region?: string): string {
-  if (!region) return PROD_ENDPOINT;
+  if (!region) return PROD_US_ENDPOINT;
 
   const endpoint = REGIONAL_ENDPOINTS[region.trim().toLowerCase()];
   if (!endpoint) {
     console.error(
-      `Unknown Ampersand region "${region}". Falling back to ${PROD_ENDPOINT}.`,
+      `Unknown Ampersand region "${region}". Falling back to ${PROD_US_ENDPOINT}.`,
     );
-    return PROD_ENDPOINT;
+    return PROD_US_ENDPOINT;
   }
 
   return endpoint;


### PR DESCRIPTION
 Adds an internal `region` option to `AmpersandProvider`. With `region: "eu"`, all API requests go to `https://api.eu.withampersand.com` instead of the default `https://api.withampersand.com`.

  ```ts
  const options = { project: 'PROJECT', apiKey: 'API_KEY', region: 'eu' };
  <AmpersandProvider options={options}>…</AmpersandProvider>
```

## Test
#### Before the change the default endpoint was US
<img width="1721" height="854" alt="Screenshot 2026-09-03 at 13 03 07" src="https://github.com/user-attachments/assets/114e4d48-64a2-4b2c-bd28-e484b5fc17f1" />

#### After the change when passing EU it uses eu endpoint
<img width="1728" height="803" alt="Screenshot 2026-09-03 at 13 19 39" src="https://github.com/user-attachments/assets/2ec5e245-78d8-4830-b5ff-f208dc34db97" />

####  when someone sets a eu region on the lib, but the  `REACT_APP_AMP_SERVER` takes precedence
<img width="1724" height="958" alt="Screenshot 2026-09-04 at 14 17 00" src="https://github.com/user-attachments/assets/06a1bb20-48ab-4e58-8b11-1cd68ce0562e" />


